### PR TITLE
Exit nicely when the compilation failed in Zinc

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/ZincCompiler.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/ZincCompiler.scala
@@ -20,6 +20,7 @@ import java.net.URLClassLoader
 
 import scala.tools.nsc.io.{ Directory, Path }
 import scala.tools.nsc.io.Path.{ jfile2path, string2path }
+import scala.util.Try
 
 import com.typesafe.scalalogging.slf4j.Logging
 import com.typesafe.zinc.{ Compiler, Inputs, Setup }
@@ -108,6 +109,9 @@ object ZincCompiler extends Logging {
 		val inputs = simulationInputs
 		Inputs.debug(inputs, zincLogger)
 
-		zincCompiler.compile(inputs)(zincLogger)
+		if (Try(zincCompiler.compile(inputs)(zincLogger)).isFailure) {
+			// Zinc is already logging all the issues, no need to deal with the exception.
+			System.exit(1)
+		}
 	}
 }

--- a/gatling-app/src/main/scala/io/gatling/app/ZincCompilerLauncher.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/ZincCompilerLauncher.scala
@@ -36,6 +36,7 @@ object ZincCompilerLauncher extends Logging {
 		val classesDirectory = Directory(binDirectory / "classes")
 
 		val cl = new CommandLine(javaExe.toString)
+
 		cl.addArgument("-cp")
 		cl.addArgument(javaClasspath)
 		configuration.core.zinc.jvmArgs.foreach(cl.addArgument)
@@ -49,9 +50,13 @@ object ZincCompilerLauncher extends Logging {
 		logger.debug(s"Launching Zinc: $cl")
 
 		val exec = new DefaultExecutor
+		exec.setExitValues(Array(0, 1))
 		exec.setStreamHandler(new PumpStreamHandler(System.out, System.err, System.in))
 		exec.setProcessDestroyer(new ShutdownHookProcessDestroyer)
-		if (exec.execute(cl) != 0) throw new RuntimeException("Compiling failed")
+		if (exec.execute(cl) != 0) {
+			println("Compilation failed")
+			System.exit(1)
+		}
 
 		classesDirectory
 	}


### PR DESCRIPTION
Currently, it fails with the following stacktrace : 

```
11:42:20.419 [ERROR] i.g.a.ZincCompiler$ - one error found
Exception in thread "main" Compilation failed
    at sbt.compiler.AnalyzingCompiler.call(AnalyzingCompiler.scala:105)
    at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:48)
    at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:41)
    at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply$mcV$sp(AggressiveCompile.scala:98)
    at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply(AggressiveCompile.scala:98)
    at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply(AggressiveCompile.scala:98)
    at sbt.compiler.AggressiveCompile.sbt$compiler$AggressiveCompile$$timed(AggressiveCompile.scala:155)
    at sbt.compiler.AggressiveCompile$$anonfun$3.compileScala$1(AggressiveCompile.scala:97)
    at sbt.compiler.AggressiveCompile$$anonfun$3.apply(AggressiveCompile.scala:138)
    at sbt.compiler.AggressiveCompile$$anonfun$3.apply(AggressiveCompile.scala:86)
    at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:30)
    at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:28)
    at sbt.inc.Incremental$.cycle(Incremental.scala:73)
    at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:33)
    at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:32)
    at sbt.inc.Incremental$.manageClassfiles(Incremental.scala:41)
    at sbt.inc.Incremental$.compile(Incremental.scala:32)
    at sbt.inc.IncrementalCompile$.apply(Compile.scala:25)
    at sbt.compiler.AggressiveCompile.compile2(AggressiveCompile.scala:146)
    at sbt.compiler.AggressiveCompile.compile1(AggressiveCompile.scala:70)
    at com.typesafe.zinc.Compiler.compile(Compiler.scala:161)
    at com.typesafe.zinc.Compiler.compile(Compiler.scala:142)
    at io.gatling.app.ZincCompiler$.main(ZincCompiler.scala:111)
    at io.gatling.app.ZincCompiler.main(ZincCompiler.scala)
Exception in thread "main" org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal(DefaultExecutor.java:377)
    at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:160)
    at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:147)
    at io.gatling.app.ZincCompilerLauncher$.apply(ZincCompilerLauncher.scala:54)
    at io.gatling.app.SimulationClassLoader$.fromSourcesDirectory(SimulationClassLoader.scala:32)
    at io.gatling.app.Gatling$$anonfun$15.apply(Gatling.scala:171)
    at io.gatling.app.Gatling$$anonfun$15.apply(Gatling.scala:171)
    at scala.Option.getOrElse(Option.scala:120)
    at io.gatling.app.Gatling.start(Gatling.scala:171)
    at io.gatling.app.Gatling$.fromMap(Gatling.scala:59)
    at io.gatling.app.Gatling$.runGatling(Gatling.scala:80)
    at io.gatling.app.Gatling$.main(Gatling.scala:54)
    at io.gatling.app.Gatling.main(Gatling.scala)
```
