### PR TITLE
the default path for the config is "$GATLING_HOME/conf"

### DIFF
--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/config/GatlingFileConfiguration.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/config/GatlingFileConfiguration.scala
@@ -27,7 +27,7 @@ import grizzled.slf4j.Logging
 
 object GatlingFileConfiguration extends Logging {
 
-	val defaultPath = new File(GATLING_HOME).getCanonicalPath
+	val defaultPath = new File(GATLING_HOME).getCanonicalPath + "/conf"
 
 	private def fromFileSystem(file: File) = ConfigFactory.parseFile(file)
 


### PR DESCRIPTION
If I launched Gatling from Eclipse, the config file was not taken into account even though I correctly defined the GATLING_HOME variable.

When Gatling was launched from the command line, the /conf directory was added to the classpath and thus, we never add an issue. 
