### PR TITLE
reorganize the consoleTemplate layout

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTextComponent.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTextComponent.scala
@@ -30,7 +30,6 @@ object Statistics {
 }
 
 case class Statistics(name: String, total: Long, success: Long, failure: Long) {
-
 	def all = List(total, success, failure)
 }
 

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/StatsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/StatsReportGenerator.scala
@@ -70,7 +70,7 @@ class StatsReportGenerator(runOn: String, dataReader: DataReader, componentLibra
 		new TemplateWriter(jsStatsFile(runOn)).writeToFile(new StatsJsTemplate(rootContainer).getOutput)
 		new TemplateWriter(jsonStatsFile(runOn)).writeToFile(new StatsJsonTemplate(rootContainer.stats, true).getOutput)
 		new TemplateWriter(tsvStatsFile(runOn)).writeToFile(new StatsTsvTemplate(rootContainer).getOutput)
-		println(new ConsoleTemplate(rootContainer.stats).getOutput)
+		println(ConsoleTemplate(rootContainer.stats))
 	}
 }
 

--- a/gatling-charts/src/main/scala/io/gatling/charts/template/ConsoleTemplate.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/template/ConsoleTemplate.scala
@@ -22,18 +22,18 @@ import io.gatling.charts.component.Statistics.PrintableStat
 import io.gatling.core.result.writer.ConsoleSummary.{ newBlock, outputLength, writeSubTitle }
 import io.gatling.core.util.StringHelper.{ eol, RichString }
 
-class ConsoleTemplate(requestStatistics: RequestStatistics) {
+object ConsoleTemplate {
 
 	def writeRequestCounters(statistics: Statistics): Fastring = {
 		import statistics._
-		fast"> ${name.rightPad(outputLength - 32)} TO=${total.printable.rightPad(6)} OK=${success.printable.rightPad(6)} KO=${failure.printable.rightPad(6)}"
+		fast"> ${name.rightPad(outputLength - 34)} ${total.printable.leftPad(7)} (OK=${success.printable.leftPad(6)} / KO=${failure.printable.leftPad(6)})"
 	}
 	def writeGroupedCounters(groupedCount: GroupedCount): Fastring = {
 		import groupedCount._
-		fast"> ${name.rightPad(outputLength - 32)} COUNT=${count.toString.rightPad(6)} PERCENTAGE=${percentage.toString.rightPad(6)}"
+		fast"> ${name.rightPad(outputLength - 34)} ${count.toString.leftPad(7)} (${percentage.toString.leftPad(3)}%)"
 	}
 
-	def getOutput: String = {
+	def apply(requestStatistics: RequestStatistics): String = {
 		import requestStatistics._
 		fast"""
 $newBlock

--- a/gatling-charts/src/test/scala/io/gatling/charts/template/ConsoleTemplateSpec.scala
+++ b/gatling-charts/src/test/scala/io/gatling/charts/template/ConsoleTemplateSpec.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.charts.template
+
+import scala.collection.mutable.Map
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.charts.component.Statistics
+import io.gatling.charts.component.RequestStatistics
+import io.gatling.charts.component.GroupedCount
+
+@RunWith(classOf[JUnitRunner])
+class ConsoleTemplateSpec extends Specification {
+
+	GatlingConfiguration.setUp()
+
+	"console template" should {
+
+		"format the request counters properly" in {
+			val numberOfRequestsStatistics = Statistics("numberOfRequestsStatistics", 20l, 19l, 1l)
+			val out = ConsoleTemplate.writeRequestCounters(numberOfRequestsStatistics)
+			out.mkString must beEqualTo("> numberOfRequestsStatistics                          20 (OK=    19 / KO=     1)")
+		}
+
+		"format the grouped counts properly" in {
+			val out = ConsoleTemplate.writeGroupedCounters(GroupedCount("t < 42 ms", 90, 42))
+			out.mkString must beEqualTo("> t < 42 ms                                           90 ( 42%)")
+		}
+
+	}
+}


### PR DESCRIPTION
I propose this small layout change in the final displayed stats so that it looks like that : 

```
================================================================================
---- Global Information --------------------------------------------------------
> numberOfRequests                                     4 (OK=     4 / KO=     0)
> minResponseTime                                     20 (OK=    20 / KO=     -)
> maxResponseTime                                    140 (OK=   140 / KO=     -)
> meanResponseTime                                    53 (OK=    53 / KO=     -)
> stdDeviation                                        50 (OK=    50 / KO=     -)
> percentiles1                                       140 (OK=   140 / KO=     -)
> percentiles2                                       140 (OK=   140 / KO=     -)
> meanNumberOfRequestsPerSecond                        6 (OK=     6 / KO=     -)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                           4 (100%)
> 800 ms < t < 1200 ms                                 0 (  0%)
> t > 1200 ms                                          0 (  0%)
> failed                                               0 (  0%)
================================================================================
```
