### PR TITLE
Workaround for FileChooser bug on Mac : select correct file using a modal

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/controller/RecorderController.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/controller/RecorderController.scala
@@ -60,8 +60,8 @@ class RecorderController extends Logging {
 	def startRecording {
 		val selectedMode = frontEnd.selectedMode
 		val harFilePath = frontEnd.harFilePath
-		if (selectedMode == Har && harFilePath.isEmpty) {
-			frontEnd.handleMissingHarFile
+		if (selectedMode == Har && !File(harFilePath).exists) {
+			frontEnd.handleMissingHarFile(harFilePath)
 		} else {
 			val simulationFile = File(ScenarioExporter.getOutputFolder / ScenarioExporter.getSimulationFileName)
 			val proceed = if (simulationFile.exists) frontEnd.askSimulationOverwrite else true

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DialogFileSelector.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DialogFileSelector.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.recorder.ui.swing.component
+
+import scala.swing._
+import scala.swing.BorderPanel.Position._
+
+import io.gatling.recorder.ui.swing.util.UIHelper._
+import io.gatling.recorder.ui.swing.frame.ConfigurationFrame
+
+object DialogFileSelector {
+	val message = """	|A Swing bug on Mac OS X prevents the Recorder from getting
+						|the correct path for file with some known extensions.
+						|Those files closely matches the file you selected, please select
+						|the correct one :
+						|""".stripMargin
+}
+class DialogFileSelector(configurationFrame: ConfigurationFrame, possibleFiles: List[String]) extends Dialog(configurationFrame) {
+
+	var selectedFile: Option[String] = None
+
+	val radioButtons = possibleFiles.map(new RadioButton(_))
+	val radiosGroup = new ButtonGroup(radioButtons: _*)
+	val cancelButton = Button("Cancel")(close())
+	val okButton = Button("OK") { radiosGroup.selected.foreach(button => selectedFile = Some(button.text)); close() }
+	val defaultBackground = background
+
+	contents = new BorderPanel {
+		val messageLabel = new TextArea(DialogFileSelector.message) { background = defaultBackground }
+		val radiosPanel = new BoxPanel(Orientation.Vertical) { radioButtons.foreach(contents += _) }
+		val buttonsPanel = new CenterAlignedFlowPanel {
+			contents += okButton
+			contents += cancelButton
+		}
+
+		layout(messageLabel) = North
+		layout(radiosPanel) = Center
+		layout(buttonsPanel) = South
+	}
+
+	modal = true
+	setLocationRelativeTo(configurationFrame)
+}

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
@@ -298,6 +298,10 @@ class ConfigurationFrame(frontend: RecorderFrontend) extends MainFrame {
 
 	def harFilePath = harPath.text
 
+	def updateHarFilePath(path: Option[String]) {
+		path.foreach(harPath.text = _)
+	}
+
 	/****************************************/
 	/**           CONFIGURATION            **/
 	/****************************************/


### PR DESCRIPTION
This PR introduce a workaround for the issue with file extensions on Mac OS X.
When the selected file does not exist, the Swing frontend looks for files that could match it and then offer to choose the correct file, using a modal.
