### PR TITLE
Sort the simulation names

### DIFF
--- a/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/Gatling.scala
@@ -78,6 +78,7 @@ class Gatling extends Logging {
 						SimulationClassLoader.fromClasspathBinariesDirectory(_))
 					.getOrElse(SimulationClassLoader.fromSourcesDirectory(GatlingFiles.sourcesDirectory))
 					.simulationClasses(configuration.simulation.classes)
+					.sortWith(_.getName < _.getName)
 
 				val selection = configuration.simulation.classes match {
 					case Nil => interactiveSelect(simulations)
@@ -112,7 +113,7 @@ class Gatling extends Logging {
 	}
 
 	private def selectSimulationClass(simulations: List[Class[Simulation]]): Class[Simulation] = {
-
+	
 		val selection = simulations.size match {
 			case 0 =>
 				// If there is no simulation file
@@ -124,8 +125,8 @@ class Gatling extends Logging {
 				0
 			case size =>
 				println("Choose a simulation number:")
-				for (i <- 0 until size) {
-					println("     [" + i + "] " + simulations(i).getName)
+				for ((simulation, index) <- simulations.zipWithIndex) {
+					println("     [" + index + "] " + simulation.getName)
 				}
 				Console.readInt
 		}


### PR DESCRIPTION
The suggested values aren't ordered ... a bit annoying to find the one you want

```
[] nire@~/Dropbox/gatling-charts-highcharts-1.3.0-SNAPSHOT/bin: ./gatling.sh 
GATLING_HOME is set to /home/nre/Dropbox/gatling-charts-highcharts-1.3.0-SNAPSHOT
Choose a simulation number:
     [0] computerdatabase.MarkovSimulation
     [1] computerdatabase.FeederSimulation
     [2] computerdatabase.BasicSimulation
     [3] computerdatabase.CustomScalaSimulation
     [4] computerdatabase.LoopSimulation
```
