### PR TITLE
POM cleanup + fix license in .bat scripts

### DIFF
--- a/gatling-app/pom.xml
+++ b/gatling-app/pom.xml
@@ -7,7 +7,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-app</artifactId>
-	<name>${project.artifactId}</name>
 	<description>Gatling command line application</description>
 
 	<properties>
@@ -52,16 +51,6 @@
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>io.gatling.app.App</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/gatling-bundle/src/main/assembly/assembly-structure/bin/gatling.bat
+++ b/gatling-bundle/src/main/assembly/assembly-structure/bin/gatling.bat
@@ -14,23 +14,6 @@
 @REM limitations under the License.
 @REM
 
-@ECHO OFF
-@REM
-@REM Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.excilys.com)
-@REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM 		http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
-@REM
-
 setlocal
 
 rem set GATLING_HOME automatically if possible

--- a/gatling-bundle/src/main/assembly/assembly-structure/bin/recorder.bat
+++ b/gatling-bundle/src/main/assembly/assembly-structure/bin/recorder.bat
@@ -14,23 +14,6 @@
 @REM limitations under the License.
 @REM
 
-@ECHO OFF
-@REM
-@REM Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.excilys.com)
-@REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM 		http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
-@REM
-
 setlocal
 
 rem set GATLING_HOME automatically if possible

--- a/gatling-charts/pom.xml
+++ b/gatling-charts/pom.xml
@@ -7,7 +7,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-charts</artifactId>
-	<name>${project.artifactId}</name>
 	<description>Gatling Charting functionnalities</description>
 
 	<properties>

--- a/gatling-core/pom.xml
+++ b/gatling-core/pom.xml
@@ -7,7 +7,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-core</artifactId>
-	<name>${project.artifactId}</name>
 	<description>Gatling Core functionnalities</description>
 
 	<properties>

--- a/gatling-http/pom.xml
+++ b/gatling-http/pom.xml
@@ -7,7 +7,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-http</artifactId>
-	<name>${project.artifactId}</name>
 	<description>Gatling HTTP functionnalities</description>
 
 	<properties>

--- a/gatling-jdbc/pom.xml
+++ b/gatling-jdbc/pom.xml
@@ -6,7 +6,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-jdbc</artifactId>
-	<name>${project.artifactId}</name>
 	<description>Gatling JDBC functionnalities</description>
 
 	<properties>

--- a/gatling-maven-plugin/pom.xml
+++ b/gatling-maven-plugin/pom.xml
@@ -7,7 +7,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-maven-plugin</artifactId>
-	<name>${project.artifactId}</name>
 	<packaging>maven-plugin</packaging>
 
 	<properties>

--- a/gatling-metrics/pom.xml
+++ b/gatling-metrics/pom.xml
@@ -9,9 +9,6 @@
 	</parent>
 
 	<artifactId>gatling-metrics</artifactId>
-
-	<name>${project.artifactId}</name>
-
 	<description>Gatling Metrics</description>
 
 	<properties>
@@ -44,10 +41,6 @@
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>com.mycila.maven-license-plugin</groupId>
-				<artifactId>maven-license-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/gatling-recorder/pom.xml
+++ b/gatling-recorder/pom.xml
@@ -6,7 +6,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-recorder</artifactId>
-	<name>${project.artifactId}</name>
 	<description>Gatling Recorder</description>
 
 	<properties>

--- a/gatling-redis/pom.xml
+++ b/gatling-redis/pom.xml
@@ -6,7 +6,6 @@
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>gatling-redis</artifactId>
-	<name>${project.artifactId}</name>
 	<description>Gatling Redis functionalities</description>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,6 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- http://repo.typesafe.com/typesafe/releases -->
-		<!-- http://repo.jenkins-ci.org/content/repositories/releases -->
 	</repositories>
 
 	<properties>
@@ -488,7 +486,7 @@
 						<header>${header.basedir}/src/etc/header.txt</header>
 						<strictCheck>true</strictCheck>
 						<excludes>
-							<exclude>src/test/resources/*.*</exclude>
+							<exclude>src/test/resources/**</exclude>
 							<exclude>**/jquery.min.js</exclude>
 							<exclude>**/bootstrap.min.*</exclude>
 							<exclude>**/*.ssp</exclude>


### PR DESCRIPTION
In this PR : 
- Remove maven-jar-plugin config in `gatling-app` module : unnecessary, since scripts call the class directly
- Remove `<name>...</name>` tags : name defaults to artifactId
- Change maven-license-plugin exclusion pattern to ignore a test resource in charts, suppressing a warning
- Fix license in `.bat` script, not properly overwritten when license changed
