### PR TITLE
Move errors table to gatling-charts

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/component/ComponentLibrary.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/ComponentLibrary.scala
@@ -56,5 +56,4 @@ trait ComponentLibrary {
 	def getNumberOfRequestsChartComponent: Component
 	def getGroupDurationChartComponent(runStart: Long, durationsSuccess: Series[IntRangeVsTimePlot], durationsFailure: Series[IntRangeVsTimePlot]): Component
 	def getGroupDetailsDurationDistributionChartComponent(durationsSuccess: Series[IntVsTimePlot], durationsFailure: Series[IntVsTimePlot]): Component
-	def getErrorTableComponent(errors: Seq[(String, Int, Int)]): Component
 }

--- a/gatling-charts/src/main/scala/io/gatling/charts/component/ErrorTableComponent.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/ErrorTableComponent.scala
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.charts.component
+
+import com.dongxiguo.fastring.Fastring.Implicits._
+
+import io.gatling.core.result.ErrorStats
+import io.gatling.core.util.StringHelper
+
+class ErrorTableComponent(errors: Seq[ErrorStats]) extends Component {
+
+	def js = StringHelper.emptyFastring
+
+	def html = if (errors.isEmpty)
+		StringHelper.emptyFastring
+	else
+		fast"""<div class="statistics extensible-geant collapsed">
+    <div class="title">
+        <div class="title_collapsed" style="cursor: auto;">ERRORS</div>
+    </div>
+    <table id="container_errors" class="statistics-in extensible-geant">
+        <thead>
+            <tr>
+                <th class="header"><span>Error</span></th>
+                <th class="header"><span>Count</span></th>
+                <th class="header"><span>Percentage</span></th>
+            </tr>
+        </thead>
+		<tbody>
+		    ${errors.map { error => fast"""<tr><td class="total">${error.message}</td><td class="value total">${error.count}</td><td class="value total">${error.percentage} %</td></tr>""" }.mkFastring}
+		</tbody>
+    </table>
+</div>
+"""
+
+	def jsFiles: Seq[String] = Seq.empty
+}

--- a/gatling-charts/src/main/scala/io/gatling/charts/component/impl/ComponentLibraryImpl.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/impl/ComponentLibraryImpl.scala
@@ -40,5 +40,4 @@ class ComponentLibraryImpl extends ComponentLibrary {
 	def getNumberOfRequestsChartComponent: Component = throw new UnsupportedOperationException
 	def getGroupDurationChartComponent(runStart: Long, durationsSuccess: Series[IntRangeVsTimePlot], durationsFailure: Series[IntRangeVsTimePlot]): Component = throw new UnsupportedOperationException
 	def getGroupDetailsDurationDistributionChartComponent(durationsSuccess: Series[IntVsTimePlot], durationsFailure: Series[IntVsTimePlot]): Component = throw new UnsupportedOperationException
-	def getErrorTableComponent(errors: Seq[(String, Int, Int)]): Component = throw new UnsupportedOperationException
 }

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/GlobalReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/GlobalReportGenerator.scala
@@ -15,7 +15,7 @@
  */
 package io.gatling.charts.report
 
-import io.gatling.charts.component.{ Component, ComponentLibrary, StatisticsTableComponent }
+import io.gatling.charts.component.{ Component, ComponentLibrary, ErrorTableComponent, StatisticsTableComponent }
 import io.gatling.charts.config.ChartsFiles.globalFile
 import io.gatling.charts.template.GlobalPageTemplate
 import io.gatling.charts.util.Colors._
