### PR TITLE
Correctly quote shell params when they are passed off

### DIFF
--- a/gatling-bundle/src/main/assembly/assembly-structure/bin/gatling.sh
+++ b/gatling-bundle/src/main/assembly/assembly-structure/bin/gatling.sh
@@ -30,4 +30,4 @@ JAVA_OPTS="-server -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms512M
 
 CLASSPATH="$GATLING_HOME/lib/*:$GATLING_CONF:$GATLING_HOME/user-files:${JAVA_CLASSPATH}"
 
-java $JAVA_OPTS -cp $CLASSPATH io.gatling.app.Gatling $@
+java $JAVA_OPTS -cp $CLASSPATH io.gatling.app.Gatling "$@"

--- a/gatling-bundle/src/main/assembly/assembly-structure/bin/recorder.sh
+++ b/gatling-bundle/src/main/assembly/assembly-structure/bin/recorder.sh
@@ -30,4 +30,4 @@ JAVA_OPTS="-Xms512M -Xmx512M -Xmn100M ${JAVA_OPTS}"
 
 CLASSPATH="$GATLING_HOME/lib/*:$GATLING_CONF:${JAVA_CLASSPATH}"
 
-java $JAVA_OPTS -cp $CLASSPATH io.gatling.recorder.GatlingRecorder $@
+java $JAVA_OPTS -cp $CLASSPATH io.gatling.recorder.GatlingRecorder "$@"


### PR DESCRIPTION
I found this little bug today caused by a tiny little issue in the .sh files. They say in the help that I can pass in a short description via the `-sd` option. I would normally expect descriptions to use space, but they break the shell script since failing to quote `$@` is causing double word expansion.

Issuing this command will reproduce the issue which this PR solves:

```
$ ./bin/gatling.sh -sd "test test"
GATLING_HOME is set to /home/<user>/gatling
Error: Unknown argument 'test'

Usage: gatling [options] 

...
```
