### PR TITLE
Correcly compute the lower bound of the window percentile range

### DIFF
--- a/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/util/StatisticsHelper.scala
+++ b/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/util/StatisticsHelper.scala
@@ -134,10 +134,10 @@ object StatisticsHelper {
 	def windowInPercentileRange(average: Long, limit: Double, records: Seq[RequestRecord]): (Long, Long) = {
 
 		val maxCount = (records.size * limit).toInt
-		val recordsSortedByDistanceToAverage = records.sortBy(record => abs(record.responseTime - average)).take(maxCount)
+		val recordsSortedByDistanceToAverage = records.sortBy(record => abs(record.responseTime - average))
 
-		var min = if (recordsSortedByDistanceToAverage.isEmpty) NO_PLOT_MAGIC_VALUE else recordsSortedByDistanceToAverage.minBy(_.responseTime).responseTime
-		var max = if (recordsSortedByDistanceToAverage.isEmpty) NO_PLOT_MAGIC_VALUE else recordsSortedByDistanceToAverage.maxBy(_.responseTime).responseTime
+		val min = if (recordsSortedByDistanceToAverage.isEmpty) NO_PLOT_MAGIC_VALUE else recordsSortedByDistanceToAverage.takeRight(maxCount).minBy(_.responseTime).responseTime
+		val max = if (recordsSortedByDistanceToAverage.isEmpty) NO_PLOT_MAGIC_VALUE else recordsSortedByDistanceToAverage.take(maxCount).maxBy(_.responseTime).responseTime
 
 		(min, max)
 	}


### PR DESCRIPTION
Currently, the window percentile range is not correctly computed. 
"95 Low Bound" is always equal to "Min", cf : http://cdn.hubic.me/R4pojFCtY20q/gatling_window_percentile.png
