### PR TITLE
Fix bug with gatling not being able to find simulations outside of the default package on Windows

### DIFF
--- a/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
+++ b/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
@@ -264,7 +264,7 @@ public class GatlingMojo extends AbstractMojo {
 	}
 
 	protected String fileNametoClassName(String fileName) {
-		return stripEnd(fileName, ".scala").replace('/', '.');
+		return stripEnd(fileName, ".scala").replace(File.separatorChar, '.');
 	}
 
 	/**
@@ -277,6 +277,7 @@ public class GatlingMojo extends AbstractMojo {
 		DirectoryScanner scanner = new DirectoryScanner();
 
 		// Set Base Directory
+		getLog().debug("effective simulationsFolder: " + simulationsFolder.getPath());
 		scanner.setBasedir(simulationsFolder);
 
 		// Resolve includes
@@ -301,6 +302,7 @@ public class GatlingMojo extends AbstractMojo {
 			includedClassNames.add(fileNametoClassName(includedFile));
 		}
 
+		getLog().debug("resolved simulation classes: " + includedClassNames);
 		return join(includedClassNames.iterator(), ",");
 	}
 


### PR DESCRIPTION
Fix bug with gatling not being able to find simulations outside of the default package on Windows:
- Use File.separatorChar instead of '/' when converting file names to class names.
- Add debug logging to record effective simulationsFolder and simulation classes that are resolved.
