### PR TITLE
Specify the encoding of simulation.log

### DIFF
--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/message/InitializeDataWriter.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/message/InitializeDataWriter.scala
@@ -24,5 +24,6 @@ import java.util.concurrent.CountDownLatch
  * @param runRecord the data on the simulation run
  * @param totalUsersCount the number of total users
  * @param latch the countdown latch that will end the simulation
+ * @param encoding the file encoding
  */
-case class InitializeDataWriter(runRecord: RunRecord, totalUsersCount: Long, latch: CountDownLatch)
+case class InitializeDataWriter(runRecord: RunRecord, totalUsersCount: Long, latch: CountDownLatch, encoding: String)

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/DataWriter.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/DataWriter.scala
@@ -36,7 +36,7 @@ object DataWriter {
 
 	private def init = system.actorOf(Props(configuration.dataWriterClass))
 
-	def init(runRecord: RunRecord, totalUsersCount: Long, latch: CountDownLatch) = instance ! InitializeDataWriter(runRecord, totalUsersCount, latch)
+	def init(runRecord: RunRecord, totalUsersCount: Long, latch: CountDownLatch, encoding: String) = instance ! InitializeDataWriter(runRecord, totalUsersCount, latch, encoding)
 
 	def startUser(scenarioName: String, userId: Int, time: Long) = DataWriter.instance ! RequestRecord(scenarioName, userId, START_OF_SCENARIO, time, time, time, time, OK, START_OF_SCENARIO)
 

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/FileDataWriter.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/FileDataWriter.scala
@@ -67,10 +67,10 @@ class FileDataWriter extends DataWriter with Logging {
 	 */
 	def receive = {
 		// If the message is sent to initialize the writer
-		case InitializeDataWriter(runRecord, totalUsersCount, latch) => {
+		case InitializeDataWriter(runRecord, totalUsersCount, latch, encoding) => {
 
 			def initStreamWriter {
-				osw = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(simulationLogFile(runRecord.runUuid).toString)))
+				osw = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(simulationLogFile(runRecord.runUuid).toString)), encoding)
 			}
 
 			def printRunRecord {

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/runner/Runner.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/runner/Runner.scala
@@ -61,7 +61,8 @@ class Runner(runRecord: RunRecord, scenarioConfigurationBuilders: Seq[ScenarioCo
 	 * This method schedules the beginning of all scenarios
 	 */
 	def run {
-		DataWriter.init(runRecord, totalNumberOfUsers, dataWriterLatch)
+	  
+		DataWriter.init(runRecord, totalNumberOfUsers, dataWriterLatch, configuration.encoding)
 
 		debug("Launching All Scenarios")
 


### PR DESCRIPTION
Hi,

In FileDataReader.scala:49 - we specify the encoding while reading the simulation.log file : 
    Source.fromFile(simLogFile, configuration.encoding).getLines

But in FileDataWriter.scala:73, we don't specify the encoding while writing the simulation.log file : 
    osw = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(simulationLogFile(runRecord.runUuid).toString)))

So, if we put no-ASCII characters in the scenario name like "Tête à toto", we get this exception : 

<pre>
Caused by: java.nio.charset.MalformedInputException: Input length = 1
        at java.nio.charset.CoderResult.throwException(CoderResult.java:260)
        at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:319)
        at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:158)
        at java.io.InputStreamReader.read(InputStreamReader.java:167)
        at java.io.BufferedReader.fill(BufferedReader.java:136)
        at java.io.BufferedReader.readLine(BufferedReader.java:299)
        at java.io.BufferedReader.readLine(BufferedReader.java:362)
        at scala.io.BufferedSource$BufferedLineIterator.hasNext(BufferedSource.scala:67)
        at scala.collection.Iterator$$anon$19.hasNext(Iterator.scala:334)
        at scala.collection.Iterator$class.foreach(Iterator.scala:660)
        at scala.collection.Iterator$$anon$19.foreach(Iterator.scala:333)
        at com.excilys.ebi.gatling.charts.result.reader.FileDataReader.<init>(FileDataReader.scala:50)
</pre>
