### PR TITLE
Don't encode the url twice when following a redirect

### DIFF
--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/ahc/GatlingAsyncHandlerActor.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/ahc/GatlingAsyncHandlerActor.scala
@@ -161,9 +161,8 @@ class GatlingAsyncHandlerActor(var session: Session, checks: List[HttpCheck[_]],
 
 			logRequest(OK, response)
 
-			val encodedRedirectUrl = computeRedirectUrl(response.getHeader(HeaderNames.LOCATION), request.getUrl)
-			val redirectUrl = if (HttpConfig.GATLING_HTTP_CONFIG_USE_RAW_URL) encodedRedirectUrl else URLDecoder.decode(encodedRedirectUrl, configuration.encoding)
-
+			val redirectUrl = computeRedirectUrl(response.getHeader(HeaderNames.LOCATION), request.getUrl)
+	
 			val requestBuilder = new RequestBuilder(request)
 				.setMethod("GET")
 				.setBodyEncoding(configuration.encoding)

--- a/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/request/builder/AbstractHttpRequestBuilder.scala
+++ b/gatling-http/src/main/scala/com/excilys/ebi/gatling/http/request/builder/AbstractHttpRequestBuilder.scala
@@ -22,7 +22,7 @@ import com.excilys.ebi.gatling.core.util.StringHelper.{ parseEvaluatable, EL_STA
 import com.excilys.ebi.gatling.http.Headers.{ Values => HeaderValues, Names => HeaderNames }
 import com.excilys.ebi.gatling.http.action.HttpRequestActionBuilder
 import com.excilys.ebi.gatling.http.check.HttpCheck
-import com.excilys.ebi.gatling.http.config.HttpProtocolConfiguration
+import com.excilys.ebi.gatling.http.config.{ HttpConfig, HttpProtocolConfiguration }
 import com.excilys.ebi.gatling.http.cookie.CookieHandling
 import com.excilys.ebi.gatling.http.referer.RefererHandling
 import com.ning.http.client.{ FluentStringsMap, FluentCaseInsensitiveStringsMap, RequestBuilder, Request, Realm }
@@ -54,13 +54,13 @@ object AbstractHttpRequestBuilder {
  * @param checks is a list of checks to execute on the response
  */
 abstract class AbstractHttpRequestBuilder[B <: AbstractHttpRequestBuilder[B]](
-		requestName: String,
-		method: String,
-		url: EvaluatableString,
-		queryParams: List[HttpParam],
-		headers: Map[String, EvaluatableString],
-		realm: Option[Session => Realm],
-		checks: List[HttpCheck[_]]) {
+	requestName: String,
+	method: String,
+	url: EvaluatableString,
+	queryParams: List[HttpParam],
+	headers: Map[String, EvaluatableString],
+	realm: Option[Session => Realm],
+	checks: List[HttpCheck[_]]) {
 
 	/**
 	 * Method overridden in children to create a new instance of the correct type
@@ -145,7 +145,7 @@ abstract class AbstractHttpRequestBuilder[B <: AbstractHttpRequestBuilder[B]](
 	 * @param session the session of the current scenario
 	 */
 	protected def getAHCRequestBuilder(session: Session, protocolConfiguration: Option[HttpProtocolConfiguration]): RequestBuilder = {
-		val requestBuilder = new RequestBuilder(method, true).setBodyEncoding(configuration.encoding)
+		val requestBuilder = new RequestBuilder(method, HttpConfig.GATLING_HTTP_CONFIG_USE_RAW_URL).setBodyEncoding(configuration.encoding)
 
 		val isHttps = configureURLAndCookies(requestBuilder, session, protocolConfiguration)
 		configureProxy(requestBuilder, session, isHttps, protocolConfiguration)


### PR DESCRIPTION
If a run a simulation where I have http.rawUrl=false and followRedirect=true, when I get this reponse from the server

```
Response DefaultHttpResponse(chunked: false)
HTTP/1.0 302 Found
Location: http://access.secutix.com/wrcontroller1/selectqueue.do?queue=q-LDT&source=https%3a%2f%2fone.secutix.com%2ftnsa10%2flive%2fshop%2fLDT%2fINTERNET%2fts%2fevent%2findex.php
Cache-Control: no-cache
Pragma: no-cache
Expires: Mon, 26 Jul 1997 05:00:00 GMT
Retry-After: 1
Server: BigIP
Connection: Keep-Alive
Content-Length: 0
```

Galting is then sending the following request :

```
11:30:53.748 [DEBUG] c.n.h.c.p.n.NettyConnectionsPool - Adding uri: https://one.secutix.com:443 for channel [id: 0x4fbc79fa, /10.10.176.49:43533 => one.secutix.com/193.73.238.153:443]
11:30:53.813 [DEBUG] c.n.h.c.p.n.NettyAsyncHttpProvider - 
Non cached request 
DefaultHttpRequest(chunked: false)
GET /wrcontroller1/selectqueue.do?queue=q-LDT&source=https%253a%252f%252fone.secutix.com%252ftnsa10%252flive%252fshop%252fLDT%252fINTERNET%252fts%252fevent%252findex.php HTTP/1.1
Host: access.secutix.com
Accept: image/png,image/*;q=0.8,*/*;q=0.5
Accept-Language: en-us,en;q=0.5
Accept-Encoding: gzip
Connection: keep-alive
User-Agent: NING/1.0
```

The URL is encoded twice ... 
