### PR TITLE
Pass percentiles and range bounds as parameters in FileDataReader's constructor, bring back all FileDataReaderSpec's tests

### DIFF
--- a/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/report/StatsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/report/StatsReportGenerator.scala
@@ -20,7 +20,6 @@ import scala.collection.immutable.ListMap
 import com.excilys.ebi.gatling.charts.component.{ ComponentLibrary, RequestStatistics, Statistics }
 import com.excilys.ebi.gatling.charts.config.ChartsFiles.{ GLOBAL_PAGE_NAME, jsStatsFile, tsvStatsFile,jsonStatsFile }
 import com.excilys.ebi.gatling.charts.template.{StatsJsonTemplate, StatsJsTemplate, StatsTsvTemplate}
-import com.excilys.ebi.gatling.core.config.GatlingConfiguration.configuration
 import com.excilys.ebi.gatling.core.result.message.RequestStatus.{KO, OK}
 import com.excilys.ebi.gatling.core.result.reader.DataReader
 
@@ -28,9 +27,6 @@ class StatsReportGenerator(runOn: String, dataReader: DataReader, componentLibra
 
 	def generate: Map[String, RequestStatistics] = {
 		val criteria: List[(String, Option[String])] = (GLOBAL_PAGE_NAME, None) :: dataReader.requestNames.map(name => (name, Some(name))).toList
-
-		val percent1 = configuration.charting.indicators.percentile1 / 100.0
-		val percent2 = configuration.charting.indicators.percentile2 / 100.0
 
 		val stats: ListMap[String, RequestStatistics] = criteria.map {
 			case (name, requestName) =>
@@ -49,7 +45,7 @@ class StatsReportGenerator(runOn: String, dataReader: DataReader, componentLibra
 				val meanNumberOfRequestsPerSecondStatistics = Statistics("meanNumberOfRequestsPerSecond", total.meanRequestsPerSec, ok.meanRequestsPerSec, ko.meanRequestsPerSec)
 
 				val groupedCounts = dataReader
-					.numberOfRequestInResponseTimeRange(configuration.charting.indicators.lowerBound, configuration.charting.indicators.higherBound, requestName)
+					.numberOfRequestInResponseTimeRange(requestName)
 					.map {
 					case (name, count) => (name, count, count * 100 / total.count)
 				}

--- a/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/result/reader/ResultsHolder.scala
+++ b/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/result/reader/ResultsHolder.scala
@@ -15,12 +15,6 @@
  */
 package com.excilys.ebi.gatling.charts.result.reader
 
-import java.util.{ HashMap => JHashMap }
-import com.excilys.ebi.gatling.charts.result.reader.stats.StatsHelper
-import com.excilys.ebi.gatling.core.result.message.RequestStatus
-import com.excilys.ebi.gatling.core.result.reader.GeneralStats
-import scala.collection.JavaConversions._
-import scala.collection.mutable
 import com.excilys.ebi.gatling.charts.result.reader.buffers.RequestsPerSecBuffers
 import com.excilys.ebi.gatling.charts.result.reader.buffers.TransactionsPerSecBuffers
 import com.excilys.ebi.gatling.charts.result.reader.buffers.ResponseTimePerSecBuffers
@@ -32,8 +26,8 @@ import com.excilys.ebi.gatling.charts.result.reader.buffers.NamesBuffers
 import com.excilys.ebi.gatling.core.action.EndAction
 import com.excilys.ebi.gatling.core.action.StartAction
 
-class ResultsHolder(minTime: Long, maxTime: Long)
-	extends GeneralStatsBuffers(maxTime - minTime)
+class ResultsHolder(minTime: Long, maxTime: Long,percentile1: Int,percentile2: Int,lowerBound: Int,higherBound: Int)
+	extends GeneralStatsBuffers(maxTime - minTime,percentile1,percentile2)
 	with LatencyPerSecBuffers
 	with NamesBuffers
 	with RequestsPerSecBuffers
@@ -55,7 +49,7 @@ class ResultsHolder(minTime: Long, maxTime: Long)
 				updateLatencyPerSecBuffers(record)
 				addNames(record)
 				updateGeneralStatsBuffers(record)
-				updateResponseTimeRangeBuffer(record)
+				updateResponseTimeRangeBuffer(record,lowerBound,higherBound)
 		}
 	}
 }

--- a/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/result/reader/buffers/GeneralStatsBuffers.scala
+++ b/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/result/reader/buffers/GeneralStatsBuffers.scala
@@ -23,10 +23,9 @@ import scala.collection.JavaConversions.mapAsScalaMap
 
 import com.excilys.ebi.gatling.charts.result.reader.FileDataReader
 import com.excilys.ebi.gatling.charts.result.reader.stats.{ PercentilesHelper, StatsHelper }
-import com.excilys.ebi.gatling.core.config.GatlingConfiguration.configuration
 import com.excilys.ebi.gatling.core.result.reader.GeneralStats
 
-abstract class GeneralStatsBuffers(durationInSec: Long) extends Buffers {
+abstract class GeneralStatsBuffers(durationInSec: Long,percentile1: Int,percentile2: Int) extends Buffers {
 
 	val generalStatsBuffers = new JHashMap[BufferKey, GeneralStatsBuffer]
 
@@ -72,7 +71,7 @@ abstract class GeneralStatsBuffers(durationInSec: Long) extends Buffers {
 
 					val sortedTimes = map.toList.sorted
 
-					val percentiles = PercentilesHelper.processPercentiles(sortedTimes, count, Seq(configuration.charting.indicators.percentile1 / 100.0, configuration.charting.indicators.percentile2 / 100.0))
+					val percentiles = PercentilesHelper.processPercentiles(sortedTimes, count, Seq(percentile1 / 100.0, percentile2 / 100.0))
 
 					GeneralStats(min, max, count, meanResponseTime, stdDev, percentiles(0), percentiles(1), meanRequestsPerSec)
 				}

--- a/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/result/reader/buffers/ResponseTimeRangeBuffers.scala
+++ b/gatling-charts/src/main/scala/com/excilys/ebi/gatling/charts/result/reader/buffers/ResponseTimeRangeBuffers.scala
@@ -25,26 +25,25 @@ trait ResponseTimeRangeBuffers extends Buffers {
 
 	def getResponseTimeRangeBuffers(requestName: Option[String]): ResponseTimeRangeBuffer = getBuffer(computeKey(requestName, None), responseTimeRangeBuffers, () => new ResponseTimeRangeBuffer)
 
-	def updateResponseTimeRangeBuffer(record: ActionRecord) {
-		getResponseTimeRangeBuffers(None).update(record)
-		getResponseTimeRangeBuffers(Some(record.request)).update(record)
+	def updateResponseTimeRangeBuffer(record: ActionRecord,lowerBound: Int,higherBound: Int) {
+		getResponseTimeRangeBuffers(None).update(record,lowerBound,higherBound)
+		getResponseTimeRangeBuffers(Some(record.request)).update(record,lowerBound,higherBound)
 	}
 
 	class ResponseTimeRangeBuffer {
 
 		import com.excilys.ebi.gatling.core.result.message.RequestStatus
-		import com.excilys.ebi.gatling.core.config.GatlingConfiguration.configuration
 
 		var low = 0
 		var middle = 0
 		var high = 0
 		var ko = 0
 
-		def update(record: ActionRecord) {
+		def update(record: ActionRecord,lowerBound: Int,higherBound: Int) {
 
 			if (record.status == RequestStatus.KO) ko += 1
-			else if (record.responseTime < configuration.charting.indicators.lowerBound) low += 1
-			else if (record.responseTime > configuration.charting.indicators.higherBound) high += 1
+			else if (record.responseTime < lowerBound) low += 1
+			else if (record.responseTime > higherBound) high += 1
 			else middle += 1
 		}
 	}

--- a/gatling-charts/src/test/scala/com/excilys/ebi/gatling/charts/result/reader/FileDataReaderSpec.scala
+++ b/gatling-charts/src/test/scala/com/excilys/ebi/gatling/charts/result/reader/FileDataReaderSpec.scala
@@ -81,44 +81,48 @@ class FileDataReaderSpec extends Specification {
 		}
 	}
 
-//	"When reading a single log file with known statistics, FileDataReder" should {
-//		val singleFileDataReader = new FileDataReader("run_single_node_with_known_stats")
-//
-//		"return expected minResponseTime for correct request data" in {
-//			singleFileDataReader.minResponseTime(None, None) must beEqualTo(2000L)
-//		}
-//
-//		"return expected maxResponseTime for correct request data" in {
-//			singleFileDataReader.maxResponseTime(None, None) must beEqualTo(9000L)
-//		}
-//
-//		"return expected responseTimeStandardDeviation for correct request data" in {
-//			singleFileDataReader.responseTimeStandardDeviation(None, None) must beEqualTo(2000L)
-//		}
-//
-//		"return expected responseTimePercentile for the (0, 0.7) percentiles" in {
-//			singleFileDataReader.percentiles(0, 0.7, None, None) must beEqualTo((2000L, 5000L))
-//		}
-//
-//		"return expected result for the (99.99, 100) percentiles" in {
-//			singleFileDataReader.percentiles(0.9999, 1, None, None) must beEqualTo(9000L, 9000L)
-//		}
-//
-//		"indicate that all the request have their response time in between 0 and 100000" in {
-//			singleFileDataReader.numberOfRequestInResponseTimeRange(0, 100000, None).map(_._2) must beEqualTo(List(0L, 8L, 0L, 0L))
-//		}
-//
-//		val nRequestInResponseTimeRange = singleFileDataReader.numberOfRequestInResponseTimeRange(2500, 5000, None).map(_._2)
-//
-//		"indicate that 1 request had a response time below 2500ms" in {
-//			nRequestInResponseTimeRange(0) must beEqualTo(1L)
-//		}
-//		"indicate that 5 request had a response time in between 2500ms and 5000ms" in {
-//			nRequestInResponseTimeRange(1) must beEqualTo(5L)
-//		}
-//
-//		"indicate that 2 request had a response time above 5000ms" in {
-//			nRequestInResponseTimeRange(2) must beEqualTo(2L)
-//		}
-//	}
+	"When reading a single log file with known statistics, FileDataReder" should {
+		val singleFileDataReader = new FileDataReader("run_single_node_with_known_stats")
+
+		"return expected minResponseTime for correct request data" in {
+			singleFileDataReader.generalStats().min must beEqualTo(2000L)
+		}
+
+		"return expected maxResponseTime for correct request data" in {
+			singleFileDataReader.generalStats().max must beEqualTo(9000L)
+		}
+
+		"return expected responseTimeStandardDeviation for correct request data" in {
+			singleFileDataReader.generalStats().stdDev must beEqualTo(2000L)
+		}
+
+		"return expected responseTimePercentile for the (0, 0.7) percentiles" in {
+			val lowPercentilesFileDataReader = new FileDataReader("run_single_node_with_known_stats",percentile1 = 0,percentile2 = 70)
+			lowPercentilesFileDataReader.generalStats().percentile1 must beEqualTo(2000L)
+			lowPercentilesFileDataReader.generalStats().percentile2 must beEqualTo(5000L)
+		}
+
+		"return expected result for the (99.99, 100) percentiles" in {
+			val highPercentilesFileDataReader = new FileDataReader("run_single_node_with_known_stats",percentile1 = 99,percentile2 = 100)
+			highPercentilesFileDataReader.generalStats().percentile1 must beEqualTo(9000L)
+			highPercentilesFileDataReader.generalStats().percentile2 must beEqualTo(9000L)
+		}
+
+		"indicate that all the request have their response time in between 0 and 100000" in {
+			new FileDataReader("run_single_node_with_known_stats",lowerBound = 0,higherBound = 100000).numberOfRequestInResponseTimeRange(None).map(_._2) must beEqualTo(List(0L, 8L, 0L, 0L))
+		}
+
+		val nRequestInResponseTimeRange = new FileDataReader("run_single_node_with_known_stats",lowerBound = 2500,higherBound = 5000).numberOfRequestInResponseTimeRange(None).map(_._2)
+
+		"indicate that 1 request had a response time below 2500ms" in {
+			nRequestInResponseTimeRange(0) must beEqualTo(1L)
+		}
+		"indicate that 5 request had a response time in between 2500ms and 5000ms" in {
+			nRequestInResponseTimeRange(1) must beEqualTo(5L)
+		}
+
+		"indicate that 2 request had a response time above 5000ms" in {
+			nRequestInResponseTimeRange(2) must beEqualTo(2L)
+		}
+	}
 }

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/reader/DataReader.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/result/reader/DataReader.scala
@@ -15,6 +15,8 @@
  */
 package com.excilys.ebi.gatling.core.result.reader
 
+import java.lang
+
 import com.excilys.ebi.gatling.core.config.GatlingConfiguration.configuration
 import com.excilys.ebi.gatling.core.result.message.{ RequestStatus, RunRecord }
 import com.excilys.ebi.gatling.core.result.message.RequestStatus.RequestStatus
@@ -22,7 +24,9 @@ import com.excilys.ebi.gatling.core.result.message.RequestStatus.RequestStatus
 object DataReader {
 	val NO_PLOT_MAGIC_VALUE = -1L
 
-	def newInstance(runOn: String) = Class.forName(configuration.data.dataReaderClass).asInstanceOf[Class[DataReader]].getConstructor(classOf[String]).newInstance(runOn)
+	def newInstance(runOn: String) = Class.forName(configuration.data.dataReaderClass).asInstanceOf[Class[DataReader]]
+		.getConstructor(classOf[String],classOf[Int],classOf[Int],classOf[Int],classOf[Int])
+		.newInstance(runOn,configuration.charting.indicators.lowerBound: lang.Integer,configuration.charting.indicators.higherBound : lang.Integer,configuration.charting.indicators.percentile1 : lang.Integer,configuration.charting.indicators.percentile2 : lang.Integer)
 }
 
 abstract class DataReader(runUuid: String) {
@@ -43,7 +47,7 @@ abstract class DataReader(runUuid: String) {
 
 	def generalStats(status: Option[RequestStatus] = None, requestName: Option[String] = None): GeneralStats
 
-	def numberOfRequestInResponseTimeRange(lowerBound: Int, higherBound: Int, requestName: Option[String] = None): Seq[(String, Long)]
+	def numberOfRequestInResponseTimeRange(requestName: Option[String] = None): Seq[(String, Long)]
 
 	def responseTimeGroupByExecutionStartDate(status: RequestStatus, requestName: String): Seq[(Long, (Long, Long))]
 


### PR DESCRIPTION
I know it can look messy at first sight, but with the current architecture :
- To bring back the tests, percentiles and range bounds values must not be "hardcoded" to configuration file's values, we need to pass them as a parameter "somewhere" 
- The only way to pass percentiles and range bounds to all functions that needs them is to pass them to ResultsHolder
- The only way to pass new parameters to ResultsHolder is to pass new parameters to FileDataReader's constructor.
  - Doing so, I had to change the FileDataReader's dynamic instantiation (using reflection), as Java knows little of Scala's default method parameters...

It's the only solution I could come up with, the other solution would be to refactor, maybe quite heavily, the newly rewritten FileDataReader.  
