### PR TITLE
Recorded simulation compiles now

### DIFF
--- a/gatling-recorder/src/main/resources/templates/pause.ssp
+++ b/gatling-recorder/src/main/resources/templates/pause.ssp
@@ -1,3 +1,3 @@
 <%@ val duration: String %>
 <%@ val inMilliseconds: Boolean %>
-pause(<%= duration %><% if(inMilliseconds){%> milliseconds<%}%>)
+			.pause(<%= duration %><% if(inMilliseconds){%> milliseconds<%}%>)

--- a/gatling-recorder/src/main/resources/templates/request.ssp
+++ b/gatling-recorder/src/main/resources/templates/request.ssp
@@ -7,7 +7,7 @@
 <%@ val id: Int %>
 <%@ val credentials: Option[(String,String)] %>
 <%@ val simulationClass: String %>
-exec(http("request_<%= id %>")
+			.exec(http("request_<%= id %>")
 					.<%= method.toLowerCase %>("<%= printedUrl %>")
 <% headersId.map { headersId => %>
 					.headers(headers_<%= headersId %>)

--- a/gatling-recorder/src/main/scala/com/excilys/ebi/gatling/recorder/config/Configuration.scala
+++ b/gatling-recorder/src/main/scala/com/excilys/ebi/gatling/recorder/config/Configuration.scala
@@ -35,7 +35,7 @@ import grizzled.slf4j.Logging
 object Configuration extends Logging {
 
 	GatlingConfiguration.setUp(new JHashMap)
-	val DEFAULT_CLASS_NAME = "Simulation"
+	val DEFAULT_CLASS_NAME = "RecordedSimulation"
 
 	private val XSTREAM = {
 		val xstream = new XStream(new DomDriver)

--- a/gatling-recorder/src/main/scala/com/excilys/ebi/gatling/recorder/scenario/ProtocolConfigElement.scala
+++ b/gatling-recorder/src/main/scala/com/excilys/ebi/gatling/recorder/scenario/ProtocolConfigElement.scala
@@ -50,14 +50,15 @@ class ProtocolConfigElement(baseUrl: String, proxy: ProxyConfig, followRedirect:
 		if (!automaticReferer)
 			sb.append(".disableAutomaticReferer").append(END_OF_LINE)
 
+		val indent = "\t\t\t"
 		baseHeaders.foreach {
 			case (headerName, headerValue) => headerName match {
-				case Headers.Names.ACCEPT => sb.append(""".acceptHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
-				case Headers.Names.ACCEPT_CHARSET => sb.append(""".acceptCharsetHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
-				case Headers.Names.ACCEPT_ENCODING => sb.append(""".acceptEncodingHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
-				case Headers.Names.ACCEPT_LANGUAGE => sb.append(""".acceptLanguageHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
-				case Headers.Names.HOST => sb.append(""".hostHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
-				case Headers.Names.USER_AGENT => sb.append(""".userAgentHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
+				case Headers.Names.ACCEPT => sb.append(indent).append(""".acceptHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
+				case Headers.Names.ACCEPT_CHARSET => sb.append(indent).append(""".acceptCharsetHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
+				case Headers.Names.ACCEPT_ENCODING => sb.append(indent).append(""".acceptEncodingHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
+				case Headers.Names.ACCEPT_LANGUAGE => sb.append(indent).append(""".acceptLanguageHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
+				case Headers.Names.HOST => sb.append(indent).append(""".hostHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
+				case Headers.Names.USER_AGENT => sb.append(indent).append(""".userAgentHeader("""").append(headerValue).append("""")""").append(END_OF_LINE)
 				case name => warn("Base header not supported " + name)
 			}
 		}


### PR DESCRIPTION
Here is the list of issues I've been able to spot. 

``` scala
import com.excilys.ebi.gatling.core.Predef._
import com.excilys.ebi.gatling.http.Predef._
import com.excilys.ebi.gatling.jdbc.Predef._
import com.excilys.ebi.gatling.http.Headers.Names._
import akka.util.duration._


//1 NICOLAS : "Simulation extends Simulation", should change the name
class Simulation extends Simulation {

    def apply = {

//2 NICOLAS : Indentation
        val httpConf = httpConfig
            .baseURL("http://computer-database.herokuapp.com")
.acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
.acceptLanguageHeader("en-us,en;q=0.5")
.acceptEncodingHeader("gzip, deflate")
.userAgentHeader("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1")
.hostHeader("computer-database.herokuapp.com")


        val headers_1 = Map(
            "DNT" -> """1"""
        )

        val headers_2 = Map(
            "Accept" -> """text/css,*/*;q=0.1""",
            "DNT" -> """1""",
            "If-None-Match" -> """5950e709b2179481c46b5ef1ee109981527a6c20"""
        )

        val headers_3 = Map(
            "Accept" -> """text/css,*/*;q=0.1""",
            "DNT" -> """1""",
            "If-None-Match" -> """bc426f69bd6f005692e053b5d5104dd54771deb9"""
        )


        val scn = scenario("Scenario Name")
//3 NICOLAS : Indentation and missing "."
exec(http("request_1")
                    .get("/")
                    .headers(headers_1)
            )
//4 NICOLAS : Indentation and missing "."
pause(684 milliseconds)
exec(http("request_2")
                    .get("/assets/stylesheets/bootstrap.min.css")
                    .headers(headers_2)
                    .check(status.is(304))
            )
pause(715 milliseconds)
exec(http("request_3")
                    .get("/assets/stylesheets/main.css")
                    .headers(headers_3)
                    .check(status.is(304))
            )
exec(http("request_4")
                    .get("/computers/381")
                    .headers(headers_1)
            )

        List(scn.configure.users(1).protocolConfig(httpConf))
    }
}
```
