### PR TITLE
Impossible to start the "https" proxy in the recorder

### DIFF
--- a/gatling-recorder/src/main/java/org/jboss/netty/example/securechat/SecureChatSslContextFactory.java
+++ b/gatling-recorder/src/main/java/org/jboss/netty/example/securechat/SecureChatSslContextFactory.java
@@ -15,6 +15,7 @@
  */
 package org.jboss.netty.example.securechat;
 
+import java.io.IOException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.security.KeyStore;
@@ -74,14 +75,14 @@ public class SecureChatSslContextFactory {
 
 		SSLContext serverContext = null;
 		SSLContext clientContext = null;
+
+		InputStream in = null;
 		try {
 			KeyStore ks = KeyStore.getInstance("JKS");
 
-			byte[] data = new byte[2048];
-			InputStream in = ClassLoader.getSystemResourceAsStream("gatling.jks");
+			in = ClassLoader.getSystemResourceAsStream("gatling.jks");
 			char[] gatlingChars = "gatling".toCharArray();
-			in.read(data);
-			ks.load(new ByteArrayInputStream(data), gatlingChars);
+			ks.load(in, gatlingChars);
 
 			// Set up key manager factory to use our key store
 			KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
@@ -92,6 +93,14 @@ public class SecureChatSslContextFactory {
 			serverContext.init(kmf.getKeyManagers(), null, null);
 		} catch (Exception e) {
 			throw new Error("Failed to initialize the server-side SSLContext", e);
+		} finally {
+			try {
+				if (in != null) {
+					in.close();
+				}
+			} catch (IOException e) {
+				throw new Error("Failed to close ", e);
+			}
 		}
 
 		try {


### PR DESCRIPTION
Hi,

On my laptop, it happened that my keystore was more than 2048 bytes and couldn't be loaded in memory.

cheers
Nicolas

PS : The documentation doesn't mention anything about the fact that a keystore called "gatling.jks" must be present in the classpath.

<pre>
GATLING_HOME is set to "D:\tools\gatling-charts-highcharts-1.1.2"
10 avr. 2012 14:59:52 org.jboss.netty.channel.socket.nio.NioServerSocketPipeline
Sink
ATTENTION: Failed to accept a connection.
java.lang.Error: Failed to initialize the server-side SSLContext
        at org.jboss.netty.example.securechat.SecureChatSslContextFactory.<clinit>(SecureChatSslContextFactory.java:94)
        at com.excilys.ebi.gatling.recorder.http.ssl.SSLEngineFactory.newServerSSLEngine(SSLEngineFactory.java:29)
        at com.excilys.ebi.gatling.recorder.http.channel.BootstrapFactory$2.getPipeline(BootstrapFactory.java:101)
        at org.jboss.netty.channel.socket.nio.NioServerSocketPipelineSink$Boss.registerAcceptedChannel(NioServerSocketPipelineSink.java:258)
        at org.jboss.netty.channel.socket.nio.NioServerSocketPipelineSink$Boss.run(NioServerSocketPipelineSink.java:225)
        at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
        at java.lang.Thread.run(Thread.java:662)
Caused by: java.io.EOFException
        at java.io.DataInputStream.readInt(DataInputStream.java:375)
        at sun.security.provider.JavaKeyStore.engineLoad(JavaKeyStore.java:664)
        at sun.security.provider.JavaKeyStore$JKS.engineLoad(JavaKeyStore.java:38)
        at java.security.KeyStore.load(KeyStore.java:1185)
        at org.jboss.netty.example.securechat.SecureChatSslContextFactory.<clinit>(SecureChatSslContextFactory.java:84)
        ... 7 more

</pre>

