### PR TITLE
Check user input for simulation selection to avoid IndexOutOfBoundsException.

### DIFF
--- a/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/Gatling.scala
@@ -219,7 +219,11 @@ class Gatling(cliOptions: Options) extends Logging {
 				Console.readInt
 		}
 
-		classes(selection)
+    if(selection >= 0 && selection < classes.size){
+		  classes(selection)
+      } else {
+      selectSimulationClass(classes)
+    }
 	}
 
 	private def run(selection: UserSelection): Seq[String] = {


### PR DESCRIPTION
This change updates the console's simulation input handler to handle out-of-bounds input without an exception.  Currently, if a user enters a number that does not map to an actual simulation, say -1 or 2 when there are only two simulations, then the selectSimulationClass will throw an IndexOutOfBoundsException because it attempts to index directly into the classes array.
