### PR TITLE
[Fix] gatling-maven: child JVM does not exit if parent JVM exits

### DIFF
--- a/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingJavaMainCallerByFork.java
+++ b/gatling-maven-plugin/src/main/java/com/excilys/ebi/gatling/mojo/GatlingJavaMainCallerByFork.java
@@ -22,7 +22,6 @@ import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.Executor;
-import org.apache.commons.exec.ProcessDestroyer;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.exec.ShutdownHookProcessDestroyer;
 import org.apache.maven.plugin.AbstractMojo;


### PR DESCRIPTION
This is a fix for issue Issue #1047. The fix is simply set a ShutdownHookProcessDestroyer to the DefaultExecutor. 

To fix this issue, I followed the last bullet point in this [DefaultExecutor's Doc](http://commons.apache.org/proper/commons-exec//apidocs/org/apache/commons/exec/DefaultExecutor.html)

I have tested this on my Windows machine.
