### PR TITLE
Make fileNameToClassName remove the file extension again

### DIFF
--- a/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
+++ b/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
@@ -15,16 +15,8 @@
  */
 package com.excilys.ebi.gatling.mojo;
 
-import static com.excilys.ebi.gatling.ant.GatlingTask.GATLING_CLASSPATH_REF_NAME;
-import static java.util.Arrays.asList;
-import static org.codehaus.plexus.util.StringUtils.chompLast;
-import static org.codehaus.plexus.util.StringUtils.join;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
+import com.excilys.ebi.gatling.ant.GatlingTask;
+import com.excilys.ebi.gatling.app.OptionsConstants;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
@@ -39,8 +31,15 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Commandline;
 import org.apache.tools.ant.types.Path;
 
-import com.excilys.ebi.gatling.ant.GatlingTask;
-import com.excilys.ebi.gatling.app.OptionsConstants;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.excilys.ebi.gatling.ant.GatlingTask.GATLING_CLASSPATH_REF_NAME;
+import static java.util.Arrays.asList;
+import static org.codehaus.plexus.util.StringUtils.join;
+import static org.codehaus.plexus.util.StringUtils.trim;
 
 /**
  * Mojo to execute Gatling.
@@ -263,8 +262,15 @@ public class GatlingMojo extends AbstractMojo {
 		}
 	}
 
-	protected String fileNametoClassName(String fileName) {
-		return chompLast(fileName, ".scala").replace(File.separatorChar, '.');
+	protected String fileNameToClassName(String fileName) {
+        String trimmedFileName = trim(fileName);
+
+        int lastIndexOfExtensionDelim = trimmedFileName.lastIndexOf(".");
+        String strippedFileName = lastIndexOfExtensionDelim > 0 ?
+                trimmedFileName.substring(0, lastIndexOfExtensionDelim) :
+                trimmedFileName;
+
+        return strippedFileName.replace(File.separatorChar, '.');
 	}
 
 	/**
@@ -299,7 +305,7 @@ public class GatlingMojo extends AbstractMojo {
 
 		List<String> includedClassNames = new ArrayList<String>(includedFiles.length);
 		for (String includedFile : includedFiles) {
-			includedClassNames.add(fileNametoClassName(includedFile));
+			includedClassNames.add(fileNameToClassName(includedFile));
 		}
 
 		getLog().debug("resolved simulation classes: " + includedClassNames);

--- a/gatling-maven-plugin/src/test/java/com/excilys/ebi/gatling/mojo/GatlingMojoFileNameConversionTest.java
+++ b/gatling-maven-plugin/src/test/java/com/excilys/ebi/gatling/mojo/GatlingMojoFileNameConversionTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2011-2012 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.excilys.ebi.gatling.mojo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(value = Parameterized.class)
+public class GatlingMojoFileNameConversionTest {
+
+    private static final String SEP = File.separator;
+    private final GatlingMojo gatlingMojo = new GatlingMojo();
+    private String className;
+    private String fileName;
+
+    public GatlingMojoFileNameConversionTest(String className, String fileName) {
+        this.className = className;
+        this.fileName = fileName;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][]{
+                {"MySimulation", "MySimulation.scala"}
+                , {"MySimulation", "MySimulation.customFileExtension"}
+                , {"45000Email", "45000Email.scala"}
+                , {"TestScala", "TestScala.scala"}
+                , {"test_a", "test_a.scala"}
+                , {"t123456", "t123456.scala"}
+                , {"A1", "A1.scala"}
+                , {"mypackage.MySimulation", "mypackage" + SEP + "MySimulation.scala"}
+                , {"my.deeply.nested.package.MySimulation",
+                    "my" + SEP + "deeply" + SEP + "nested" + SEP + "package" + SEP + "MySimulation.scala"}
+                , {"leading.whitespace.MySimulation",
+                    " \n\t " + "leading" + SEP + "whitespace" + SEP + "MySimulation.scala"}
+                , {"trailing.whitespace.MySimulation",
+                    "trailing" + SEP + "whitespace" + SEP + "MySimulation.scala" + " \n\t "}
+        };
+        return Arrays.asList(data);
+    }
+
+    @Test
+    public void test_fileNametoClassName() {
+        assertEquals(className, gatlingMojo.fileNameToClassName(fileName));
+    }
+
+}


### PR DESCRIPTION
Make fileNameToClassName remove the file extension again.  Add tests to verify simulation files will be found:
- in default package
- with .scala and custom file extensions
- with varyious package depths
- with leading and trailing whitespace surrounding the filename
- when letters in scala are just ahead of the file extension delimiter, i.e. situation described in 30bf5f7
