### PR TITLE
Feature: Allow users to extract information from HTTP Request and Response

### DIFF
--- a/gatling-app/src/test/scala/com/excilys/ebi/gatling/app/test/CompileTest.scala
+++ b/gatling-app/src/test/scala/com/excilys/ebi/gatling/app/test/CompileTest.scala
@@ -18,6 +18,7 @@ import com.excilys.ebi.gatling.core.Predef._
 import com.excilys.ebi.gatling.http.Predef._
 import com.excilys.ebi.gatling.jdbc.Predef._
 import com.excilys.ebi.gatling.http.Headers.Names._
+import com.ning.http.client.{Response, Request}
 
 object CompileTest {
 
@@ -40,6 +41,10 @@ object CompileTest {
 		.acceptEncodingHeader("gzip,deflate,sdch")
 		.userAgentHeader("Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.19 (KHTML, like Gecko) Ubuntu/12.04 Chromium/18.0.1025.151 Chrome/18.0.1025.151 Safari/535.19")
 		.hostHeader("172.30.5.143:8080")
+
+  val httpConfToVerifyUserProvidedInfoExtractors = httpConfig
+    .requestInfoExtractor((request: Request) => { List[String]()})
+    .responseInfoExtractor((response: Response) => { List[String]()})
 
 	val usersInformation = tsv("user_information.tsv")
 

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/message/RequestRecord.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/message/RequestRecord.scala
@@ -30,5 +30,11 @@ import com.excilys.ebi.gatling.core.result.message.RecordType.ACTION
  * @param responseReceivingStartDate the date on which the response was started being received
  * @param requestStatus the status of the action
  * @param requestMessage the message of the action on completion
+ * @param extraInfo information about the request and response extracted via a user-defined function
  */
-case class RequestRecord(scenarioName: String, userId: Int, requestName: String, executionStartDate: Long, executionEndDate: Long, requestSendingEndDate: Long, responseReceivingStartDate: Long, requestStatus: RequestStatus.RequestStatus, requestMessage: String) extends Record(ACTION)
+case class RequestRecord(scenarioName: String, userId: Int, requestName: String,
+                         executionStartDate: Long, executionEndDate: Long,
+                         requestSendingEndDate: Long, responseReceivingStartDate: Long,
+                         requestStatus: RequestStatus.RequestStatus, requestMessage: String,
+                         extraInfo: List[String] = List())
+  extends Record(ACTION)

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/ConsoleDataWriter.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/ConsoleDataWriter.scala
@@ -50,7 +50,7 @@ class ConsoleDataWriter extends DataWriter with Logging {
 	}
 
 	def initialized: Receive = {
-		case RequestRecord(scenarioName, userId, actionName, executionStartDate, executionEndDate, requestSendingEndDate, responseReceivingStartDate, resultStatus, resultMessage) =>
+		case RequestRecord(scenarioName, userId, actionName, executionStartDate, executionEndDate, requestSendingEndDate, responseReceivingStartDate, resultStatus, resultMessage, extraInfo) =>
 
 			actionName match {
 				case START_OF_SCENARIO => activeUsersCount += 1

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/DataWriter.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/DataWriter.scala
@@ -51,8 +51,14 @@ object DataWriter {
 
 	def askFlush = dispatch(FlushDataWriter)
 
-	def logRequest(scenarioName: String, userId: Int, requestName: String, executionStartDate: Long, executionEndDate: Long, requestSendingEndDate: Long, responseReceivingStartDate: Long, requestResult: RequestStatus.RequestStatus, requestMessage: String) =
-		dispatch(RequestRecord(scenarioName, userId, requestName, executionStartDate, executionEndDate, requestSendingEndDate, responseReceivingStartDate, requestResult, requestMessage))
+  def logRequest(scenarioName: String, userId: Int, requestName: String,
+                 executionStartDate: Long, executionEndDate: Long, requestSendingEndDate: Long, responseReceivingStartDate: Long,
+                 requestResult: RequestStatus.RequestStatus, requestMessage: String, extraInfo: List[String] = List()) = {
+
+    dispatch(RequestRecord(scenarioName, userId, requestName,
+      executionStartDate, executionEndDate, requestSendingEndDate, responseReceivingStartDate,
+      requestResult, requestMessage, extraInfo))
+  }
 }
 
 /**

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/FileDataWriter.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/writer/FileDataWriter.scala
@@ -27,6 +27,40 @@ import com.excilys.ebi.gatling.core.util.StringHelper.END_OF_LINE
 
 import grizzled.slf4j.Logging
 
+object FileDataWriter {
+  val sanitizerPattern = """[\n\r\t]""".r
+
+  private[writer] def append(appendable:Appendable, requestRecord:RequestRecord) {
+
+    appendable.append(ACTION).append(TABULATION_SEPARATOR)
+      .append(requestRecord.scenarioName).append(TABULATION_SEPARATOR)
+      .append(requestRecord.userId.toString).append(TABULATION_SEPARATOR)
+      .append(requestRecord.requestName).append(TABULATION_SEPARATOR)
+      .append(requestRecord.executionStartDate.toString).append(TABULATION_SEPARATOR)
+      .append(requestRecord.executionEndDate.toString).append(TABULATION_SEPARATOR)
+      .append(requestRecord.requestSendingEndDate.toString).append(TABULATION_SEPARATOR)
+      .append(requestRecord.responseReceivingStartDate.toString).append(TABULATION_SEPARATOR)
+      .append(requestRecord.requestStatus.toString).append(TABULATION_SEPARATOR)
+      .append(requestRecord.requestMessage)
+
+    requestRecord.extraInfo.foreach((info: String) => {
+      appendable.append(TABULATION_SEPARATOR).append(sanitize(info))
+    })
+
+    appendable.append(END_OF_LINE)
+  }
+
+  /**
+   * Converts whitespace characters that would break the simulation log format into spaces.
+   * @param input
+   * @return
+   */
+  private[writer] def sanitize(input:String):String = {
+    sanitizerPattern.replaceAllIn(input, " ")
+  }
+
+}
+
 /**
  * File implementation of the DataWriter
  *
@@ -62,18 +96,8 @@ class FileDataWriter extends DataWriter with Logging {
 	}
 
 	def initialized: Receive = {
-		case RequestRecord(scenarioName, userId, actionName, executionStartDate, executionEndDate, requestSendingEndDate, responseReceivingStartDate, resultStatus, resultMessage) =>
-			osw.append(ACTION).append(TABULATION_SEPARATOR)
-				.append(scenarioName).append(TABULATION_SEPARATOR)
-				.append(userId.toString).append(TABULATION_SEPARATOR)
-				.append(actionName).append(TABULATION_SEPARATOR)
-				.append(executionStartDate.toString).append(TABULATION_SEPARATOR)
-				.append(executionEndDate.toString).append(TABULATION_SEPARATOR)
-				.append(requestSendingEndDate.toString).append(TABULATION_SEPARATOR)
-				.append(responseReceivingStartDate.toString).append(TABULATION_SEPARATOR)
-				.append(resultStatus.toString).append(TABULATION_SEPARATOR)
-				.append(resultMessage)
-				.append(END_OF_LINE)
+		case requestRecord:RequestRecord =>
+			FileDataWriter.append(osw, requestRecord)
 
 		case FlushDataWriter =>
 			info("Received flush order")

--- a/gatling-core/src/test/scala/com/excilys/ebi/gatling/core/result/message/RequestRecordSpec.scala
+++ b/gatling-core/src/test/scala/com/excilys/ebi/gatling/core/result/message/RequestRecordSpec.scala
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011-2012 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.excilys.ebi.gatling.core.result.message
+
+import org.specs2.mutable.Specification
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import com.excilys.ebi.gatling.core.result.message.RequestStatus._
+
+@RunWith(classOf[JUnitRunner])
+class RequestRecordSpec extends Specification {
+
+  "constructor" should {
+    "have sensible defaults for optional parameters" in {
+      val record: RequestRecord = RequestRecord("scenarioName", 1, "requestName", 0L, 0L, 0L, 0L, OK, "requestMessage")
+
+      record.extraInfo should beEmpty
+    }
+
+  }
+}

--- a/gatling-core/src/test/scala/com/excilys/ebi/gatling/core/result/writer/FileDataWriterSpec.scala
+++ b/gatling-core/src/test/scala/com/excilys/ebi/gatling/core/result/writer/FileDataWriterSpec.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2011-2012 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.excilys.ebi.gatling.core.result.writer
+
+import com.excilys.ebi.gatling.core.result.message.{RequestStatus, RequestRecord}
+import com.excilys.ebi.gatling.core.util.StringHelper.END_OF_LINE
+
+import org.junit.runner.RunWith
+
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import java.io.StringWriter
+
+@RunWith(classOf[JUnitRunner])
+class FileDataWriterSpec extends Specification {
+
+  "file data writer" should {
+
+    "log a standard request record" in {
+      val record = new RequestRecord("scenario", 1, "requestName", 2L, 3L, 4L, 5L, RequestStatus.OK, "message")
+
+      val stringWriter = new StringWriter()
+
+      FileDataWriter.append(stringWriter, record)
+
+      val loggedRequestRecord:String = stringWriter.getBuffer.toString
+
+      loggedRequestRecord must beEqualTo("ACTION\tscenario\t1\trequestName\t2\t3\t4\t5\tOK\tmessage" + END_OF_LINE)
+    }
+
+    "append extra info to request records" in {
+      val extraInfo:List[String] = List("some", "extra info", "for the log")
+      val record = new RequestRecord("scenario", 1, "requestName", 2L, 3L, 4L, 5L, RequestStatus.OK, "message", extraInfo)
+
+      val stringWriter = new StringWriter()
+
+      FileDataWriter.append(stringWriter, record)
+
+      val loggedRequestRecord:String = stringWriter.getBuffer.toString
+
+      loggedRequestRecord must beEqualTo("ACTION\tscenario\t1\trequestName\t2\t3\t4\t5\tOK\tmessage\tsome\textra info\tfor the log" + END_OF_LINE)
+    }
+
+    "sanitize extra info so that simulation log format is preserved" in {
+      FileDataWriter.sanitize("\nnewlines \n are\nnot \n\n allowed\n") must beEqualTo(" newlines   are not    allowed ")
+      FileDataWriter.sanitize("\rcarriage returns \r are\rnot \r\r allowed\r") must beEqualTo(" carriage returns   are not    allowed ")
+      FileDataWriter.sanitize("\ttabs \t are\tnot \t\t allowed\t") must beEqualTo(" tabs   are not    allowed ")
+    }
+
+  }
+}

--- a/gatling-http/pom.xml
+++ b/gatling-http/pom.xml
@@ -29,6 +29,18 @@
 			<artifactId>scalate-core</artifactId>
 		</dependency>
 
+        <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2_2.9.2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 		<!-- runtime -->
 		<dependency>
 			<groupId>io.netty</groupId>

--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/action/HttpRequestAction.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/action/HttpRequestAction.scala
@@ -107,7 +107,7 @@ class HttpRequestAction(requestName: String, next: ActorRef, requestBuilder: Abs
 		try {
 			val request = requestBuilder.build(session, protocolConfiguration)
 			val newSession = storeReferer(request, session, protocolConfiguration)
-			val actor = context.actorOf(Props(new GatlingAsyncHandlerActor(newSession, checks, next, requestName, request, followRedirect, gatlingConfiguration, handlerFactory, responseBuilderFactory)))
+			val actor = context.actorOf(Props(new GatlingAsyncHandlerActor(newSession, checks, next, requestName, request, followRedirect, protocolConfiguration, gatlingConfiguration, handlerFactory, responseBuilderFactory)))
 			val ahcHandler = handlerFactory(requestName, actor)
 			client.executeRequest(request, ahcHandler)
 

--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfiguration.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfiguration.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,27 @@
 package com.excilys.ebi.gatling.http.config
 
 import com.excilys.ebi.gatling.core.config.ProtocolConfiguration
-import com.ning.http.client.ProxyServer
+import com.ning.http.client.{Response, Request, ProxyServer}
 
 /**
  * HttpProtocolConfiguration class companion
  */
 object HttpProtocolConfiguration {
-	val HTTP_PROTOCOL_TYPE = "httpProtocol"
+  val HTTP_PROTOCOL_TYPE = "httpProtocol"
 }
 
 /**
  * Class containing the configuration for the HTTP protocol
  *
- * @param baseUrl the radix of all the URLs that will be used (eg: http://mywebsite.tld)
+ * @param baseURL the radix of all the URLs that will be used (eg: http://mywebsite.tld)
  * @param proxy a proxy through which all the requests must pass to succeed
  */
-case class HttpProtocolConfiguration(baseURL: Option[String], proxy: Option[ProxyServer], securedProxy: Option[ProxyServer], followRedirectEnabled: Boolean, automaticRefererEnabled: Boolean, baseHeaders: Map[String, String]) extends ProtocolConfiguration {
-	val protocolType = HttpProtocolConfiguration.HTTP_PROTOCOL_TYPE
+case class HttpProtocolConfiguration(baseURL: Option[String],
+                                     proxy: Option[ProxyServer], securedProxy: Option[ProxyServer],
+                                     followRedirectEnabled: Boolean, automaticRefererEnabled: Boolean,
+                                     baseHeaders: Map[String, String],
+                                     extraRequestInfoExtractor: Option[(Request => List[String])],
+                                     extraResponseInfoExtractor: Option[(Response => List[String])])
+  extends ProtocolConfiguration {
+  val protocolType = HttpProtocolConfiguration.HTTP_PROTOCOL_TYPE
 }

--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilder.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilder.scala
@@ -17,15 +17,15 @@ package com.excilys.ebi.gatling.http.config
 
 import com.excilys.ebi.gatling.http.action.HttpRequestAction.HTTP_CLIENT
 import com.excilys.ebi.gatling.http.Headers
-import com.ning.http.client.{ RequestBuilder, ProxyServer }
 
 import grizzled.slf4j.Logging
+import com.ning.http.client.{Response, Request, RequestBuilder, ProxyServer}
 
 /**
  * HttpProtocolConfigurationBuilder class companion
  */
 object HttpProtocolConfigurationBuilder {
-	def httpConfig = new HttpProtocolConfigurationBuilder(None, None, None, true, true, Map.empty, Some("http://gatling-tool.org"))
+	def httpConfig = new HttpProtocolConfigurationBuilder(None, None, None, true, true, Map.empty, Some("http://gatling-tool.org"), None, None)
 
 	implicit def toHttpProtocolConfiguration(builder: HttpProtocolConfigurationBuilder) = builder.build
 }
@@ -36,34 +36,45 @@ object HttpProtocolConfigurationBuilder {
  * @param baseUrl the radix of all the URLs that will be used (eg: http://mywebsite.tld)
  * @param proxy a proxy through which all the requests must pass to succeed
  */
-class HttpProtocolConfigurationBuilder(baseUrl: Option[String], proxy: Option[ProxyServer], securedProxy: Option[ProxyServer], followRedirectParam: Boolean, automaticRefererParam: Boolean, baseHeaders: Map[String, String], warmUpUrl: Option[String]) extends Logging {
+class HttpProtocolConfigurationBuilder(baseUrl: Option[String],
+                                       proxy: Option[ProxyServer], securedProxy: Option[ProxyServer],
+                                       followRedirectParam: Boolean, automaticRefererParam: Boolean,
+                                       baseHeaders: Map[String, String],
+                                       warmUpUrl: Option[String],
+                                       extraRequestInfoExtractor: Option[(Request => List[String])],
+                                       extraResponseInfoExtractor: Option[(Response => List[String])])
+  extends Logging {
 
 	/**
 	 * Sets the baseURL of the future HttpProtocolConfiguration
 	 *
-	 * @param baseurl the base url that will be set
+	 * @param baseUrl the base url that will be set
 	 */
-	def baseURL(baseUrl: String) = new HttpProtocolConfigurationBuilder(Some(baseUrl), proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl)
+	def baseURL(baseUrl: String) = new HttpProtocolConfigurationBuilder(Some(baseUrl), proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def disableFollowRedirect = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, false, automaticRefererParam, baseHeaders, warmUpUrl)
+	def disableFollowRedirect = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, false, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def disableAutomaticReferer = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, false, baseHeaders, warmUpUrl)
+	def disableAutomaticReferer = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, false, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT -> value), warmUpUrl)
+	def acceptHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptCharsetHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_CHARSET -> value), warmUpUrl)
+	def acceptCharsetHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_CHARSET -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptEncodingHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_ENCODING -> value), warmUpUrl)
+	def acceptEncodingHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_ENCODING -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptLanguageHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_LANGUAGE -> value), warmUpUrl)
+	def acceptLanguageHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_LANGUAGE -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def hostHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.HOST -> value), warmUpUrl)
+	def hostHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.HOST -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def userAgentHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.USER_AGENT -> value), warmUpUrl)
+	def userAgentHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.USER_AGENT -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def warmUp(warmUpUrl: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, Some(warmUpUrl))
+	def warmUp(warmUpUrl: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, Some(warmUpUrl), extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def disableWarmUp = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, None)
+	def disableWarmUp = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, None, extraRequestInfoExtractor, extraResponseInfoExtractor)
+
+  def requestInfoExtractor(value: (Request => List[String])) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, Some(value), extraResponseInfoExtractor)
+
+  def responseInfoExtractor(value: (Response) => List[String]) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, Some(value))
 
 	/**
 	 * Sets the proxy of the future HttpProtocolConfiguration
@@ -73,7 +84,7 @@ class HttpProtocolConfigurationBuilder(baseUrl: Option[String], proxy: Option[Pr
 	 */
 	def proxy(host: String, port: Int) = new HttpProxyBuilder(this, host, port)
 
