### PR TITLE
Gatling Debian Package

### DIFF
--- a/gatling-bundle/pom.xml
+++ b/gatling-bundle/pom.xml
@@ -24,6 +24,20 @@
 	<build>
 		<plugins>
 			<plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptors>
@@ -49,6 +63,69 @@
 					</includes>
 				</configuration>
 			</plugin>
+            <plugin>
+                <artifactId>jdeb</artifactId>
+                <groupId>org.vafer</groupId>
+                <configuration>
+                    <deb>${project.build.directory}/gatling-${project.version}.deb</deb>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jdeb</goal>
+                        </goals>
+                        <configuration>
+                            <dataSet>
+                                <data>
+                                    <src>${project.basedir}/src/main/assembly/assembly-structure/bin</src>
+                                    <type>directory</type>
+                                    <excludes>*.bat</excludes>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/share/gatling/bin</prefix>
+                                        <filemode>755</filemode>
+                                        <user>root</user>
+                                        <group>root</group>
+                                    </mapper>
+                                </data>
+                                <data>
+                                    <src>${project.basedir}/src/main/assembly/assembly-structure/conf</src>
+                                    <type>directory</type>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/share/gatling/conf</prefix>
+                                        <filemode>755</filemode>
+                                        <user>root</user>
+                                        <group>root</group>
+                                    </mapper>
+                                </data>
+                                <data>
+                                    <src>${project.build.directory}/lib</src>
+                                    <type>directory</type>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/share/gatling/lib</prefix>
+                                        <user>root</user>
+                                        <group>root</group>
+                                    </mapper>
+                                </data>
+                                <data>
+                                    <src>${project.basedir}/src/deb/bin</src>
+                                    <type>directory</type>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/bin</prefix>
+                                        <filemode>755</filemode>
+                                        <user>root</user>
+                                        <group>root</group>
+                                    </mapper>
+                                </data>
+                            </dataSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 </project>

--- a/gatling-bundle/src/deb/bin/gatling
+++ b/gatling-bundle/src/deb/bin/gatling
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+# Copyright 2011-2012 eBusiness Information, Groupe Excilys (www.excilys.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 		http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -e
+
+# Gatling User directory
+GATLING_USER_HOME=${GATLING_USER_HOME:="~/.gatling"}
+
+GATLING_HOME="/usr/share/gatling"
+GATLING_SCRIPT="$GATLING_HOME/bin/gatling.sh"
+VERBOSE="false"
+
+# By default this variables points to $GATLING_USER_HOME directories,
+# but may be defined on the ~/.bashrc script for example.
+
+GATLING_CONF=${GATLING_CONF:="$GATLING_USER_HOME/conf"}
+
+GATLING_CONF_FILE=${GATLING_CONF_FILE:="$GATLING_CONF/gatling.conf"}
+
+GATLING_DATA=${GATLING_DATA:="$GATLING_USER_HOME/user-files/data"}
+
+GATLING_REQUEST_BODIES=${GATLING_REQUEST_BODIES:="$GATLING_USER_HOME/user-files/request-bodies"}
+
+GATLING_SIMULATIONS=${GATLING_SIMULATIONS:="$GATLING_USER_HOME/user-files/simulations"}
+
+GATLING_RESULTS=${GATLING_RESULTS:="$GATLING_USER_HOME/results"}
+
+GATLING_REPORTS_ONLY=${GATLING_REPORTS_ONLY:=""}
+
+# print usage
+print_usage() {
+  sh "$GATLING_SCRIPT" "-h"
+  exit 1
+}
+
+# get_opts : Parse arguments and options.
+get_opts(){
+ OTHER_ARGS=""		
+ until [ $# -eq 0 ]; do
+   local FIRST="${1:0:1}"
+   if [ "$FIRST" = "-" ] ; then
+     local option="${1:1}"
+     case $option in
+        cf|-config-file)
+            shift
+            if [ -z $1 ]; then
+              print_usage
+            fi
+            GATLING_CONF_FILE="$1"
+            GATLING_CONF=`dirname "$GATLING_CONF_FILE"`;;
+        df|-data-folder)
+            shift
+            if [ -z $1 ]; then
+              print_usage
+            fi
+            GATLING_DATA="$1";;
+        rf|-results-folder)
+            shift
+            if [ -z $1 ]; then
+              print_usage
+            fi
+            GATLING_RESULTS="$1";;
+        bf|-request-bodies-folder)
+            shift
+            if [ -z $1 ]; then
+              print_usage
+            fi
+            GATLING_REQUEST_BODIES="$1";;
+        sf|-simulations-folder)
+            shift
+            if [ -z $1 ]; then
+              print_usage
+            fi
+            GATLING_SIMULATIONS="$1";;
+        ro|-reports-only)
+            shift
+            if [ -z $1 ]; then
+              print_usage
+            fi
+            GATLING_REPORTS_ONLY="$1";;
+        v|-verbose)
+            VERBOSE="true";;
+        h|-help) 
+            print_usage;;
+        ?)
+            shift
+            OTHER_ARGS="$OTHER_ARGS -$option $1";;		
+     esac
+   else
+      print_usage
+   fi
+   shift
+ done
+}
+
+
+# Override default variables by command line variables.
+get_opts $@
+
+# Try to create folders
+mkdir -p "$GATLING_CONF" "$GATLING_DATA" "$GATLING_REQUEST_BODIES" "$GATLING_SIMULATIONS" "$GATLING_RESULTS"
+
+
+# Copy default configuration if does not exists
+if [ ! -f  "$GATLING_CONF_FILE" ]; then
+    cp -f /usr/share/gatling/conf/gatling.conf "$GATLING_CONF_FILE"
+fi
+
+# Copy default logging configuration if does not exists
+if [ ! -f  "$GATLING_CONF/logback.xml" ]; then
+    cp -f /usr/share/gatling/conf/logback.xml  "$GATLING_CONF"
+fi
+
+# Export variables used by $GATLING_SCRIPT
+export GATLING_HOME GATLING_CONF
+
+# Create arguments to execute gatling.sh
+GATLING_ARGS="-cf $GATLING_CONF_FILE -df $GATLING_DATA -bf $GATLING_REQUEST_BODIES -sf $GATLING_SIMULATIONS -rf $GATLING_RESULTS $OTHER_ARGS"
+
+if [ -n "$GATLING_REPORTS_ONLY" ];then
+  mkdir -p  "$GATLING_REPORTS_ONLY"
+  GATLING_ARGS="$GATLING_ARGS -ro $GATLING_REPORTS_ONLY"
+fi
+
+if [ "$VERBOSE" = "true" ];then
+  echo "Execute Gatling with args : $GATLING_ARGS"
+fi
+
+# Exec GATLING_SCRIPT with "$GATLING_ARGS"
+exec "$GATLING_SCRIPT" "$GATLING_ARGS"

