### PR TITLE
Fix class name resolver from filename (gatling-maven-plugin)

### DIFF
--- a/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
+++ b/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
@@ -264,7 +264,7 @@ public class GatlingMojo extends AbstractMojo {
 	}
 
 	protected String fileNametoClassName(String fileName) {
-		return stripEnd(fileName, ".scala").replace(File.separatorChar, '.');
+		return fileName.substring(0, fileName.lastIndexOf('.')).replace(File.separatorChar, '.');
 	}
 
 	/**


### PR DESCRIPTION
Replace stripEnd method by substring method

With stripEnd
    45000Email.scala ==> 45000Emai (ko)
    Commit5Cx500Mailblablal ==> Commit5Cx500Mailblab (ko)
    TestScala.scala ==> TestS (ko)
    test_a.scala ==> test_ (ko)
    t123456.scala ==> t123456 (ok)
It seem to be incorrect when filename has any letter in [c, a, l, a]
