### PR TITLE
Replace Jackson by json-smart for HAR mapping, close #1112

### DIFF
--- a/gatling-recorder/pom.xml
+++ b/gatling-recorder/pom.xml
@@ -40,10 +40,6 @@
 			<groupId>com.excilys.ebi</groupId>
 			<artifactId>plexus-selector</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.module</groupId>
-			<artifactId>jackson-module-scala_2.10</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/util/Json.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/util/Json.scala
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.recorder.util
+
+import net.minidev.json.{ JSONArray, JSONValue, JSONObject }
+
+object Json {
+	def parseJson(s: String) = new Json(JSONValue.parse(s))
+
+	implicit def JsonToString(s: Json) = s.toString
+	implicit def JsonToInt(s: Json) = s.toInt
+	implicit def JsonToDouble(s: Json) = s.toDouble
+}
+
+class JsonException extends Exception
+
+class JsonIterator(i: java.util.Iterator[Object]) extends Iterator[Json] {
+	def hasNext = i.hasNext
+	def next = new Json(i.next)
+}
+
+class Json(o: Object) extends Seq[Json] with Dynamic {
+
+	override def toString: String = o.toString
+
+	def toInt: Int = o match {
+		case i: Integer => i
+		case _ => throw new JsonException
+	}
+
+	def toDouble: Double = o match {
+		case d: java.lang.Double => d
+		case f: java.lang.Float => f.toDouble
+		case _ => throw new JsonException
+	}
+
+	def apply(key: String): Json = o match {
+		case m: JSONObject => new Json(m.get(key))
+		case _ => throw new JsonException
+	}
+
+	def apply(idx: Int): Json = o match {
+		case a: JSONArray => new Json(a.get(idx))
+		case _ => throw new JsonException
+	}
+
+	def length: Int = o match {
+		case a: JSONArray => a.size
+		case m: JSONObject => m.size
+		case _ => throw new JsonException
+	}
+
+	def iterator: Iterator[Json] = o match {
+		case a: JSONArray => new JsonIterator(a.iterator)
+		case _ => throw new JsonException
+	}
+
+	def selectDynamic(name: String): Json = apply(name)
+
+	def applyDynamic(name: String)(arg: Any) = {
+		arg match {
+			case s: String => apply(name)(s)
+			case n: Int => apply(name)(n)
+			case u: Unit => apply(name)
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@
 		<joda-convert.version>1.2</joda-convert.version>
 		<scopt.version>2.1.0</scopt.version>
 		<scalalogging.version>1.0.1</scalalogging.version>
-		<jackson.version>2.2.0</jackson.version>
 		<jayway-jsonpath.version>0.8.1</jayway-jsonpath.version>
 		<commons-math3.version>3.2</commons-math3.version>
 		<commons-io.version>2.4</commons-io.version>
@@ -318,16 +317,6 @@
 				<version>${maven2.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.module</groupId>
-				<artifactId>jackson-module-scala_2.10</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>com.jayway.jsonpath</groupId>
 				<artifactId>json-path</artifactId>
 				<version>${jayway-jsonpath.version}</version>
@@ -451,6 +440,7 @@
 									<arg>-unchecked</arg>
 									<arg>-language:implicitConversions</arg>
 									<arg>-language:postfixOps</arg>
+									<arg>-language:dynamics</arg>
 								</args>
 							</configuration>
 						</execution>


### PR DESCRIPTION
Using the json-smart wrapper from @Mononofu : http://www.furidamu.org/blog/2012/09/18/beautiful-json-parsing-in-scala/ .
Also removed unused parts of HAR from mapping.

As Config does it parsing/saving "by hand", the HOCON template is not strictly needed for removing Jackson.
