### PR TITLE
Remove Maven plugin's last dependency to Ant, DirectoryScanner

### DIFF
--- a/gatling-maven-plugin/pom.xml
+++ b/gatling-maven-plugin/pom.xml
@@ -88,12 +88,6 @@
 			<artifactId>commons-exec</artifactId>
 		</dependency>
 
-		<!-- Ant Dependencies -->
-		<dependency>
-			<groupId>org.apache.ant</groupId>
-			<artifactId>ant</artifactId>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
+++ b/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingMojo.java
@@ -31,7 +31,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
-import org.apache.tools.ant.DirectoryScanner;
+import org.codehaus.plexus.util.DirectoryScanner;
 
 import scala_maven_executions.JavaMainCallerByFork;
 import scala_maven_executions.MainHelper;

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
 		<joda-convert.version>1.2</joda-convert.version>
 		<xstream.version>1.4.3</xstream.version>
 		<scopt.version>2.1.0</scopt.version>
-		<ant.version>1.8.3</ant.version>
 		<grizzled-slf4j.version>1.0.1</grizzled-slf4j.version>
 		<jackson.version>2.1.2</jackson.version>
 		<commons-math3.version>3.0</commons-math3.version>
@@ -317,11 +316,6 @@
 				<groupId>com.github.scopt</groupId>
 				<artifactId>scopt_2.10</artifactId>
 				<version>${scopt.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.ant</groupId>
-				<artifactId>ant</artifactId>
-				<version>${ant.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.clapper</groupId>


### PR DESCRIPTION
Plexus Utils provides its own version of DirectoryScanner, with same functionality.
