### PR TITLE
Gatling scenario recorder, the entry point is GatlingHttpProxyUI #13

### DIFF
--- a/gatling-proxy/pom.xml
+++ b/gatling-proxy/pom.xml
@@ -1,0 +1,84 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.excilys.ebi.gatling</groupId>
+	<artifactId>gatling-proxy</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>gatling-proxy</name>
+	<url>http://maven.apache.org</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.6</java.version>
+		<netty.version>3.2.6.Final</netty.version>
+		<velocity.version>1.7</velocity.version>
+		<xstream.version>1.4.2</xstream.version>
+		<commons-lang.version>2.6</commons-lang.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.jboss.netty</groupId>
+				<artifactId>netty</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.velocity</groupId>
+				<artifactId>velocity</artifactId>
+				<version>${velocity.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.thoughtworks.xstream</groupId>
+				<artifactId>xstream</artifactId>
+				<version>${xstream.version}</version>
+				<exclusions>
+					<exclusion>
+						<artifactId>xpp3_min</artifactId>
+						<groupId>xpp3</groupId>
+					</exclusion>
+					<exclusion>
+						<artifactId>xmlpull</artifactId>
+						<groupId>xmlpull</groupId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>commons-lang</groupId>
+				<artifactId>commons-lang</artifactId>
+				<version>${commons-lang.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jboss.netty</groupId>
+			<artifactId>netty</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.velocity</groupId>
+			<artifactId>velocity</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/GatlingHttpProxy.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/GatlingHttpProxy.java
@@ -1,0 +1,55 @@
+package com.excilys.ebi.gatling.proxy;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.Executors;
+
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.*;
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
+import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
+import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+
+import com.excilys.ebi.gatling.proxy.core.HttpRequestHandler;
+import com.excilys.ebi.gatling.proxy.event.ProxyAction;
+
+public class GatlingHttpProxy extends ProxyAction {
+	private int port;
+	private ChannelFactory factory;
+	private ServerBootstrap bootstrap;
+
+	public GatlingHttpProxy(int port, String outgoingProxyHost, int outgoingProxyPort) {
+		this.port = port;
+
+		factory = new NioServerSocketChannelFactory(Executors.newCachedThreadPool(), Executors.newCachedThreadPool());
+		bootstrap = new ServerBootstrap(factory);
+
+		final HttpRequestHandler rh = new HttpRequestHandler(this);
+
+		/* Adding outgoing proxy configuration */
+		if (outgoingProxyPort > 0) {
+			rh.setOutgoingProxyHost(outgoingProxyHost);
+			rh.setOutgoingProxyPort(outgoingProxyPort);
+		}
+
+		bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
+			@Override
+			public ChannelPipeline getPipeline() throws Exception {
+				return Channels.pipeline(new HttpRequestDecoder(), new HttpResponseEncoder(), rh);
+			}
+		});
+
+		bootstrap.setOption("tcpNoDelay", true);
+		bootstrap.setOption("keepAlive", true);
+	}
+
+	public void start() {
+		getGroup().add(bootstrap.bind(new InetSocketAddress(port)));
+	}
+
+	public void shutdown() {
+		// Now close all channels
+		getGroup().close().awaitUninterruptibly();
+		// Now release resources
+		factory.releaseExternalResources();
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/configuration/Configuration.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/configuration/Configuration.java
@@ -1,0 +1,85 @@
+package com.excilys.ebi.gatling.proxy.configuration;
+
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.excilys.ebi.gatling.proxy.ui.enumeration.Filter;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.FilterType;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.ResultType;
+
+public class Configuration {
+
+	private int proxyPort;
+	private String outgoingProxyHost;
+	private int outgoingProxyPort;
+	private Filter filter;
+	private FilterType filterType;
+	private List<String> filters;
+	private String resultPath;
+	private List<ResultType> resultTypes;
+
+	public int getProxyPort() {
+		return proxyPort;
+	}
+
+	public void setProxyPort(int proxyPort) {
+		this.proxyPort = proxyPort;
+	}
+
+	public String getOutgoingProxyHost() {
+		return outgoingProxyHost;
+	}
+
+	public void setOutgoingProxyHost(String outgoingProxyHost) {
+		this.outgoingProxyHost = StringUtils.trimToNull(outgoingProxyHost);
+	}
+
+	public int getOutgoingProxyPort() {
+		return outgoingProxyPort;
+	}
+
+	public void setOutgoingProxyPort(int outgoingProxyPort) {
+		this.outgoingProxyPort = outgoingProxyPort;
+	}
+
+	public Filter getFilter() {
+		return filter;
+	}
+
+	public void setFilter(Filter filter) {
+		this.filter = filter;
+	}
+
+	public FilterType getFilterType() {
+		return filterType;
+	}
+
+	public void setFilterType(FilterType filterType) {
+		this.filterType = filterType;
+	}
+
+	public List<String> getFilters() {
+		return filters;
+	}
+
+	public void setFilters(List<String> filters) {
+		this.filters = filters;
+	}
+
+	public String getResultPath() {
+		return resultPath;
+	}
+
+	public void setResultPath(String resultPath) {
+		this.resultPath = StringUtils.trimToNull(resultPath);
+	}
+
+	public List<ResultType> getResultTypes() {
+		return resultTypes;
+	}
+
+	public void setResultTypes(List<ResultType> resultTypes) {
+		this.resultTypes = resultTypes;
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/configuration/ConfigurationHelper.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/configuration/ConfigurationHelper.java
@@ -1,0 +1,62 @@
+package com.excilys.ebi.gatling.proxy.configuration;
+
+import static com.excilys.ebi.gatling.proxy.ui.Constants.GATLING_RECORDER_FILE_NAME;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import com.excilys.ebi.gatling.proxy.ui.enumeration.ResultType;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.DomDriver;
+
+public final class ConfigurationHelper {
+
+	private static final XStream XSTREAM = new XStream(new DomDriver());
+
+	private static final File CONFIGURATION_FILE = new File(System.getProperty("user.home"), GATLING_RECORDER_FILE_NAME);
+
+	static {
+		XSTREAM.alias("resultType", ResultType.class);
+		XSTREAM.alias("configuration", Configuration.class);
+	}
+
+	private ConfigurationHelper() {
+		throw new UnsupportedOperationException();
+	}
+
+	public static Configuration readFromDisk() {
+
+		if (CONFIGURATION_FILE.exists()) {
+			try {
+				return (Configuration) XSTREAM.fromXML(CONFIGURATION_FILE);
+			} catch (Exception e) {
+				System.err.println(e);
+				return null;
+			}
+		} else {
+			return null;
+		}
+	}
+
+	public static void saveToDisk(Configuration configuration) {
+
+		FileWriter fw = null;
+		try {
+			fw = new FileWriter(CONFIGURATION_FILE);
+			XSTREAM.toXML(configuration, fw);
+
+		} catch (IOException e) {
+			System.err.println(e);
+
+		} finally {
+			if (fw != null) {
+				try {
+					fw.close();
+				} catch (IOException e) {
+					System.err.println(e);
+				}
+			}
+		}
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/core/HttpMessageHandler.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/core/HttpMessageHandler.java
@@ -1,0 +1,14 @@
+package com.excilys.ebi.gatling.proxy.core;
+
+import org.jboss.netty.channel.SimpleChannelHandler;
+
+import com.excilys.ebi.gatling.proxy.event.ProxyAction;
+
+class HttpMessageHandler extends SimpleChannelHandler {
+
+	public final ProxyAction proxyAction;
+
+	public HttpMessageHandler(ProxyAction proxyAction) {
+		this.proxyAction = proxyAction;
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/core/HttpRequestHandler.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/core/HttpRequestHandler.java
@@ -1,0 +1,98 @@
+package com.excilys.ebi.gatling.proxy.core;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.concurrent.Executors;
+
+import org.jboss.netty.bootstrap.ClientBootstrap;
+import org.jboss.netty.channel.*;
+import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
+import org.jboss.netty.handler.codec.http.*;
+
+import com.excilys.ebi.gatling.proxy.event.ProxyAction;
+import com.excilys.ebi.gatling.proxy.event.ProxyEvent;
+
+/**
+ * Class forwarding an HTTP request to a remote endpoint
+ * 
+ * @author nmaupu
+ */
+public class HttpRequestHandler extends HttpMessageHandler {
+	private String outgoingProxyHost;
+	private int outgoingProxyPort;
+
+	public HttpRequestHandler(ProxyAction proxyAction) {
+		super(proxyAction);
+	}
+
+	@Override
+	public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+
+		proxyAction.getGroup().add(ctx.getChannel());
+
+		final HttpRequest request = (HttpRequest) e.getMessage();
+
+		// Notify all listeners
+		super.proxyAction.notifyListeners(new ProxyEvent(request));
+
+		URI uri = new URI(request.getUri());
+		final String host = uri.getHost();
+		int port = uri.getPort() == -1 ? 80 : uri.getPort();
+
+		// Discard if host is null
+		if (host == null)
+			return;
+
+		ChannelFactory factory = new NioClientSocketChannelFactory(Executors.newCachedThreadPool(), Executors.newCachedThreadPool());
+		ClientBootstrap bootstrap = new ClientBootstrap(factory);
+
+		// Create responseHandler and set listeners
+		final HttpResponseHandler rh = new HttpResponseHandler(proxyAction, ctx, request);
+
+		bootstrap.setPipelineFactory(new ChannelPipelineFactory() {
+			@Override
+			public ChannelPipeline getPipeline() throws Exception {
+				return Channels.pipeline(new HttpRequestEncoder(), new HttpResponseDecoder(), new HttpChunkAggregator(1048576), rh);
+			}
+		});
+
+		ChannelFuture future;
+		if (outgoingProxyHost == null)
+			future = bootstrap.connect(new InetSocketAddress(host, port));
+		else
+			future = bootstrap.connect(new InetSocketAddress(outgoingProxyHost, outgoingProxyPort));
+
+		future.addListener(new ChannelFutureListener() {
+			@Override
+			public void operationComplete(ChannelFuture future) throws Exception {
+				future.getChannel().write(request);
+			}
+		});
+
+		ctx.sendUpstream(e);
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {
+		System.err.println("Exception caught = " + e.getCause().getMessage());
+
+		// Properly closing
+		ChannelFuture future = ctx.getChannel().getCloseFuture();
+		future.addListener(new ChannelFutureListener() {
+			@Override
+			public void operationComplete(ChannelFuture future) throws Exception {
+				future.getChannel().close();
+			}
+		});
+
+		ctx.sendUpstream(e);
+	}
+
+	public void setOutgoingProxyHost(String outgoingProxyHost) {
+		this.outgoingProxyHost = outgoingProxyHost;
+	}
+
+	public void setOutgoingProxyPort(int outgoingProxyPort) {
+		this.outgoingProxyPort = outgoingProxyPort;
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/core/HttpResponseHandler.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/core/HttpResponseHandler.java
@@ -1,0 +1,36 @@
+package com.excilys.ebi.gatling.proxy.core;
+
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+
+import com.excilys.ebi.gatling.proxy.event.ProxyAction;
+import com.excilys.ebi.gatling.proxy.event.ProxyEvent;
+
+public class HttpResponseHandler extends HttpMessageHandler {
+	private final ChannelHandlerContext context;
+	private final HttpRequest request;
+
+	public HttpResponseHandler(ProxyAction proxyAction, ChannelHandlerContext ctx, HttpRequest request) {
+		super(proxyAction);
+		this.context = ctx;
+		this.request = request;
+	}
+
+	@Override
+	public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+
+		proxyAction.getGroup().add(ctx.getChannel());
+
+		HttpResponse response = (HttpResponse) e.getMessage();
+
+		// Notify listeners (and set corresponding request)
+		proxyAction.notifyListeners(new ProxyEvent(response, request));
+
+		// Send back to client
+		context.getChannel().write(response);
+
+		ctx.sendUpstream(e);
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/ProxyAction.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/ProxyAction.java
@@ -1,0 +1,44 @@
+package com.excilys.ebi.gatling.proxy.event;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.jboss.netty.channel.group.ChannelGroup;
+import org.jboss.netty.channel.group.DefaultChannelGroup;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+
+public abstract class ProxyAction {
+
+	private final Collection<ProxyListener> listeners = new ArrayList<ProxyListener>();
+	private final ChannelGroup group = new DefaultChannelGroup("Gatling_Recorder");
+
+	public ChannelGroup getGroup() {
+		return group;
+	}
+
+	public void addProxyListener(ProxyListener listener) {
+		listeners.add(listener);
+	}
+
+	public void removeProxyListener(ProxyListener listener) {
+		listeners.remove(listener);
+	}
+
+	public void clearProxyListeners() {
+		listeners.clear();
+	}
+
+	public void notifyListeners(ProxyEvent event) {
+
+		if (event == null || event.getSource() == null)
+			throw new IllegalArgumentException();
+
+		for (ProxyListener listener : listeners) {
+			if (event.getSource() instanceof HttpRequest)
+				listener.onHttpRequest(event);
+			else if (event.getSource() instanceof HttpResponse)
+				listener.onHttpResponse(event);
+		}
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/ProxyEvent.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/ProxyEvent.java
@@ -1,0 +1,57 @@
+package com.excilys.ebi.gatling.proxy.event;
+
+import java.util.*;
+
+import org.jboss.netty.handler.codec.http.HttpMessage;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+@SuppressWarnings("serial")
+public class ProxyEvent extends EventObject {
+
+	private HttpRequest originalRequest;
+	private int id;
+	private Map<String, List<String>> requestParams = new LinkedHashMap<String, List<String>>();
+	private boolean withBody;
+
+	public ProxyEvent(HttpMessage source) {
+		super(source);
+	}
+
+	public ProxyEvent(HttpMessage source, HttpRequest correspondingRequest) {
+		this(source);
+		this.originalRequest = correspondingRequest;
+	}
+
+	public HttpRequest getOriginalRequest() {
+		return originalRequest;
+	}
+
+	public void setOriginalRequest(HttpRequest originalRequest) {
+		this.originalRequest = originalRequest;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public Map<String, List<String>> getRequestParams() {
+		return requestParams;
+	}
+
+	public void setRequestParams(Map<String, List<String>> requestParams) {
+		this.requestParams = requestParams;
+	}
+
+	public boolean isWithBody() {
+		return withBody;
+	}
+
+	public void setWithBody(boolean withBody) {
+		this.withBody = withBody;
+	}
+
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/ProxyListener.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/ProxyListener.java
@@ -1,0 +1,8 @@
+package com.excilys.ebi.gatling.proxy.event;
+
+public interface ProxyListener {
+
+	void onHttpRequest(ProxyEvent e);
+
+	void onHttpResponse(ProxyEvent e);
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/TagEvent.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/event/TagEvent.java
@@ -1,0 +1,15 @@
+package com.excilys.ebi.gatling.proxy.event;
+
+import java.util.EventObject;
+
+@SuppressWarnings("serial")
+public class TagEvent extends EventObject {
+
+	public TagEvent(String tag) {
+		super(tag);
+	}
+
+	public String getTag() {
+		return String.class.cast(getSource());
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/ConfigurationValidatorListener.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/ConfigurationValidatorListener.java
@@ -1,0 +1,121 @@
+package com.excilys.ebi.gatling.proxy.ui;
+
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.border.Border;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.excilys.ebi.gatling.proxy.configuration.Configuration;
+import com.excilys.ebi.gatling.proxy.configuration.ConfigurationHelper;
+import com.excilys.ebi.gatling.proxy.ui.component.ConfigurationFrame;
+import com.excilys.ebi.gatling.proxy.ui.component.RunningFrame;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.Filter;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.FilterType;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.ResultType;
+
+public class ConfigurationValidatorListener implements ActionListener {
+
+	private ConfigurationFrame frame;
+
+	public ConfigurationValidatorListener(ConfigurationFrame frame) {
+		this.frame = frame;
+	}
+
+	public void actionPerformed(ActionEvent e) {
+
+		boolean hasError = false;
+		Border defaultBorder = frame.txtProxyHost.getBorder();
+
+		Configuration config = new Configuration();
+
+		// Parse local proxy port
+		try {
+			config.setProxyPort(Integer.parseInt(frame.txtPort.getText()));
+			frame.txtPort.setBorder(defaultBorder);
+		} catch (NumberFormatException nfe) {
+			System.err.println("Error, while parsing proxy port...");
+			frame.txtPort.setBorder(BorderFactory.createMatteBorder(2, 2, 2, 2, Color.red));
+			hasError = true;
+		}
+
+		config.setOutgoingProxyHost(StringUtils.trimToNull(frame.txtProxyHost.getText()));
+
+		// Parse outgoing proxy port
+		if (!StringUtils.isEmpty(config.getOutgoingProxyHost())) {
+			try {
+				config.setOutgoingProxyPort(Integer.parseInt(frame.txtProxyPort.getText()));
+				frame.txtProxyPort.setBorder(defaultBorder);
+			} catch (NumberFormatException nfe) {
+				System.err.println("Error, while parsing outgoing proxy port... !");
+				frame.txtProxyPort.setBorder(BorderFactory.createMatteBorder(2, 2, 2, 2, Color.red));
+				hasError = true;
+			}
+		}
+
+		config.setFilter((Filter) frame.cbFilter.getSelectedItem());
+		config.setFilterType((FilterType) frame.cbFilterType.getSelectedItem());
+		// Set urls filters into a list
+		config.setFilters(new ArrayList<String>());
+		for (int i = 0; i < frame.listElements.size(); i++)
+			config.getFilters().add((String) frame.listElements.get(i));
+
+		// Check if a directory was entered
+		config.setResultPath(StringUtils.trimToNull(frame.txtResultPath.getText()));
+		if (config.getResultPath() == null) {
+			System.err.println("Error, no directory selected for results.");
+			frame.txtResultPath.setBorder(BorderFactory.createMatteBorder(2, 2, 2, 2, Color.red));
+			hasError = true;
+		} else
+			frame.txtResultPath.setBorder(defaultBorder);
+
+		// Set selected results type into a list
+		config.setResultTypes(new ArrayList<ResultType>());
+		boolean tmp = false;
+		for (JCheckBox cb : frame.listResultsType) {
+			if (cb.isSelected()) {
+				tmp = true;
+				config.getResultTypes().add(ResultType.valueOf(cb.getText()));
+			}
+		}
+		// If nothing was selected we add by default 'text'
+		if (!tmp)
+			config.getResultTypes().add(ResultType.Text);
+
+		if (hasError)
+			return;
+
+		if (frame.cbSavePref.isSelected())
+			ConfigurationHelper.saveToDisk(config);
+
+		displayConfiguration(config);
+
+		/* Hide the configuration frame and display the running frame */
+		frame.setVisible(false);
+		JFrame runningFrame = new RunningFrame(config);
+		runningFrame.setVisible(true);
+	}
+
+	public void displayConfiguration(Configuration conf) {
+		System.out.println("Configuration");
+		System.out.println("-------------");
+		System.out.println("Proxy port: " + conf.getProxyPort());
+		if (conf.getOutgoingProxyHost() != null)
+			System.out.println("Outgoing proxy: " + conf.getOutgoingProxyHost() + ":" + conf.getOutgoingProxyPort());
+		System.out.println("Filters: " + conf.getFilter() + "(" + conf.getFilterType() + ")");
+		if (!conf.getFilterType().equals(FilterType.All))
+			for (String f : conf.getFilters())
+				System.out.println(" - " + f);
+		System.out.println("Results: " + conf.getResultPath());
+		System.out.println("Result type:");
+		for (ResultType r : conf.getResultTypes())
+			System.out.println(" - " + r);
+		System.out.println();
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/Constants.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/Constants.java
@@ -1,0 +1,11 @@
+package com.excilys.ebi.gatling.proxy.ui;
+
+public final class Constants {
+
+	public static final String GATLING_RECORDER_FILE_NAME = "gatling-recorder.ini";
+	public static final String GATLING_REQUEST_BODIES_DIRECTORY_NAME = "requests-bodies";
+
+	private Constants() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/GatlingHttpProxyUI.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/GatlingHttpProxyUI.java
@@ -1,0 +1,21 @@
+package com.excilys.ebi.gatling.proxy.ui;
+
+import java.awt.EventQueue;
+
+import javax.swing.JFrame;
+
+import com.excilys.ebi.gatling.proxy.ui.component.ConfigurationFrame;
+
+public class GatlingHttpProxyUI {
+
+	public static void main(String[] args) {
+
+		EventQueue.invokeLater(new Runnable() {
+
+			public void run() {
+				JFrame confFrame = new ConfigurationFrame();
+				confFrame.setVisible(true);
+			}
+		});
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/component/ConfigurationFrame.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/component/ConfigurationFrame.java
@@ -1,0 +1,294 @@
+package com.excilys.ebi.gatling.proxy.ui.component;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+
+import java.awt.*;
+import java.awt.event.*;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.*;
+
+import com.excilys.ebi.gatling.proxy.configuration.Configuration;
+import com.excilys.ebi.gatling.proxy.configuration.ConfigurationHelper;
+import com.excilys.ebi.gatling.proxy.ui.ConfigurationValidatorListener;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.Filter;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.FilterType;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.ResultType;
+
+public class ConfigurationFrame extends JFrame {
+
+	private static final long serialVersionUID = 1L;
+
+	public final JTextField txtPort = new JTextField(4);
+	public final JTextField txtProxyHost = new JTextField(10);
+	public final JTextField txtProxyPort = new JTextField(4);
+	public final JComboBox cbFilter = new JComboBox();
+	public final JComboBox cbFilterType = new JComboBox();
+	public final DefaultListModel listElements = new DefaultListModel();
+	public final JList listFilters = new JList(listElements);
+	public final JTextField txtResultPath = new JTextField(15);
+	public final List<JCheckBox> listResultsType = new ArrayList<JCheckBox>();
+	public final JCheckBox cbSavePref = new JCheckBox("Save preferences");
+
+	public ConfigurationFrame() {
+
+		/* Initialization of the frame */
+		setTitle("Proxy configuration");
+		setLayout(new GridBagLayout());
+		setMinimumSize(new Dimension(550, 400));
+		setResizable(false);
+		setLocationRelativeTo(null);
+		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+		/* Declaration of components */
+		JScrollPane panelFilters = new JScrollPane(listFilters);
+		panelFilters.setPreferredSize(new Dimension(180, 80));
+		final JTextField txtFilters = new JTextField(10);
+		JButton btnFiltersAdd = new JButton("+");
+		JButton btnFiltersDel = new JButton("-");
+		JButton btnPathResults = new JButton("Browse");
+		for (Filter f : Filter.values())
+			cbFilter.addItem(f);
+		for (FilterType ft : FilterType.values())
+			cbFilterType.addItem(ft);
+		for (ResultType rt : ResultType.values())
+			listResultsType.add(new JCheckBox(rt.name()));
+		cbSavePref.setHorizontalTextPosition(SwingConstants.LEFT);
+		JButton btnClear = new JButton("Clear");
+		JButton btnStart = new JButton("Start !");
+
+		createPopupMenu();
+
+		/* Initialization of components */
+		Configuration config = ConfigurationHelper.readFromDisk();
+		if (config != null)
+			populateItemsFromConfiguration(config);
+
+		/* Layout */
+		GridBagConstraints gbc = new GridBagConstraints();
+
+		// 1st column
+		gbc.gridx = gbc.gridy = 0;
+		gbc.gridwidth = GridBagConstraints.REMAINDER;
+		gbc.insets = new Insets(10, 5, 0, 0);
+		add(new JLabel("<html><u><i>Configuration</i></u></html>"), gbc);
+
+		gbc.gridy = 1;
+		gbc.gridwidth = 2;
+		gbc.anchor = GridBagConstraints.LINE_END;
+		add(new JLabel("Proxy port :"), gbc);
+
+		gbc.gridy = 2;
+		add(new JLabel("Outgoing proxy :"), gbc);
+
+		gbc.gridy = 3;
+		add(new JLabel("URL filters :"), gbc);
+
+		gbc.gridy = 4;
+		gbc.gridwidth = 1;
+		add(txtFilters, gbc);
+
+		gbc.gridy = 6;
+		gbc.gridwidth = 2;
+		add(new JLabel("Results :"), gbc);
+
+		gbc.gridy = 7;
+		add(new JLabel("Results type: "), gbc);
+
+		gbc.gridy = 8;
+		add(cbSavePref, gbc);
+
+		// 2nd column
+		gbc.gridx = 1;
+		gbc.gridy = 4;
+		gbc.gridwidth = 1;
+		add(btnFiltersAdd, gbc);
+
+		// 3rd column
+		gbc.gridx = 2;
+		gbc.gridy = 2;
+		add(new JLabel("host:"), gbc);
+
+		gbc.gridy = 4;
+		gbc.gridwidth = 3;
+		gbc.gridheight = 2;
+		gbc.anchor = GridBagConstraints.CENTER;
+		add(panelFilters, gbc);
+
+		// 4th column
+		gbc.anchor = GridBagConstraints.LINE_START;
+		gbc.gridwidth = 1;
+		gbc.gridheight = 1;
+		gbc.gridx = 3;
+		gbc.gridy = 2;
+		add(txtProxyHost, gbc);
+
+		gbc.gridy = 3;
+		add(cbFilter, gbc);
+
+		gbc.gridy = 6;
+		add(txtResultPath, gbc);
+
+		gbc.gridy = 7;
+		gbc.gridx = GridBagConstraints.RELATIVE;
+		gbc.anchor = GridBagConstraints.LINE_END;
+		for (JCheckBox cb : listResultsType)
+			add(cb, gbc);
+
+		gbc.gridy = 8;
+		gbc.gridwidth = 2;
+		gbc.anchor = GridBagConstraints.CENTER;
+		add(btnClear, gbc);
+
+		// 5th column
+		gbc.gridwidth = 1;
+		gbc.gridx = 4;
+		gbc.gridy = 2;
+		gbc.anchor = GridBagConstraints.LINE_END;
+		add(new JLabel("port:"), gbc);
+
+		// 6th column
+		gbc.anchor = GridBagConstraints.LINE_START;
+		gbc.gridx = 5;
+		gbc.gridy = 1;
+		add(txtPort, gbc);
+
+		gbc.gridy = 2;
+		add(txtProxyPort, gbc);
+
+		gbc.gridy = 3;
+		add(cbFilterType, gbc);
+
+		gbc.gridy = 6;
+		add(btnPathResults, gbc);
+
+		gbc.gridy = 8;
+		gbc.gridwidth = 2;
+		gbc.anchor = GridBagConstraints.CENTER;
+		add(btnStart, gbc);
+
+		// 6th column
+		gbc.gridx = 5;
+		gbc.gridy = 4;
+		gbc.gridwidth = 1;
+		gbc.anchor = GridBagConstraints.LINE_START;
+		add(btnFiltersDel, gbc);
+
+		/* Listeners */
+		cbFilterType.addItemListener(new ItemListener() {
+			public void itemStateChanged(ItemEvent e) {
+				// Switch to '1' when goes active state and '2' for passive state.
+				if (e.getStateChange() == 1 && e.getItem().equals(FilterType.All))
+					listFilters.setBackground(Color.LIGHT_GRAY);
+				else
+					listFilters.setBackground(Color.WHITE);
+			}
+		});
+
+		btnFiltersAdd.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				if (!listElements.contains(txtFilters.getText())) {
+					listElements.addElement(txtFilters.getText());
+					listFilters.ensureIndexIsVisible(listElements.getSize() - 1);
+				}
+				txtFilters.setText(EMPTY);
+			}
+		});
+
+		btnFiltersDel.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				for (int i : listFilters.getSelectedIndices())
+					listElements.remove(i);
+				txtFilters.setText(EMPTY);
+			}
+		});
+
+		listFilters.addMouseListener(new MouseAdapter() {
+			public void mouseClicked(MouseEvent e) {
+				if (listFilters.getSelectedIndex() >= 0)
+					txtFilters.setText((String) listElements.get(listFilters.getSelectedIndex()));
+			}
+		});
+
+		btnPathResults.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				JFileChooser fc = new JFileChooser();
+				fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+
+				int choice = fc.showOpenDialog(null);
+
+				if (choice != JFileChooser.APPROVE_OPTION)
+					return;
+
+				File chosenFile = fc.getSelectedFile();
+				txtResultPath.setText(chosenFile.getPath());
+			}
+		});
+
+		btnClear.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				txtPort.setText(EMPTY);
+				txtProxyHost.setText(EMPTY);
+				txtProxyPort.setText(EMPTY);
+				txtFilters.setText(EMPTY);
+				listElements.removeAllElements();
+				txtResultPath.setText(EMPTY);
+				for (JCheckBox cb : listResultsType)
+					cb.setSelected(false);
+			}
+		});
+
+		btnStart.addActionListener(new ConfigurationValidatorListener(this));
+	}
+
+	private void populateItemsFromConfiguration(Configuration config) {
+		txtPort.setText(String.valueOf(config.getProxyPort()));
+		txtProxyHost.setText(config.getOutgoingProxyHost());
+		txtProxyPort.setText(String.valueOf(config.getOutgoingProxyPort()));
+		cbFilter.setSelectedItem(config.getFilter());
+		cbFilterType.setSelectedItem(config.getFilterType());
+		for (String filter : config.getFilters())
+			listElements.addElement(filter);
+		txtResultPath.setText(config.getResultPath());
+		for (JCheckBox cb : listResultsType)
+			for (ResultType resultType : config.getResultTypes())
+				if (cb.getText().equals(resultType.name()))
+					cb.setSelected(true);
+	}
+
+	private void createPopupMenu() {
+		// Create the popup menu
+		final JPopupMenu popup = new JPopupMenu();
+		JMenuItem menuItem = new JMenuItem("delete");
+		menuItem.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				for (int i : listFilters.getSelectedIndices())
+					listElements.remove(i);
+			}
+		});
+		popup.add(menuItem);
+
+		// Add listener so the popup menu can come up
+		listFilters.addMouseListener(new MouseAdapter() {
+
+			public void mousePressed(MouseEvent e) {
+				maybeShowPopup(e);
+			}
+
+			public void mouseReleased(MouseEvent e) {
+				maybeShowPopup(e);
+			}
+
+			private void maybeShowPopup(MouseEvent e) {
+				if (e.isPopupTrigger()) {
+					// Change the selected item if many items aren't selected
+					if (listFilters.getSelectedIndices().length < 1)
+						listFilters.setSelectedIndex(listFilters.locationToIndex(e.getPoint()));
+					popup.show(e.getComponent(), e.getX(), e.getY());
+				}
+			}
+		});
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/component/RunningFrame.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/component/RunningFrame.java
@@ -1,0 +1,402 @@
+package com.excilys.ebi.gatling.proxy.ui.component;
+
+import static com.excilys.ebi.gatling.proxy.ui.Constants.GATLING_REQUEST_BODIES_DIRECTORY_NAME;
+import static org.apache.commons.lang.StringUtils.EMPTY;
+
+import java.awt.*;
+import java.awt.event.*;
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.swing.*;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.QueryStringDecoder;
+
+import com.excilys.ebi.gatling.proxy.GatlingHttpProxy;
+import com.excilys.ebi.gatling.proxy.configuration.Configuration;
+import com.excilys.ebi.gatling.proxy.event.ProxyEvent;
+import com.excilys.ebi.gatling.proxy.event.ProxyListener;
+import com.excilys.ebi.gatling.proxy.event.TagEvent;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.Filter;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.FilterType;
+import com.excilys.ebi.gatling.proxy.ui.enumeration.ResultType;
+import com.excilys.ebi.gatling.proxy.ui.event.HttpEvent;
+
+public class RunningFrame extends JFrame implements ProxyListener {
+
+	private static final long serialVersionUID = 1L;
+
+	private GatlingHttpProxy proxy;
+
+	private JTextField txtTag = new JTextField(10);
+	private JButton btnTag = new JButton("Set");
+	private DefaultListModel listElements = new DefaultListModel();
+	private JList listExecutedRequests = new JList(listElements);
+
+	private List<EventObject> listRequests = new ArrayList<EventObject>();
+	private String protocol;
+	private String domain;
+	private int port;
+	private String urlBase = null;
+	private String urlBaseString = null;
+	private TreeMap<String, String> urls = new TreeMap<String, String>();
+	private TreeMap<String, Map<String, String>> headers = new TreeMap<String, Map<String, String>>();
+
+	private Filter filter;
+	private FilterType filterType;
+	private List<String> filters;
+	private String resultPath;
+	private List<ResultType> resultType;
+	private Date date = new Date();
+	private SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
+
+	public RunningFrame(Configuration conf) {
+
+		filter = conf.getFilter();
+		filterType = conf.getFilterType();
+		filters = conf.getFilters();
+		resultPath = conf.getResultPath();
+		resultType = conf.getResultTypes();
+
+		proxy = new GatlingHttpProxy(conf.getProxyPort(), conf.getOutgoingProxyHost(), conf.getOutgoingProxyPort());
+		proxy.addProxyListener(this);
+		proxy.start();
+
+		/* Initialization of the frame */
+		setTitle("Recorder running...");
+		setMinimumSize(new Dimension(660, 480));
+		setLocationRelativeTo(null);
+		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		GridBagLayout gbl = new GridBagLayout();
+		setLayout(gbl);
+
+		/* Declaration & initialization of components */
+		JButton btnClear = new JButton("Clear");
+		final JButton btnStop = new JButton("Stop !");
+		btnStop.setSize(120, 30);
+
+		JScrollPane panelFilters = new JScrollPane(listExecutedRequests);
+		panelFilters.setPreferredSize(new Dimension(300, 100));
+
+		final TextAreaPanel stringRequest = new TextAreaPanel("Request:");
+		stringRequest.setPreferredSize(new Dimension(330, 100));
+		final TextAreaPanel stringResponse = new TextAreaPanel("Response:");
+		final TextAreaPanel stringRequestBody = new TextAreaPanel("Request Body:");
+		JSplitPane requestResponsePane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, new JScrollPane(stringRequest), new JScrollPane(stringResponse));
+		final JSplitPane sp = new JSplitPane(JSplitPane.VERTICAL_SPLIT, requestResponsePane, stringRequestBody);
+
+		/* Layout */
+		GridBagConstraints gbc = new GridBagConstraints();
+		gbc.insets = new Insets(10, 5, 0, 0);
+
+		gbc.gridx = 0;
+		gbc.anchor = GridBagConstraints.LINE_START;
+		gbc.gridy = 0;
+		add(new JLabel("Tag :"), gbc);
+
+		gbc.gridx = 1;
+		add(txtTag, gbc);
+
+		gbc.gridx = 2;
+		gbc.weightx = 0.5;
+		add(btnTag, gbc);
+
+		gbc.gridx = 3;
+		gbc.anchor = GridBagConstraints.CENTER;
+		gbc.weightx = 0.25;
+		add(btnClear, gbc);
+
+		gbc.gridx = 4;
+		gbc.anchor = GridBagConstraints.LINE_END;
+		add(btnStop, gbc);
+
+		gbc.gridx = 0;
+		gbc.gridy = 1;
+		gbc.gridwidth = GridBagConstraints.REMAINDER;
+		gbc.weightx = 1;
+		gbc.weighty = 0.25;
+		gbc.fill = GridBagConstraints.BOTH;
+		add(panelFilters, gbc);
+
+		gbc.gridy = 3;
+		gbc.weightx = 1;
+		gbc.weighty = 0.75;
+		gbc.fill = GridBagConstraints.BOTH;
+		add(sp, gbc);
+
+		/* Listeners */
+		btnTag.addActionListener(new ActionListener() {
+
+			public void actionPerformed(ActionEvent e) {
+				if (!txtTag.getText().equals(EMPTY)) {
+					listElements.addElement("Tag ! " + txtTag.getText());
+					listExecutedRequests.ensureIndexIsVisible(listElements.getSize() - 1);
+					listRequests.add(new TagEvent(txtTag.getText()));
+					txtTag.setText(EMPTY);
+				}
+			}
+		});
+
+		listExecutedRequests.addMouseListener(new MouseAdapter() {
+			public void mouseClicked(MouseEvent e) {
+				if (listExecutedRequests.getSelectedIndex() >= 0) {
+					Object obj = listRequests.get(listExecutedRequests.getSelectedIndex());
+					if (obj instanceof HttpEvent) {
+						HttpEvent request = (HttpEvent) obj;
+						stringRequest.txt.setText(request.getStringRequest());
+						stringResponse.txt.setText(request.getStringResponse());
+						stringRequestBody.txt.setText(request.getContent());
+					} else {
+						stringRequest.txt.setText(EMPTY);
+						stringResponse.txt.setText(EMPTY);
+						stringRequestBody.txt.setText(EMPTY);
+					}
+				}
+			}
+		});
+
+		btnClear.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				listElements.removeAllElements();
+				stringRequest.txt.setText(EMPTY);
+				stringRequestBody.txt.setText(EMPTY);
+				stringResponse.txt.setText(EMPTY);
+				listRequests.clear();
+				urls.clear();
+				headers.clear();
+				protocol = null;
+				domain = null;
+				port = -1;
+				urlBase = null;
+				urlBaseString = null;
+			}
+		});
+
+		btnStop.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				saveScenario();
+				proxy.shutdown();
+				setVisible(false);
+				JFrame confFrame = new ConfigurationFrame();
+				confFrame.setVisible(true);
+			}
+		});
+	}
+
+	public void onHttpRequest(ProxyEvent e) {
+
+	}
+
+	public void onHttpResponse(ProxyEvent e) {
+		if (addRequest(e))
+			processRequest(e);
+	}
+
+	private boolean addRequest(ProxyEvent e) {
+		HttpRequest request = e.getOriginalRequest();
+		boolean add = true;
+		URI uri = null;
+		try {
+			uri = new URI(request.getUri());
+		} catch (URISyntaxException ex) {
+			System.err.println("Can't create URI from request uri (" + request.getUri() + ")" + ex.getStackTrace());
+		}
+
+		if (!FilterType.All.equals(filterType)) {
+			Pattern pattern;
+			Matcher matcher;
+			if (Filter.Java.equals(filter)) {
+
+				if (FilterType.Only.equals(filterType)) {
+					for (String f : filters) {
+						pattern = Pattern.compile(f);
+						matcher = pattern.matcher(uri.toString());
+						if (!matcher.find())
+							add = false;
+					}
+				} else if (FilterType.Except.equals(filterType)) {
+					for (String f : filters) {
+						pattern = Pattern.compile(f);
+						matcher = pattern.matcher(uri.toString());
+						if (matcher.find())
+							add = false;
+					}
+				}
+			} else if (Filter.Ant.equals(filter)) {
+				if (FilterType.Only.equals(filterType)) {
+					for (String f : filters) {
+						pattern = Pattern.compile(toRegexp(f));
+						matcher = pattern.matcher(uri.getPath());
+						if (!matcher.find())
+							add = false;
+					}
+				} else if (FilterType.Except.equals(filterType)) {
+					for (String f : filters) {
+						pattern = Pattern.compile(toRegexp(f));
+						matcher = pattern.matcher(uri.getPath());
+						if (matcher.find())
+							add = false;
+					}
+				}
+			}
+		}
+		return add;
+	}
+
+	private void processRequest(ProxyEvent e) {
+
+		HttpRequest request = e.getOriginalRequest();
+
+		URI uri = null;
+		try {
+			uri = new URI(request.getUri());
+		} catch (URISyntaxException ex) {
+			System.err.println("Can't create URI from request uri (" + request.getUri() + ")" + ex.getStackTrace());
+		}
+
+		listElements.addElement(request.getMethod() + " | " + request.getUri());
+		listExecutedRequests.ensureIndexIsVisible(listElements.getSize() - 1);
+
+		int id = listRequests.size() + 1;
+		e.setId(id);
+
+		/* URLs */
+		if (urlBase == null) {
+			protocol = uri.getScheme();
+			domain = uri.getAuthority();
+			port = uri.getPort();
+			urlBase = protocol + "://" + domain;
+			urlBaseString = "PROTOCOL + \"://\" + DOMAIN";
+			if (port != -1) {
+				urlBase += ":" + port;
+				urlBaseString += " + \":\" + PORT";
+			}
+		}
+
+		String requestUrlBase = uri.getScheme() + "://" + uri.getAuthority();
+		if (uri.getPort() != -1)
+			requestUrlBase += ":" + uri.getPort();
+		if (requestUrlBase.equals(urlBase))
+			urls.put("url_" + id, uri.getPath());
+		else
+			urls.put("url_" + id, uri.toString());
+
+		/* Headers */
+		TreeMap<String, String> hm = new TreeMap<String, String>();
+		for (Entry<String, String> entry : request.getHeaders()) {
+			hm.put(entry.getKey(), entry.getValue());
+		}
+		headers.put("headers_" + id, hm);
+
+		/* Params */
+		QueryStringDecoder decoder = new QueryStringDecoder(request.getUri());
+		e.getRequestParams().putAll((decoder.getParameters()));
+
+		/* Content */
+		if (request.getContent().capacity() > 0) {
+			String content = new String(request.getContent().array());
+			// We check if it's a form validation and so we extract post params
+			if ("application/x-www-form-urlencoded".equals(request.getHeader("Content-Type"))) {
+				decoder = new QueryStringDecoder("http://localhost/?" + content);
+				e.getRequestParams().putAll(decoder.getParameters());
+			} else {
+				e.setWithBody(true);
+				dumpRequestBody(id, content);
+			}
+		}
+		listRequests.add(e);
+	}
+
+	private void dumpRequestBody(int idEvent, String content) {
+		// Dump request body
+		String directoryDump = resultPath + "/" + sdf.format(date) + "_" + GATLING_REQUEST_BODIES_DIRECTORY_NAME;
+		File dir = new File(directoryDump);
+		if (!dir.exists())
+			dir.mkdir();
+
+		FileWriter fw = null;
+		try {
+			fw = new FileWriter(directoryDump + "/request_" + idEvent + ".txt");
+			fw.write(content);
+		} catch (IOException ex) {
+			System.err.println("Error, while dumping request body..." + ex.getStackTrace());
+		} finally {
+			if (fw != null) {
+				try {
+					fw.flush();
+					fw.close();
+				} catch (IOException ioe) {
+					System.err.println(ioe);
+				}
+			}
+		}
+	}
+
+	private void saveScenario() {
+		VelocityEngine ve = new VelocityEngine();
+		ve.setProperty("file.resource.loader.class", ClasspathResourceLoader.class.getName());
+		ve.init();
+
+		VelocityContext context = new VelocityContext();
+		context.put("protocol", protocol);
+		context.put("domain", domain);
+		context.put("port", port);
+		context.put("urlBase", urlBaseString);
+		context.put("urls", urls);
+		context.put("headers", headers);
+		context.put("name", "Scenario name");
+		context.put("reqs", listRequests);
+
+		Template t = null;
+		FileWriter fw = null;
+		for (ResultType r : resultType) {
+			try {
+				if (ResultType.Text.equals(r)) {
+					t = ve.getTemplate("scenarioText.vm");
+					fw = new FileWriter(resultPath + "/" + sdf.format(date) + "_scenario.txt");
+				} else if (ResultType.Scala.equals(r)) {
+					t = ve.getTemplate("scenarioScala.vm");
+					fw = new FileWriter(resultPath + "/" + sdf.format(date) + "_scenario.scala");
+				}
+				t.merge(context, fw);
+				fw.flush();
+
+			} catch (IOException e) {
+				System.err.println("Error, while saving '" + r + "' scenario..." + e.getStackTrace());
+
+			} finally {
+				if (fw != null) {
+					try {
+						fw.close();
+					} catch (IOException e) {
+						System.err.println(e);
+					}
+				}
+			}
+		}
+		StringWriter writer = new StringWriter();
+		t.merge(context, writer);
+		System.out.println("\n" + writer.toString());
+	}
+
+	private String toRegexp(String pattern) {
+		String regexpPattern = null;
+		regexpPattern = pattern.replace(".", "\\.");
+		regexpPattern = regexpPattern.replace("**", ".#?#?");
+		regexpPattern = regexpPattern.replace("*", "[^/\\.]*");
+		regexpPattern = regexpPattern.replace("#?#", "*");
+		return regexpPattern;
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/component/TextAreaPanel.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/component/TextAreaPanel.java
@@ -1,0 +1,39 @@
+package com.excilys.ebi.gatling.proxy.ui.component;
+
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+
+public class TextAreaPanel extends JPanel {
+
+	private static final long serialVersionUID = 1L;
+
+	public final JTextArea txt = new JTextArea();
+
+	public TextAreaPanel(String title) {
+
+		JLabel lblTitle = new JLabel(title);
+		txt.setEditable(false);
+		txt.setPreferredSize(new Dimension(200, 100));
+
+		GridBagLayout gbl = new GridBagLayout();
+		setLayout(gbl);
+
+		GridBagConstraints gbc = new GridBagConstraints();
+
+		gbc.gridx = 0;
+		gbc.gridy = 0;
+		add(lblTitle, gbc);
+
+		gbc.gridy = 1;
+		gbc.weightx = 1;
+		gbc.weighty = 1;
+		gbc.fill = GridBagConstraints.BOTH;
+		gbl.setConstraints(txt, gbc);
+		add(txt, gbc);
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/enumeration/Filter.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/enumeration/Filter.java
@@ -1,0 +1,5 @@
+package com.excilys.ebi.gatling.proxy.ui.enumeration;
+
+public enum Filter {
+	Java, Ant;
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/enumeration/FilterType.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/enumeration/FilterType.java
@@ -1,0 +1,5 @@
+package com.excilys.ebi.gatling.proxy.ui.enumeration;
+
+public enum FilterType {
+	All, Only, Except;
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/enumeration/ResultType.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/enumeration/ResultType.java
@@ -1,0 +1,5 @@
+package com.excilys.ebi.gatling.proxy.ui.enumeration;
+
+public enum ResultType {
+	Text, Scala;
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/event/Event.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/event/Event.java
@@ -1,0 +1,5 @@
+package com.excilys.ebi.gatling.proxy.ui.event;
+
+public interface Event {
+
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/event/HttpEvent.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/ui/event/HttpEvent.java
@@ -1,0 +1,93 @@
+package com.excilys.ebi.gatling.proxy.ui.event;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HttpEvent implements Event {
+
+	private String name;
+	private String url;
+	private String method;
+	private String content;
+	private Map<String, List<String>> params;
+	private String headers;
+
+	private String stringRequest;
+	private String stringResponse;
+
+	public HttpEvent() {
+		name = null;
+		url = null;
+		method = null;
+		content = null;
+		params = new LinkedHashMap<String, List<String>>();
+		headers = null;
+		stringRequest = null;
+		stringResponse = null;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public String getMethod() {
+		return method;
+	}
+
+	public void setMethod(String method) {
+		this.method = method;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+	public Map<String, List<String>> getParams() {
+		return params;
+	}
+
+	public void setParams(Map<String, List<String>> params) {
+		this.params = params;
+	}
+
+	public String getHeaders() {
+		return headers;
+	}
+
+	public void setHeaders(String headers) {
+		this.headers = headers;
+	}
+
+	public String getStringRequest() {
+		return stringRequest;
+	}
+
+	public void setStringRequest(String request) {
+		this.stringRequest = request;
+	}
+
+	public String getStringResponse() {
+		return stringResponse;
+	}
+
+	public void setStringResponse(String response) {
+		this.stringResponse = response;
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/wrapper/HttpWrapper.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/wrapper/HttpWrapper.java
@@ -1,0 +1,32 @@
+package com.excilys.ebi.gatling.proxy.wrapper;
+
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+
+public class HttpWrapper implements IHttpWrapper {
+	private HttpRequest request;
+	private HttpResponse response;
+
+	public HttpWrapper(HttpRequest req) {
+		this.request = req;
+	}
+
+	public HttpWrapper(HttpRequest req, HttpResponse resp) {
+		this(req);
+		setHttpResponse(resp);
+	}
+
+	public void setHttpResponse(HttpResponse resp) {
+		this.response = resp;
+	}
+
+	@Override
+	public HttpRequest getHttpRequest() {
+		return this.request;
+	}
+
+	@Override
+	public HttpResponse getHttpResponse() {
+		return this.response;
+	}
+}

--- a/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/wrapper/IHttpWrapper.java
+++ b/gatling-proxy/src/main/java/com/excilys/ebi/gatling/proxy/wrapper/IHttpWrapper.java
@@ -1,0 +1,10 @@
+package com.excilys.ebi.gatling.proxy.wrapper;
+
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+
+public interface IHttpWrapper {
+	public HttpRequest getHttpRequest();
+
+	public HttpResponse getHttpResponse();
+}

--- a/gatling-proxy/src/main/resources/scenarioScala.vm
+++ b/gatling-proxy/src/main/resources/scenarioScala.vm
@@ -1,0 +1,7 @@
+import com.excilys.ebi.gatling.core.Predef._
+import com.excilys.ebi.gatling.http.Predef._
+
+class Simulation extends GatlingSimulation {
+#parse("scenarioText.vm")
+
+}

--- a/gatling-proxy/src/main/resources/scenarioText.vm
+++ b/gatling-proxy/src/main/resources/scenarioText.vm
@@ -1,0 +1,48 @@
+	val PROTOCOL = "$protocol"
+	val DOMAIN = "$domain"
+#if ($port != -1)
+	val PORT = "$port"
+#end
+	val urlBase = $urlBase
+	
+	val httpConf = httpConfig.baseURL(urlBase)
+	
+#foreach($url in $urls.entrySet())
+	val $url.key = "$url.value"
+#end
+	
+#foreach ($h in $headers.entrySet())
+	val $h.key = Map(
+#foreach ($header in $h.value.entrySet())
+		"$header.key" -> "$header.value"#if($foreach.hasNext), 
+#else
+	
+		)
+#end
+#end
+	
+#end
+	
+	val scn = scenario("$name")
+#foreach($req in $reqs)
+#if($req.class.simpleName == "TagEvent")
+		/* $req.getTag() */
+#else
+		.exec(
+			http("request_$req.getId()")
+			$req.getCorrespondingRequest().getMethod().toString().toLowerCase()(url_$req.getId())
+	#foreach($param in $req.getParams().entrySet())
+#foreach($val in $param.value)
+		param("$param.key", "$val")
+#end
+	#end
+		headers(headers_$req.getId())
+	#if($req.isWithBody())
+		withFile("request_${req.getId()}.txt")
+	#end
+		)
+#end
+#end
+	
+	val scnConf = scn.configure users 1 protocolConfig httpConf
+	runSimulations(scnConf)


### PR DESCRIPTION
The ConfigurationFrame is used to specify different kind of settings (port, filters, etc...) for the recorder. Closes #201
RunningFrame represents the running state of the recorder. Closes #202
Forwarded requests are shown in the RunningFrame. Closes #203
The URL filter for Java regular expression is configurable in the ConfigurationFrame. Closes #204
Same as Java regular expression, but for Ant pattern. Closes #205
Preferences can be saved if selected in the ConfigurationFrame. They are saved in the user home directory. Closes #206
Requests with body are automaticaly dumped in a specific directory. Closes #207
