### PR TITLE
Allow `runDescription` to be specified via CLI or conf file

### DIFF
--- a/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/CommandLineConstants.scala
+++ b/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/CommandLineConstants.scala
@@ -35,4 +35,6 @@ object CommandLineConstants {
 	val CLI_SIMULATION_ALIAS = "simulation"
 	val CLI_OUTPUT_DIRECTORY_BASE_NAME = "on"
 	val CLI_OUTPUT_DIRECTORY_BASE_NAME_ALIAS = "output-name"
+  val CLI_SIMULATION_DESCRIPTION = "sd"
+  val CLI_SIMULATION_DESCRIPTION_ALIAS = "simulation-description"
 }

--- a/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/com/excilys/ebi/gatling/app/Gatling.scala
@@ -67,6 +67,7 @@ object Gatling extends Logging {
 			opt(CLI_SIMULATIONS_BINARIES_FOLDER, CLI_SIMULATIONS_BINARIES_FOLDER_ALIAS, "<directoryPath>", "Uses <directoryPath> to discover already compiled simulations", { v: String => props.binariesDirectory(v) })
 			opt(CLI_SIMULATION, CLI_SIMULATION_ALIAS, "<className>", "Runs <className> simulation", { v: String => props.clazz(v) })
 			opt(CLI_OUTPUT_DIRECTORY_BASE_NAME, CLI_OUTPUT_DIRECTORY_BASE_NAME_ALIAS, "<name>", "Use <name> for the base name of the output directory", { v: String => props.outputDirectoryBaseName(v) })
+      opt(CLI_SIMULATION_DESCRIPTION, CLI_SIMULATION_DESCRIPTION_ALIAS, "<description>", "A short <description> of the run to include in the report", { v: String => props.runDescription(v) })
 		}
 
 		// if arguments are incorrect, usage message is displayed
@@ -94,7 +95,8 @@ class Gatling extends Logging {
 				val selection = configuration.core.simulationClass.map { _ =>
 					val simulation = simulations.head
 					val outputDirectoryBaseName = defaultOutputDirectoryBaseName(simulation)
-					new Selection(simulation, outputDirectoryBaseName, outputDirectoryBaseName)
+          val runDescription = configuration.core.runDescription.getOrElse(outputDirectoryBaseName)
+					new Selection(simulation, outputDirectoryBaseName, runDescription)
 				}.getOrElse(interactiveSelect(simulations))
 
 				val (runId, simulation) = new Runner(selection).run

--- a/gatling-bundle/src/main/assembly/assembly-structure/conf/gatling.conf
+++ b/gatling-bundle/src/main/assembly/assembly-structure/conf/gatling.conf
@@ -7,7 +7,7 @@
 gatling {
 	core {
 		#outputDirectoryBaseName = ""
-		#runDescription = run
+		#runDescription = ""
 		#encoding = "utf-8"							# encoding for every file manipulation made in gatling
 		#simulationClass = ""
 		timeOut {

--- a/gatling-core/src/main/resources/gatling-defaults.conf
+++ b/gatling-core/src/main/resources/gatling-defaults.conf
@@ -7,7 +7,7 @@
 gatling {
 	core {
 		outputDirectoryBaseName = ""
-		runDescription = run
+		runDescription = ""
 		encoding = "utf-8"							# encoding for every file manipulation made in gatling
 		simulationClass = ""
 		timeOut {

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/config/GatlingConfiguration.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/config/GatlingConfiguration.scala
@@ -50,7 +50,7 @@ object GatlingConfiguration extends Logging {
 		configuration = GatlingConfiguration(
 			core = CoreConfiguration(
 				outputDirectoryBaseName = trimToOption(config.getString(CONF_CORE_OUTPUT_DIRECTORY_BASE_NAME)),
-				runDescription = config.getString(CONF_CORE_RUN_DESCRIPTION),
+				runDescription = trimToOption(config.getString(CONF_CORE_RUN_DESCRIPTION)),
 				encoding = config.getString(CONF_CORE_ENCODING),
 				simulationClass = trimToOption(config.getString(CONF_CORE_SIMULATION_CLASS)),
 				timeOut = TimeOutConfiguration(
@@ -137,7 +137,7 @@ object GatlingConfiguration extends Logging {
 
 case class CoreConfiguration(
 	outputDirectoryBaseName: Option[String],
-	runDescription: String,
+	runDescription: Option[String],
 	encoding: String,
 	simulationClass: Option[String],
 	timeOut: TimeOutConfiguration,

--- a/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/config/GatlingPropertiesBuilder.scala
+++ b/gatling-core/src/main/scala/com/excilys/ebi/gatling/core/config/GatlingPropertiesBuilder.scala
@@ -61,5 +61,9 @@ class GatlingPropertiesBuilder {
 		props.put(CONF_CORE_OUTPUT_DIRECTORY_BASE_NAME, v)
 	}
 
+  def runDescription(v: String) {
+    props.put(CONF_CORE_RUN_DESCRIPTION, v)
+  }
+
 	def build = props
 }


### PR DESCRIPTION
Prior to this commit, if you ran Gatling with the CLI or config
file option for the simulation class defined, it would automatically
set the run description to the same value as the run ID.

This commit changes the behavior to look and see if the user
specified a value for `runDescription` via the CLI or in
the config file, and uses the value if they did.  It falls
back to the old behavior if the user did not specify a value.
