### PR TITLE
Use non-greedy EL interpolation pattern 

### DIFF
--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/util/StringHelper.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/util/StringHelper.scala
@@ -40,7 +40,7 @@ object StringHelper extends Logging {
 
 	val jdk6Pattern = Pattern.compile("\\p{InCombiningDiacriticalMarks}+")
 
-	val elPatternString = """\$\{([^\$]*)\}"""
+	val elPatternString = """\$\{([^\$]*?)\}"""
 	val elPattern = elPatternString.r
 	val elOccurrencePattern = """\((\d+)\)""".r
 


### PR DESCRIPTION
Avoids matching incorrectly in strings which contain "}" (such as JSON).