@@ -75,7 +75,7 @@ class GlobalReportGenerator(runOn: String, dataReader: DataReader, componentLibr
 			componentLibrary.getNumberOfRequestsChartComponent,
 			componentLibrary.getRequestDetailsIndicatorChartComponent,
 			new StatisticsTableComponent,
-			componentLibrary.getErrorTableComponent(dataReader.errors(None, None)),
+			new ErrorTableComponent(dataReader.errors(None, None)),
 			activeSessionsChartComponent,
 			responseTimeDistributionChartComponent,
 			requestsChartComponent,

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/GroupDetailsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/GroupDetailsReportGenerator.scala
@@ -15,7 +15,7 @@
  */
 package io.gatling.charts.report
 
-import io.gatling.charts.component.{ Component, ComponentLibrary, StatisticsTextComponent }
+import io.gatling.charts.component.{ Component, ComponentLibrary, ErrorTableComponent, StatisticsTextComponent }
 import io.gatling.charts.config.ChartsFiles.requestFile
 import io.gatling.charts.template.GroupDetailsPageTemplate
 import io.gatling.charts.util.Colors.{ BLUE, RED }
@@ -52,7 +52,7 @@ class GroupDetailsReportGenerator(runOn: String, dataReader: DataReader, compone
 				new GroupDetailsPageTemplate(group,
 					statisticsComponent,
 					indicatorChartComponent,
-					componentLibrary.getErrorTableComponent(dataReader.errors(None, Some(group))),
+					new ErrorTableComponent(dataReader.errors(None, Some(group))),
 					responseTimeChartComponent,
 					responseTimeDistributionChartComponent)
 

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/RequestDetailsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/RequestDetailsReportGenerator.scala
@@ -15,7 +15,7 @@
  */
 package io.gatling.charts.report
 
-import io.gatling.charts.component.{ Component, ComponentLibrary, StatisticsTextComponent }
+import io.gatling.charts.component.{ Component, ComponentLibrary, ErrorTableComponent, StatisticsTextComponent }
 import io.gatling.charts.config.ChartsFiles.requestFile
 import io.gatling.charts.result.reader.RequestPath
 import io.gatling.charts.template.RequestDetailsPageTemplate
@@ -70,7 +70,7 @@ class RequestDetailsReportGenerator(runOn: String, dataReader: DataReader, compo
 					group,
 					new StatisticsTextComponent,
 					componentLibrary.getRequestDetailsIndicatorChartComponent,
-					componentLibrary.getErrorTableComponent(dataReader.errors(requestName, group)),
+					new ErrorTableComponent(dataReader.errors(requestName, group)),
 					responseTimeChartComponent,
 					responseTimeDistributionChartComponent,
 					latencyChartComponent,

--- a/gatling-charts/src/main/scala/io/gatling/charts/result/reader/FileDataReader.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/result/reader/FileDataReader.scala
@@ -26,7 +26,7 @@ import io.gatling.charts.result.reader.buffers.{ CountBuffer, RangeBuffer }
 import io.gatling.charts.result.reader.stats.StatsHelper
 import io.gatling.core.config.GatlingConfiguration.configuration
 import io.gatling.core.config.GatlingFiles.simulationLogDirectory
-import io.gatling.core.result.{ Group, GroupStatsPath, IntRangeVsTimePlot, IntVsTimePlot, RequestStatsPath, StatsPath }
+import io.gatling.core.result.{ ErrorStats, Group, GroupStatsPath, IntRangeVsTimePlot, IntVsTimePlot, RequestStatsPath, StatsPath }
 import io.gatling.core.result.message.{ GroupMessageType, KO, OK, RequestMessageType, RunMessage, RunMessageType, ScenarioMessageType, Status }
 import io.gatling.core.result.reader.{ DataReader, GeneralStats }
 import io.gatling.core.util.DateHelper.parseTimestampString
@@ -239,9 +239,9 @@ class FileDataReader(runUuid: String) extends DataReader(runUuid) with Logging {
 			}.sortBy(_.time)
 	}
 
-	def errors(requestName: Option[String], group: Option[Group]): Seq[(String, Int, Int)] = {
+	def errors(requestName: Option[String], group: Option[Group]): Seq[ErrorStats] = {
 		val buff = resultsHolder.getErrorsBuffers(requestName, group)
 		val total = buff.foldLeft(0)(_ + _._2)
-		buff.toSeq.map { case (name, count) => (name, count, count * 100 / total) }.sortWith(_._2 > _._2)
+		buff.toSeq.map { case (name, count) => ErrorStats(name, count, count * 100 / total) }.sortWith(_.count > _.count)
 	}
 }

--- a/gatling-core/src/main/scala/io/gatling/core/result/package.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/result/package.scala
@@ -21,4 +21,5 @@ package result {
 	case class IntVsTimePlot(time: Int, value: Int)
 	case class IntRangeVsTimePlot(time: Int, lower: Int, higher: Int)
 	case class PieSlice(name: String, value: Int)
+	case class ErrorStats(message: String, count: Int, percentage: Int)
 }

--- a/gatling-core/src/main/scala/io/gatling/core/result/reader/DataReader.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/result/reader/DataReader.scala
@@ -16,7 +16,7 @@
 package io.gatling.core.result.reader
 
 import io.gatling.core.config.GatlingConfiguration.configuration
-import io.gatling.core.result.{ Group, IntRangeVsTimePlot, IntVsTimePlot, StatsPath }
+import io.gatling.core.result.{ ErrorStats, Group, IntRangeVsTimePlot, IntVsTimePlot, StatsPath }
 import io.gatling.core.result.message.{ RunMessage, Status }
 
 object DataReader {
@@ -41,5 +41,5 @@ abstract class DataReader(runUuid: String) {
 	def responseTimeGroupByExecutionStartDate(status: Status, requestName: Option[String] = None, group: Option[Group] = None): Seq[IntRangeVsTimePlot]
 	def latencyGroupByExecutionStartDate(status: Status, requestName: Option[String] = None, group: Option[Group] = None): Seq[IntRangeVsTimePlot]
 	def responseTimeAgainstGlobalNumberOfRequestsPerSec(status: Status, requestName: Option[String] = None, group: Option[Group] = None): Seq[IntVsTimePlot]
-	def errors(requestName: Option[String], group: Option[Group]): Seq[(String, Int, Int)]
+	def errors(requestName: Option[String], group: Option[Group]): Seq[ErrorStats]
 }


### PR DESCRIPTION
As the errors table is only HTML code and does not relies on HighCharts/HighStocks, it can be safely moved to gatling-charts.
