### PR TITLE
Converting session attribute from String to Integer

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/session/Session.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/session/Session.scala
@@ -37,6 +37,7 @@ case class SessionAttribute(session: Session, key: String) {
 	def as[T]: T = session.attributes(key).asInstanceOf[T]
 	def asOption[T]: Option[T] = session.attributes.get(key).map(_.asInstanceOf[T])
 	def validate[T: ClassTag]: Validation[T] = session.attributes.get(key).map(_.asValidation[T]).getOrElse(undefinedSessionAttributeMessage(key).failure[T])
+	def toInt: Int = Integer.parseInt(session.attributes(key).asInstanceOf[String])
 }
 
 /**


### PR DESCRIPTION
session("myAttribute").as[Int] causes a class cast exception from String to Integer, toInt will parse the String as an Integer.

Used where an integer (for example and expected status code) is read from a csv, for obtaining from the session as an integer.