-	private[http] def addProxies(httpProxy: ProxyServer, httpsProxy: Option[ProxyServer]) = new HttpProtocolConfigurationBuilder(baseUrl, Some(httpProxy), httpsProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl)
+	private[http] def addProxies(httpProxy: ProxyServer, httpsProxy: Option[ProxyServer]) = new HttpProtocolConfigurationBuilder(baseUrl, Some(httpProxy), httpsProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
 	private[http] def build = {
 		warmUpUrl.map { url =>
@@ -85,10 +96,10 @@ class HttpProtocolConfigurationBuilder(baseUrl: Option[String], proxy: Option[Pr
 			try {
 				HTTP_CLIENT.executeRequest(requestBuilder.build).get
 			} catch {
-				case e => info("Couln't execute warm up request " + url, e)
+				case e => info("Couldn't execute warm up request " + url, e)
 			}
 		}
 
-		HttpProtocolConfiguration(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders)
+		HttpProtocolConfiguration(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, extraRequestInfoExtractor, extraResponseInfoExtractor)
 	}
 }

--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/request/builder/AbstractHttpRequestWithBodyBuilder.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/request/builder/AbstractHttpRequestWithBodyBuilder.scala
@@ -45,7 +45,7 @@ object AbstractHttpRequestWithBodyBuilder {
 /**
  * This class serves as model to HTTP request with a body
  *
- * @param httpRequestActionBuilder the HttpRequestActionBuilder with which this builder is linked
+ * @param requestName name of the request under test
  * @param url the function returning the url
  * @param queryParams the query parameters that should be added to the request
  * @param headers the headers that should be added to the request
@@ -72,7 +72,7 @@ abstract class AbstractHttpRequestWithBodyBuilder[B <: AbstractHttpRequestWithBo
 	/**
 	 * Method overridden in children to create a new instance of the correct type
 	 *
-	 * @param httpRequestActionBuilder the HttpRequestActionBuilder with which this builder is linked
+	 * @param requestName name of the request under test
 	 * @param url the function returning the url
 	 * @param queryParams the query parameters that should be added to the request
 	 * @param headers the headers that should be added to the request

--- a/gatling-http/src/test/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilderSpec.scala
+++ b/gatling-http/src/test/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilderSpec.scala
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2011-2012 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.excilys.ebi.gatling.http.config
+
+import org.specs2.mutable.Specification
+import com.ning.http.client.{Response, Request}
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class HttpProtocolConfigurationBuilderSpec extends Specification {
+
+  "http protocol configuration builder" should {
+    "support an optional extra request info extractor" in {
+
+      val expectedExtractor: (Request => List[String]) = {
+        (Request) => List()
+      }
+
+      val builder = HttpProtocolConfigurationBuilder.httpConfig
+        .disableWarmUp
+        .requestInfoExtractor(expectedExtractor)
+      val config: HttpProtocolConfiguration = builder.build
+
+      config.extraRequestInfoExtractor.get should beEqualTo(expectedExtractor)
+    }
+
+    "support an optional extra response info extractor" in {
+
+      val expectedExtractor: (Response => List[String]) = {
+        (Response) => List()
+      }
+
+      val builder = HttpProtocolConfigurationBuilder.httpConfig
+        .disableWarmUp
+        .responseInfoExtractor(expectedExtractor)
+      val config: HttpProtocolConfiguration = builder.build
+
+      config.extraResponseInfoExtractor.get should beEqualTo(expectedExtractor)
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,18 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- http://repo.typesafe.com/typesafe/releases -->
+        <repository>
+            <id>typesafe</id>
+            <name>Typesafe Repository</name>
+            <url>http://repo.typesafe.com/typesafe/releases/</url>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- http://repo.typesafe.com/typesafe/releases -->
 		<!-- http://maven.jenkins-ci.org/content/repositories/releases -->
 		<!-- http://maven.twttr.com -->
 	</repositories>
@@ -202,6 +213,11 @@
 			<dependency>
 				<groupId>com.typesafe.akka</groupId>
 				<artifactId>akka-actor</artifactId>
+				<version>${akka.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.typesafe.akka</groupId>
+				<artifactId>akka-testkit</artifactId>
 				<version>${akka.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Allow users to extract information from HTTP Request and Response instances used in the simulation and append the information to the request's line in the simulation log.  The extra information is thus available for post-processing.

The extra info extraction functions must have the form:

``` scala
(Request => List[String])
(Response => List[String])
```

The extraction functions may be provided to the http configuration instance(s) used in the simulation.

An simple usage of this feature would be to extract the url from the request and the status code from the response:

``` scala
val httpConf = httpConfig.baseURL(urlBase)
  .requestInfoExtractor((request: Request) => {
  List[String](request.getRawUrl())
})
.responseInfoExtractor((response: Response) => {
  List[String](response.getStatusCode.toString())
})
```

Implements https://github.com/excilys/gatling/issues/446

---

Squashed commit of the following:

commit 2a1552a5a7e88a2222dcb1e37527a1288e52740a
Merge: 234d3a4 7962864
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Thu Jun 14 20:59:54 2012 -0700

```
Merge branch 'master' of git://github.com/excilys/gatling into feature-log-more-request-info
```

commit 234d3a4fce0b3afac6967dd6aee807e5df0340e4
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Thu Jun 14 20:25:58 2012 -0700

```
Sanitize extraInfo extracted by users before appending to log.
```

commit 6076847a672be9d0d4c39b494c7444bd45c9318a
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Thu Jun 14 19:38:45 2012 -0700

```
Collect extra response info and pass along.
```

commit 9bc30c92e67c4372f156cdd3f1a85ad5bff862ff
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Wed Jun 13 20:58:36 2012 -0700

```
Use an ArrayList to collect arguments because it can change its size.
```

commit f2668dc8a83d3b07dc0aba513320eecb9a62443e
Merge: 65b6fe8 a968e84
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Wed Jun 13 20:01:23 2012 -0700

```
Merge branch 'master' of git://github.com/excilys/gatling into feature-log-more-request-info
```

commit 65b6fe87780ea67ed24a24e4c219a5a8ba0a2381
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Tue Jun 12 21:51:24 2012 -0700

```
Remove failed attempt to test GatlingAsyncHandlerActor.
```

commit 649851a15f04609a5571f99754cbbf1a19d12577
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Tue Jun 12 21:27:07 2012 -0700

```
Add requestInfoExtractor and responseInfoExtractor to CompileTest to verify support.
```

commit 45e8f1f6eec34108527b8c567f3cd2aa16ed2cda
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Mon Jun 11 06:38:04 2012 -0700

```
Make GatlingAsyncHandlerActor robust against exceptions thrown by extraction functions.  Attempt to test GAHA.
```

commit ca60c587bdd761036c9ece42078b1870efa1b088
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 16:41:55 2012 -0700

```
Use custom request/response info extraction functions.
```

commit d24d8f6098d5313f14635d7041b7585fec23e2d5
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 15:31:29 2012 -0700

```
Correct ScalaDoc.
```

commit 503756ef4b46dd89bd7bdfe1ebf941019590900e
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 15:21:18 2012 -0700

```
Append extra information to the log via file data writer.
```

commit 4d26030f9d2685b603dd74a3f8e3baa5454a122e
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 13:03:22 2012 -0700

```
Modify RequestRecord to accept extra response info.
```

commit a2acf75145e2e952610080219c3cd6d5a4b410d6
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 12:48:25 2012 -0700

```
Annotate Spec with JUnit runner so test will be executed by maven surefire plugin.
```

commit 7f5a9eff719a0d678b7b5d69404264db63a3db21
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 12:28:04 2012 -0700

```
Remove pointless scaladoc.
```

commit d30ff1d94de0bb3df56f6bd79e2807891ebe5d20
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 12:27:23 2012 -0700

```
Fix compilation error: Update Writers to accept RequestRecord with request info extractor.
```

commit 27d9c622e92bfb0f92796ad5870d24cfd70ed0a1
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 12:16:08 2012 -0700

```
Clean-up import.
```

commit 3b11807c0ab12818e2b6a56650695fd5ffd34a71
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 12:15:38 2012 -0700

```
Modify HttpProtocolConfiguration to accept an extra information extractor function for responses.
```

commit 4d707b89fc2071b6a013a035da8df1b6c6b389d6
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 10:50:10 2012 -0700

```
Modify HttpProtocolConfiguration to accept an extra information extractor function.
```

commit 639b191c6c2dc649763724f0133c4f155429c01f
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 09:56:39 2012 -0700

```
Rename to RequestRecordSpec in order to match convention.
```

commit 79f97f0c952458eb13558bdf43d3379a744513f5
Author: Stephen Kuenzli skuenzli@qualimente.com
Date:   Sat Jun 9 09:54:37 2012 -0700

```
Modify RequestRecord to accept extra information about the request, optionally.
```
