### PR TITLE
SBT build cleanup

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -35,7 +35,10 @@ object BuildSettings {
 		)
 	) ++ publishingSettings ++ releaseSettings
 
-	lazy val gatlingModuleSettings = basicSettings ++ formattingSettings ++ graphSettings
+	lazy val gatlingModuleSettings =
+		basicSettings ++ formattingSettings ++ graphSettings ++ Seq(
+			exportJars := true
+		)
 
 	/*************************/
 	/** Publishing settings **/

--- a/project/Bundle.scala
+++ b/project/Bundle.scala
@@ -6,9 +6,6 @@ import com.typesafe.sbt.packager.universal.Keys.packageZipTarball
 
 object Bundle {
 
-	val bundleAllClasspaths = taskKey[Seq[Classpath]]("Aggregated classpath of all modules")
-	val bundleAllDependencies = taskKey[Seq[File]]("Lists of all dependencies' JARs' paths")
-	val gatlingJars = taskKey[Seq[File]]("List of all Gatling jars")
 	val allJars = taskKey[Seq[File]]("List of all jars needed for the bundle")
 
 	val bundleArtifacts = {
@@ -21,21 +18,8 @@ object Bundle {
 	}
 
 	val bundleSettings = packagerSettings ++ bundleArtifacts ++ Seq(
-		bundleAllClasspaths <<= (thisProjectRef, buildStructure) flatMap aggregated(dependencyClasspath.task in Runtime),
-		bundleAllDependencies := bundleAllClasspaths.value.flatten.map(_.data).filter(ClasspathUtilities.isArchive).distinct,
-		gatlingJars <<= (thisProjectRef, buildStructure) flatMap aggregated(packageBin.task in Compile),
-		allJars := bundleAllDependencies.value ++ gatlingJars.value,
+		allJars := (fullClasspath in Runtime).value.map(_.data).filter(ClasspathUtilities.isArchive),
 		mappings in Universal ++= allJars.value.map(jar => jar -> ("lib/" + jar.getName))
 	)
-
-	def aggregated[T](task: SettingKey[Task[T]])(projectRef: ProjectRef, structure: BuildStructure) = {
-		val projects = aggregatedProjects(projectRef, structure)
-		projects flatMap { task in LocalProject(_) get structure.data } join
-	}
-
-	def aggregatedProjects(projectRef: ProjectRef, structure: BuildStructure): Seq[String] = {
-		val aggregate = Project.getProject(projectRef, structure).toSeq.flatMap(_.aggregate)
-		aggregate flatMap { ref => ref.project +: aggregatedProjects(ref, structure) }
-	}
 
 }

--- a/project/GatlingBuild.scala
+++ b/project/GatlingBuild.scala
@@ -18,7 +18,7 @@ object GatlingBuild extends Build {
 	lazy val root = Project("gatling-parent", file("."))
 		.aggregate(core, jdbc, redis, http, charts, metrics, app, recorder, bundle)
 		.settings(basicSettings: _*)
-		.settings(noCodeToPublish: _*)
+		.settings(noCodeToPublish: _*) // Doesn't work with aether-deploy
 		.settings(docSettings: _*)
 
 	/*************/
@@ -59,9 +59,9 @@ object GatlingBuild extends Build {
 		.dependsOn(core, http)
 		.settings(libraryDependencies ++= recorderDeps)
 
-	// FIXME : No need for aggregation if runtime dependencies could be part of gatling-bundle's classpath 
 	lazy val bundle = gatlingModule("gatling-bundle")
-		.aggregate(core, jdbc, redis, http, charts, metrics, app, recorder)
+		.dependsOn(Seq(app, recorder).map(_ % "runtime->runtime"): _*)
 		.settings(bundleSettings: _*)
-		.settings(noCodeToPublish: _*)
+		.settings(noCodeToPublish: _*) // Doesn't work with aether-deploy
+		.settings(exportJars := false) // Don't export gatling-bundle's jar 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,3 @@
-// Show deprecation and features warnings in SBT build file
-scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps")
-
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.1.0")


### PR DESCRIPTION
- No need for local Maven repo, as all artifacts can be fetched from local Ivy repo
- Prefer configuration mapping + `exportJars` to aggregation for `gatling-bundle` : bundles generation becomes MUCH simpler
