### PR TITLE
Write tests for StatisticsHelper.{averageTime, responseTimeStandardDeviation}

### DIFF
--- a/gatling-charts/pom.xml
+++ b/gatling-charts/pom.xml
@@ -19,6 +19,18 @@
 			<groupId>org.fusesource.scalate</groupId>
 			<artifactId>scalate-core</artifactId>
 		</dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2_2.9.1-1</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>
@@ -74,6 +86,20 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>com.mmakowski</groupId>
+                <artifactId>maven-specs2-plugin</artifactId>
+                <version>0.2.1</version>
+                <executions>
+                    <execution>
+                        <id>verify</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>run-specs</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
 	</build>
 </project>

--- a/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/util/StatisticsHelper.scala
+++ b/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/util/StatisticsHelper.scala
@@ -33,6 +33,11 @@ object StatisticsHelper {
 
 	val averageLatency = averageTime(_.latency) _
 
+  /**
+   * Compute the population standard deviation of the provided data.
+   *
+   * @param data is all the RequestRecords from a test run
+   */
 	def responseTimeStandardDeviation(data: Seq[RequestRecord]): Long = {
 		val avg = averageResponseTime(data)
 		if (avg != NO_PLOT_MAGIC_VALUE) sqrt(data.map(result => pow(result.responseTime - avg, 2)).sum / data.length).toLong else NO_PLOT_MAGIC_VALUE

--- a/gatling-charts/src/test/scala/com/excilys/ebi/gatling/charts/util/StatisticsHelperSpec.scala
+++ b/gatling-charts/src/test/scala/com/excilys/ebi/gatling/charts/util/StatisticsHelperSpec.scala
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011-2012 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.excilys.ebi.gatling.charts.util
+
+import collection.mutable.ListBuffer
+
+import org.junit.runner.RunWith
+
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import com.excilys.ebi.gatling.core.result.message.{RequestStatus, RequestRecord}
+import com.excilys.ebi.gatling.charts.util.StatisticsHelper.{averageTime, responseTimeStandardDeviation}
+
+@RunWith(classOf[JUnitRunner])
+class StatisticsHelperSpec extends Specification {
+
+  val emptyRequestData: Seq[RequestRecord] = new ListBuffer[RequestRecord]
+  val testRequestRecords: Seq[RequestRecord] = createTestRequestRecords
+
+  "empty request data: { }" should {
+
+    "should return NO_PLOT_MAGIC_VALUE for averageTime(_.responseTime)" in {
+      averageTime(_.responseTime)(emptyRequestData) must beEqualTo(StatisticsHelper.NO_PLOT_MAGIC_VALUE)
+    }
+
+    "return NO_PLOT_MAGIC_VALUE for responseTimeStandardDeviation" in {
+      responseTimeStandardDeviation( emptyRequestData ) must beEqualTo(StatisticsHelper.NO_PLOT_MAGIC_VALUE)
+    }
+
+  }
+
+  "real request data: {2000, 4000, 4000, 4000, 5000, 5000, 7000, 9000}" should {
+    "return 5000 for averageTime(_.responseTime)" in {
+      averageTime(_.responseTime)(testRequestRecords) must beEqualTo(5000)
+    }
+
+    "return 2000 for responseTimeStandardDeviation" in {
+      responseTimeStandardDeviation(testRequestRecords) must beEqualTo(2000)
+    }
+
+  }
+
+  private def createTestRequestRecords():Seq[RequestRecord] = {
+    val requestRecords: ListBuffer[RequestRecord] = new ListBuffer[RequestRecord]
+    // Wolfram Alpha reports the following statistics for {2000, 4000, 4000, 4000, 5000, 5000, 7000, 9000}:
+    //   average (mean): 5000
+    //   stddev: 2138
+    //   median: 4500
+    // http://www.wolframalpha.com/input/?i=2000%2C+4000%2C+4000%2C+4000%2C+5000%2C+5000%2C+7000%2C+9000
+    requestRecords + createRequestRecord(1000, 3000, 3500, 5000)
+    requestRecords + createRequestRecord(2000, 6000, 3500, 5000)
+    requestRecords + createRequestRecord(3000, 7000, 3500, 5000)
+    requestRecords + createRequestRecord(4000, 8000, 3500, 5000)
+    requestRecords + createRequestRecord(5000, 10000, 3500, 5000)
+    requestRecords + createRequestRecord(5000, 10000, 3500, 5000)
+    requestRecords + createRequestRecord(7000, 14000, 3500, 5000)
+    requestRecords + createRequestRecord(0, 9000, 3500, 5000)
+
+    requestRecords
+  }
+
+  private def createRequestRecord(execStart:Long, execEnd:Long, sendEnd:Long, responseRecvStart:Long) : RequestRecord = RequestRecord(
+    "testScenario", 1, "Test Request", execStart, execEnd, sendEnd, responseRecvStart, RequestStatus.OK, "test request record"
+  )
+
+
+}


### PR DESCRIPTION
Hello, I wrote some very basic tests for StatisticsHelper's averageTime and responseTimeStandardDeviation functions.

Note that the specs dependency specified in gatling-charts/pom.xml has since updated to specs2_2.9.2.
