### PR TITLE
Exclude jaxen's dependencies on maven 1 static analysis plugins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,16 @@
 				<groupId>jaxen</groupId>
 				<artifactId>jaxen</artifactId>
 				<version>${jaxen.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>maven-plugins</groupId>
+						<artifactId>maven-cobertura-plugin</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>maven-plugins</groupId>
+						<artifactId>maven-findbugs-plugin</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>xerces</groupId>


### PR DESCRIPTION
This prevents two classes of related errors:
- failure to build gatling itself
- failure to use gatling-maven-plugin 1.4.x for testing your own project, e.g. https://github.com/skuenzli/simplyreliable

The error from maven looks something like:

> [ERROR] Failed to execute goal on project gatling-core: Could not resolve dependencies for project com.excilys.ebi.gatling:gatling-core:jar:1.4.0-SNAPSHOT: The following artifacts could not be resolved: maven-plugins:maven-cobertura-plugin:plugin:1.3, maven-plugins:maven-findbugs-plugin:plugin:1.3.1: Failure to find maven-plugins:maven-cobertura-plugin:plugin:1.3 in http://repository.excilys.com/content/groups/public was cached in the local repository, resolution will not be reattempted until the update interval of excilys has elapsed or updates are forced -> [Help 1]

Additional details are on the mailing list at https://groups.google.com/forum/?fromgroups=#!topic/gatling-development/RIyA0eUKBi4

I noticed messages in the 1.4.x changelog indicating that the maven plugin no longer executes via ant.  Perhaps execution via ant was masking this issue in earlier versions of gatling.
