### PR TITLE
HAR support

### DIFF
--- a/gatling-recorder/pom.xml
+++ b/gatling-recorder/pom.xml
@@ -41,6 +41,10 @@
 			<groupId>com.excilys.ebi</groupId>
 			<artifactId>plexus-selector</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-scala_2.10</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarMapping.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarMapping.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.recorder.har
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+case class HttpArchive(log: Log)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class Log(entries: Seq[Entry])
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class Entry(startedDateTime: String, request: Request, response: Response)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class Request(method: String, url: String, headers: Seq[Header], queryString: Seq[QueryParam], postData: Option[PostData])
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class Response(status: Int, headers: Seq[Header], content: Content, redirectURL: String)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class Header(name: String, value: String)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class QueryParam(name: String, value: String)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class PostData(mimeType: String, text: String, params: Seq[PostParam])
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class PostParam(name: String, value: Option[String], fileName: Option[String], contentType: Option[String])
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class Content(size: Int, text: Option[String])

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarReader.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarReader.scala
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.recorder.har
+
+import scala.math.round
+import scala.util.Try
+
+import java.io.File
+import java.net.{ URL, URLEncoder }
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+import io.gatling.core.config.GatlingConfiguration.configuration
+import io.gatling.core.util.StringHelper.RichString
+import io.gatling.http.Headers.Names.CONTENT_TYPE
+import io.gatling.recorder.scenario.{ PauseElement, PauseUnit, RequestElement, ScenarioElement }
+import io.gatling.recorder.util.FiltersHelper.isRequestAccepted
+import io.gatling.recorder.util.RedirectHelper._
+
+import org.joda.convert.StringConvert
+import org.joda.time.DateTime
+
+
+object HarReader {
+
+	val mapper = {
+		val objectMapper = new ObjectMapper
+		objectMapper.registerModule(DefaultScalaModule)
+	}
+
+	var scenarioElements: List[ScenarioElement] = Nil
+
+	private var lastEntry: Entry = _
+	private var lastStatus: Int = 0
+	private var lastRequestTimestamp: Long = 0
+
+	def processHarFile(path: String) {
+		def isValidURL(url: String) = Try(new URL(url)).isSuccess
+
+		val file = new File(path)
+		val httpArchive = mapper.readValue(file, classOf[HttpArchive])
+		httpArchive.log.entries.filter(entry => isValidURL(entry.request.url)).foreach(processEntry)
+
+	}
+
+	def cleanHarReaderState {
+		scenarioElements = Nil
+		lastEntry = null
+		lastStatus = 0
+		lastRequestTimestamp = 0
+	}
+
+	private def processEntry(entry: Entry) {
+
+		def buildHeaders(entry: Entry) = {
+			val headers = entry.request.headers.map(header => (header.name, header.value)).toMap
+			// NetExport doesn't add Content-Type to headers when POSTing, but both Chrome Dev Tools and NetExport set mimeType
+			entry.request.postData.map(postData => headers.updated(CONTENT_TYPE, postData.mimeType)).getOrElse(headers)
+		}
+
+		def createRequest(entry: Entry, statusCode: Int) {
+			def buildContent(postParams: Seq[PostParam]) = {
+				def encode(s: String) = URLEncoder.encode(s, configuration.core.encoding)
+
+				postParams.map(postParam => encode(postParam.name) + "=" + encode(postParam.value.get)).mkString("&")
+			}
+
+			val uri = entry.request.url
+			val method = entry.request.method
+			val headers = buildHeaders(entry)
+			// NetExport doesn't copy post params to text field
+			val content = entry.request.postData.map(postData => postData.text.trimToOption.getOrElse(buildContent(postData.params)))
+			scenarioElements = new RequestElement(uri, method, headers, content, statusCode, None) :: scenarioElements
+		}
+
+		def createPause {
+			def parseMillisFromIso8601DateTime(time: String) = StringConvert.INSTANCE.convertFromString(classOf[DateTime],time).getMillis
+
+			val timestamp = parseMillisFromIso8601DateTime(entry.startedDateTime)
+			val diff = timestamp - lastRequestTimestamp
+			if(lastRequestTimestamp != 0 && diff > 10) {
+				val (pauseValue, pauseUnit) =
+					if (diff > 1000)
+						(round(diff / 1000).toLong, PauseUnit.SECONDS)
+					else
+						(diff, PauseUnit.MILLISECONDS)
+				scenarioElements = new PauseElement(pauseValue, pauseUnit) :: scenarioElements
+			}
+			lastRequestTimestamp = timestamp
+		}
+
+		if (isRequestAccepted(entry.request.url, entry.request.method)) {
+			if (isRequestRedirectChainStart(lastStatus, entry.response.status)) {
+				createPause
+				lastEntry = entry
+
+			} else if (isRequestRedirectChainEnd(lastStatus, entry.response.status)) {
+				// process request with new status
+				createRequest(lastEntry, entry.response.status)
+				lastEntry = null
+
+			} else if (!isRequestInsideRedirectChain(lastStatus, entry.response.status)) {
+				// standard use case
+				createPause
+				createRequest(entry, entry.response.status)
+			}
+			lastStatus = entry.response.status
+		}
+	}
+
+}

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
@@ -32,7 +32,7 @@ import io.gatling.recorder.scenario.template.SimulationTemplate
 object ScenarioExporter extends Logging {
 	private val EVENTS_GROUPING = 100
 
-	def saveScenario(startDate: Date, scenarioElements: List[ScenarioElement]) {
+	def saveScenario(scenarioElements: List[ScenarioElement]) {
 
 		val baseUrl = getBaseUrl(scenarioElements)
 
@@ -80,7 +80,7 @@ object ScenarioExporter extends Logging {
 			def generateHeaders(elements: List[RequestElement], headers: Map[Int, List[(String, String)]]): Map[Int, List[(String, String)]] = elements match {
 				case Nil => headers
 				case element :: others => {
-					val acceptedHeaders = element.headers
+					val acceptedHeaders = element.headers.toList
 						.filterNot {
 							case (headerName, headerValue) => filteredHeaders.contains(headerName) || baseHeaders.get(headerName).map(baseValue => baseValue == headerValue).getOrElse(false)
 						}
@@ -120,7 +120,7 @@ object ScenarioExporter extends Logging {
 
 		val output = SimulationTemplate.render(configuration.simulation.pkg, configuration.simulation.className, protocolConfigElement, headers, "Scenario Name", newScenarioElements)
 
-		withCloseable(new FileWriter(File(getOutputFolder / getSimulationFileName(startDate)).jfile)) {
+		withCloseable(new FileWriter(File(getOutputFolder / getSimulationFileName).jfile)) {
 			_.write(output)
 		}
 	}
@@ -172,7 +172,7 @@ object ScenarioExporter extends Logging {
 		}
 	}
 
-	def getSimulationFileName(date: Date): String = configuration.simulation.className + ".scala"
+	def getSimulationFileName: String = configuration.simulation.className + ".scala"
 
 	def getOutputFolder = {
 		val path = configuration.simulation.outputFolder + File.separator + configuration.simulation.pkg.replace(".", File.separator)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/util/FiltersHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/util/FiltersHelper.scala
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.recorder.util
+
+import scala.annotation.tailrec
+
+import java.net.URI
+
+import org.codehaus.plexus.util.SelectorUtils
+
+import io.gatling.recorder.config.RecorderConfiguration.configuration
+import io.gatling.recorder.config.Pattern
+import io.gatling.recorder.ui.enumeration.{ FilterStrategy, PatternType }
+
+object FiltersHelper {
+
+	private val supportedHttpMethods = Vector("POST", "GET", "PUT", "DELETE", "HEAD")
+
+	def isRequestAccepted(uri: String, method: String): Boolean = {
+
+		def requestMatched = {
+			val path = new URI(uri).getPath
+
+			def gatlingPatternToPlexusPattern(pattern: Pattern) = {
+
+				val prefix = pattern.patternType match {
+					case PatternType.ANT => SelectorUtils.ANT_HANDLER_PREFIX
+					case PatternType.JAVA => SelectorUtils.REGEX_HANDLER_PREFIX
+				}
+
+				prefix + pattern.pattern + SelectorUtils.PATTERN_HANDLER_SUFFIX
+			}
+
+			@tailrec
+			def matchPath(patterns: List[Pattern]): Boolean = patterns match {
+				case Nil => false
+				case head :: tail =>
+					if (SelectorUtils.matchPath(gatlingPatternToPlexusPattern(head), path)) true
+					else matchPath(tail)
+			}
+
+			matchPath(configuration.filters.patterns)
+		}
+
+		def requestPassFilters = configuration.filters.filterStrategy match {
+			case FilterStrategy.EXCEPT => !requestMatched
+			case FilterStrategy.ONLY => requestMatched
+			case FilterStrategy.NONE => true
+		}
+
+		supportedHttpMethods.contains(method) && requestPassFilters
+	}
+}

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/util/RedirectHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/util/RedirectHelper.scala
@@ -1,0 +1,14 @@
+package io.gatling.recorder.util
+
+import io.gatling.recorder.config.RecorderConfiguration.configuration
+
+object RedirectHelper {
+
+	def isRedirectCode(code: Int) = code >= 300 && code <= 399
+
+	def isRequestRedirectChainStart(lastStatus: Int, currentStatus: Int): Boolean = configuration.http.followRedirect && !isRedirectCode(lastStatus) && isRedirectCode(currentStatus)
+
+	def isRequestInsideRedirectChain(lastStatus: Int, currentStatus: Int): Boolean = configuration.http.followRedirect && isRedirectCode(lastStatus) && isRedirectCode(currentStatus)
+
+	def isRequestRedirectChainEnd(lastStatus: Int, currentStatus: Int): Boolean = configuration.http.followRedirect && isRedirectCode(lastStatus) && !isRedirectCode(currentStatus)
+}

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
 		<scopt.version>2.1.0</scopt.version>
 		<scalalogging.version>1.0.1</scalalogging.version>
 		<jackson.version>2.1.4</jackson.version>
+		<jackson-module-scala.version>2.1.3</jackson-module-scala.version>
 		<commons-math3.version>3.2</commons-math3.version>
 		<commons-io.version>2.4</commons-io.version>
 		<commons-exec.version>1.1</commons-exec.version>
@@ -320,6 +321,11 @@
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
 				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.module</groupId>
+				<artifactId>jackson-module-scala_2.10</artifactId>
+				<version>${jackson-module-scala.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Changes in this pull request : 
- Obviously, HAR support :)
- Added a new dep, jackson-module-scala (easier deserialization to Scala)
- UI change : dropdown to switch between "HTTP Proxy" mode and "HAR Converter" mode, & display appropriate options (network panel or HAR file chooser) according to which mode is selected
- Minor refactoring :
  - Now able to create RequestElement(s) without a Netty's HTTPRequest
  - Extracted filters and redirection handling to logic to share it with HAR
