### PR TITLE
When having multiple URLs, prefer a Round-Robin strategy

### DIFF
--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilder.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilder.scala
@@ -20,7 +20,6 @@ import com.excilys.ebi.gatling.http.action.HttpRequestAction.HTTP_CLIENT
 import com.ning.http.client.{ Response, RequestBuilder, Request, ProxyServer }
 
 import grizzled.slf4j.Logging
-import util.Random
 
 /**
  * HttpProtocolConfigurationBuilder class companion
@@ -37,49 +36,47 @@ object HttpProtocolConfigurationBuilder {
  * @param baseUrl the radix of all the URLs that will be used (eg: http://mywebsite.tld)
  * @param proxy a proxy through which all the requests must pass to succeed
  */
-class HttpProtocolConfigurationBuilder(baseUrl: Option[() => String],
+class HttpProtocolConfigurationBuilder(baseUrls: Option[Seq[String]],
 	proxy: Option[ProxyServer], securedProxy: Option[ProxyServer],
 	followRedirectParam: Boolean, automaticRefererParam: Boolean,
 	baseHeaders: Map[String, String],
 	warmUpUrl: Option[String],
 	extraRequestInfoExtractor: Option[(Request => List[String])],
 	extraResponseInfoExtractor: Option[(Response => List[String])])
-		extends Logging {
-
-  val rand = new Random()
+	extends Logging {
 
 	/**
 	 * Sets the baseURL of the future HttpProtocolConfiguration
 	 *
 	 * @param baseUrl the base url that will be set
 	 */
-	def baseURL(baseUrl: String) = new HttpProtocolConfigurationBuilder(Some(() => baseUrl), proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def baseURL(baseUrl: String) = new HttpProtocolConfigurationBuilder(Some(List(baseUrl)), proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-  def baseURLs(baseUrls: Array[String]) = new HttpProtocolConfigurationBuilder(Some(() => {baseUrls(rand.nextInt(baseUrls.length))}), proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def baseURLs(baseUrls: Seq[String]) = new HttpProtocolConfigurationBuilder(Some(baseUrls), proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def disableFollowRedirect = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, false, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def disableFollowRedirect = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, false, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def disableAutomaticReferer = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, false, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def disableAutomaticReferer = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, false, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def acceptHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptCharsetHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_CHARSET -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def acceptCharsetHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_CHARSET -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptEncodingHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_ENCODING -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def acceptEncodingHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_ENCODING -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def acceptLanguageHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_LANGUAGE -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def acceptLanguageHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.ACCEPT_LANGUAGE -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def hostHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.HOST -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def hostHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.HOST -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def userAgentHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.USER_AGENT -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def userAgentHeader(value: String) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders + (Headers.Names.USER_AGENT -> value), warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def warmUp(warmUpUrl: String) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, Some(warmUpUrl), extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def warmUp(warmUpUrl: String) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, Some(warmUpUrl), extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def disableWarmUp = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, None, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	def disableWarmUp = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, None, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
-	def requestInfoExtractor(value: (Request => List[String])) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, Some(value), extraResponseInfoExtractor)
+	def requestInfoExtractor(value: (Request => List[String])) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, Some(value), extraResponseInfoExtractor)
 
-	def responseInfoExtractor(value: (Response) => List[String]) = new HttpProtocolConfigurationBuilder(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, Some(value))
+	def responseInfoExtractor(value: (Response) => List[String]) = new HttpProtocolConfigurationBuilder(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, Some(value))
 
 	/**
 	 * Sets the proxy of the future HttpProtocolConfiguration
@@ -89,7 +86,7 @@ class HttpProtocolConfigurationBuilder(baseUrl: Option[() => String],
 	 */
 	def proxy(host: String, port: Int) = new HttpProxyBuilder(this, host, port)
 
-	private[http] def addProxies(httpProxy: ProxyServer, httpsProxy: Option[ProxyServer]) = new HttpProtocolConfigurationBuilder(baseUrl, Some(httpProxy), httpsProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
+	private[http] def addProxies(httpProxy: ProxyServer, httpsProxy: Option[ProxyServer]) = new HttpProtocolConfigurationBuilder(baseUrls, Some(httpProxy), httpsProxy, followRedirectParam, automaticRefererParam, baseHeaders, warmUpUrl, extraRequestInfoExtractor, extraResponseInfoExtractor)
 
 	private[http] def build = {
 		warmUpUrl.map { url =>
@@ -105,6 +102,6 @@ class HttpProtocolConfigurationBuilder(baseUrl: Option[() => String],
 			}
 		}
 
-		HttpProtocolConfiguration(baseUrl, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, extraRequestInfoExtractor, extraResponseInfoExtractor)
+		HttpProtocolConfiguration(baseUrls, proxy, securedProxy, followRedirectParam, automaticRefererParam, baseHeaders, extraRequestInfoExtractor, extraResponseInfoExtractor)
 	}
 }

--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/request/builder/AbstractHttpRequestBuilder.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/request/builder/AbstractHttpRequestBuilder.scala
@@ -191,7 +191,7 @@ abstract class AbstractHttpRequestBuilder[B <: AbstractHttpRequestBuilder[B]](
 		val resolvedUrl = if (providedUrl.startsWith(Protocol.HTTP.getProtocol))
 			providedUrl
 		else protocolConfiguration match {
-			case Some(config) => config.baseURL.getOrElse(throw new IllegalArgumentException("No protocolConfiguration.baseURL defined but provided url is relative : " + providedUrl))() + providedUrl
+			case Some(config) => config.baseURL.getOrElse(throw new IllegalArgumentException("No protocolConfiguration.baseURL defined but provided url is relative : " + providedUrl)) + providedUrl
 			case None => throw new IllegalArgumentException("No protocolConfiguration defined but provided url is relative : " + providedUrl)
 		}
 

--- a/gatling-http/src/test/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilderSpec.scala
+++ b/gatling-http/src/test/scala/com/excilys/ebi/gatling/http/config/HttpProtocolConfigurationBuilderSpec.scala
@@ -16,36 +16,63 @@
 package com.excilys.ebi.gatling.http.config
 
 import org.specs2.mutable.Specification
-import com.ning.http.client.{Response, Request}
+import com.ning.http.client.{ Response, Request }
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class HttpProtocolConfigurationBuilderSpec extends Specification {
 
-  "http protocol configuration builder" should {
-    "support an optional extra request info extractor" in {
+	"http protocol configuration builder" should {
+		"support an optional extra request info extractor" in {
 
-      val expectedExtractor: (Request => List[String]) = (Request) => Nil
+			val expectedExtractor: (Request => List[String]) = (Request) => Nil
 
-      val builder = HttpProtocolConfigurationBuilder.httpConfig
-        .disableWarmUp
-        .requestInfoExtractor(expectedExtractor)
-      val config: HttpProtocolConfiguration = builder.build
+			val builder = HttpProtocolConfigurationBuilder.httpConfig
+				.disableWarmUp
+				.requestInfoExtractor(expectedExtractor)
+			val config: HttpProtocolConfiguration = builder.build
 
-      config.extraRequestInfoExtractor.get should beEqualTo(expectedExtractor)
-    }
+			config.extraRequestInfoExtractor.get should beEqualTo(expectedExtractor)
+		}
 
-    "support an optional extra response info extractor" in {
+		"support an optional extra response info extractor" in {
 
-      val expectedExtractor: (Response => List[String]) = (Response) => Nil
+			val expectedExtractor: (Response => List[String]) = (Response) => Nil
 
-      val builder = HttpProtocolConfigurationBuilder.httpConfig
-        .disableWarmUp
-        .responseInfoExtractor(expectedExtractor)
-      val config: HttpProtocolConfiguration = builder.build
+			val builder = HttpProtocolConfigurationBuilder.httpConfig
+				.disableWarmUp
+				.responseInfoExtractor(expectedExtractor)
+			val config: HttpProtocolConfiguration = builder.build
 
-      config.extraResponseInfoExtractor.get should beEqualTo(expectedExtractor)
-    }
-  }
+			config.extraResponseInfoExtractor.get should beEqualTo(expectedExtractor)
+		}
+
+		
+		"be able to support a base URL" in {
+			val url = "http://url"
+
+			val builder = HttpProtocolConfigurationBuilder
+				.httpConfig.baseURL(url)
+				.disableWarmUp
+
+			val config: HttpProtocolConfiguration = builder.build
+
+			Seq(config.baseURL.get, config.baseURL.get, config.baseURL.get) must be equalTo (Seq(url, url, url))
+		}
+		
+		"provide a Round-Robin strategy when multiple urls are provided" in {
+			val url1 = "http://url1"
+			val url2 = "http://url2"
+
+			val builder = HttpProtocolConfigurationBuilder
+				.httpConfig.baseURLs(List(url1, url2))
+				.disableWarmUp
+
+			val config: HttpProtocolConfiguration = builder.build
+
+			Seq(config.baseURL.get, config.baseURL.get, config.baseURL.get) must be equalTo (Seq(url1, url2, url1))
+		}
+
+	}
 }


### PR DESCRIPTION
Hi,

Here is my proposition to improve #607.

A load-balancer will more likely use a Round-Robin strategy for dispatching the requests ...

cheers,
Nicolas
