### PR TITLE
Sphinx documentation support : first steps

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -5,8 +5,8 @@ import aether.WagonWrapper
 import aether.Aether._
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+import com.typesafe.sbt.SbtSite.site
 import sbtrelease.ReleasePlugin._
-
 import net.virtualvoid.sbt.graph.Plugin.graphSettings
 
 import Dependencies._
@@ -57,6 +57,12 @@ object BuildSettings {
 	lazy val noCodeToPublish = Seq(
 		publishArtifact in Compile := false
 	)
+
+	/****************************/
+	/** Documentation settings **/
+	/****************************/
+
+	lazy val docSettings = site.settings ++ site.sphinxSupport()
 
 	/**************************************/
 	/** gatling-charts specific settings **/

--- a/project/GatlingBuild.scala
+++ b/project/GatlingBuild.scala
@@ -19,6 +19,7 @@ object GatlingBuild extends Build {
 		.aggregate(core, jdbc, redis, http, charts, metrics, app, recorder, bundle)
 		.settings(basicSettings: _*)
 		.settings(noCodeToPublish: _*)
+		.settings(docSettings: _*)
 
 	/*************/
 	/** Modules **/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,8 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % "0.10")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7.1")
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
+
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")
 
 // Dependency needed for the WebDAV wagon

--- a/src/sphinx/conf.py
+++ b/src/sphinx/conf.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Gatling documentation build configuration
+
+import sys, os
+
+##############
+# Extensions #
+##############
+
+extensions = []
+
+################
+# Project info #
+################
+
+project = u'Gatling'
+copyright = u'2013, eBusiness Information'
+version = '2.0.0-SNAPSHOT'
+release = version
+
+####################
+# General settings #
+####################
+
+master_doc = 'index'
+add_function_parentheses = False
+highlight_language = 'scala'
+nitpicky = True
+
+###############
+# HTML output #
+###############
+
+html_title = "Gatling documentation"
+html_domain_indices = False
+html_use_index = False
+html_show_sourcelink = False
+html_show_sphinx = False
+htmlhelp_basename = 'Gatlingdoc'

--- a/src/sphinx/index.rst
+++ b/src/sphinx/index.rst
@@ -1,0 +1,2 @@
+Gatling documentation
+=====================


### PR DESCRIPTION
Setup the sbt-site plugin and a basic Sphinx configuration.
Publishing is not configured yet : we'll need to move our repos to the new organization before configuring the sbt-ghpages plugin](https://github.com/sbt/sbt-ghpages) with the correct repo to pushlish to.
