### PR TITLE
Enable overriding of graphite root path prefix

### DIFF
--- a/gatling-metrics/src/main/scala/com/excilys/ebi/gatling/metrics/GraphiteDataWriter.scala
+++ b/gatling-metrics/src/main/scala/com/excilys/ebi/gatling/metrics/GraphiteDataWriter.scala
@@ -52,13 +52,15 @@ class GraphiteDataWriter extends DataWriter {
 	}
 
 	def onInitializeDataWriter(runRecord: RunRecord, scenarios: Seq[ShortScenarioDescription]) {
-		metricRootPath = List("gatling", runRecord.simulationId)
+		metricRootPath = List(getRootPathPrefix(), runRecord.simulationId)
 		allUsers = new UserMetric(scenarios.map(_.nbUsers).sum)
 		scenarios.foreach(scenario => usersPerScenario.+=((scenario.name, new UserMetric(scenario.nbUsers))))
 		writer = newWriter
 		timer = new Timer(true)
 		timer.scheduleAtFixedRate(new SendToGraphiteTask, 0, 1000)
 	}
+	
+	def getRootPathPrefix() : String = { "gatling" }
 
 	def onScenarioRecord(scenarioRecord: ScenarioRecord) {
 		usersPerScenario(scenarioRecord.scenarioName).update(scenarioRecord)


### PR DESCRIPTION
This patch enables one to set a different datawriter in `gatling.conf` which can influence the graphite path

```
data {
        writers = [console, file, CustomGraphiteWriter ]
}
```

Example implementation:

``` scala
class CustomGraphiteWriter extends MyDataWriter {

    override def getRootPathPrefix() : String = { 
        // val machinename = ?
        // val databasename= ?
        "loadtest.machinename.databasename" 
    }
}
```