--- a/gatling-bundle/src/deb/control/control
+++ b/gatling-bundle/src/deb/control/control
@@ -1,0 +1,9 @@
+Package: gatling
+Version: [[version]]
+Architecture: all
+Maintainer: Nicolas Huray <nicolas.huray@gmail.com>
+Depends: openjdk-6-jre-headless | sun-java6-jre
+Section: web
+Priority: optional
+Homepage: http://gatling-tool.org/
+Description: Optimized Stress Tool

--- a/gatling-bundle/src/main/assembly/assembly-structure/bin/gatling.sh
+++ b/gatling-bundle/src/main/assembly/assembly-structure/bin/gatling.sh
@@ -21,13 +21,14 @@ DEFAULT_GATLING_HOME=`readlink -f ${BIN_DIR}/..`
 
 GATLING_HOME=${GATLING_HOME:=${DEFAULT_GATLING_HOME}}
 GATLING_HOME=`echo ${GATLING_HOME} | sed -e 's/ /\\ /g'`
-export GATLING_HOME
+GATLING_CONF=${GATLING_CONF:="$GATLING_HOME/conf"}
+
+export GATLING_HOME GATLING_CONF
 
 echo "GATLING_HOME is set to ${GATLING_HOME}"
 
-
 JAVA_OPTS="-server -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms512M -Xmx512M -Xmn100M -Xss1024k -XX:+HeapDumpOnOutOfMemoryError -XX:+AggressiveOpts -XX:+OptimizeStringConcat -XX:+UseFastAccessorMethods -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=1 -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly"
 
-CLASSPATH="$GATLING_HOME/lib/*:$GATLING_HOME/conf"
+CLASSPATH="$GATLING_HOME/lib/*:$GATLING_CONF"
 
 java $JAVA_OPTS -cp $CLASSPATH com.excilys.ebi.gatling.app.Gatling $@

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
 		<maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
 		<maven-plugin-plugin.version>2.9</maven-plugin-plugin.version>
 		<build-helper-maven-plugin.version>1.7</build-helper-maven-plugin.version>
+        <maven-jdeb-plugin.version>0.8</maven-jdeb-plugin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -501,6 +502,11 @@
 					<artifactId>maven-plugin-plugin</artifactId>
 					<version>${maven-plugin-plugin.version}</version>
 				</plugin>
+                <plugin>
+                    <artifactId>jdeb</artifactId>
+                    <groupId>org.vafer</groupId>
+                    <version>${maven-jdeb-plugin.version}</version>
+                </plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
Hi all,

I'd like to proposed a patch to build Gatling as a Debian package. 

The Debian package is built with the JDeb Maven plugin : https://github.com/tcurdt/jdeb

The Debian package installation has the following structure :

<pre>
/usr/share/gatling       : gatling home directory
                     \_ bin   : bin directory 
                     \_ conf : default configuration
                     \_ lib    : lib directory

/usr/bin/gatling : bash script who calls /usr/share/gatling/bin/gatling.sh script
</pre>


When the /usr/bin/gatling script is called, a workspace is created for the user in :

<pre>
/home/{user}/.gatling
                     \_ conf : gatling user conf (copied from /usr/share/gatling/conf)
                     \_ user-files          
                                    \_ data : data files
                                    \_ request-bodies : request bodies files
                                    \_ simulations : simulations files
                     \_ results : results directory

</pre>

It's also possible to set environnement variables for the user in ~/.bashrc for example.

Of course if the gatling parameters are set they takes precedence over the variables defined on~/.bashrc

Regards,

Nicolas
