### PR TITLE
SBT build minor cleanup

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,8 +1,6 @@
 import sbt._
 import sbt.Keys._
 
-import aether.WagonWrapper
-import aether.Aether._
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.sbt.SbtSite.site
@@ -10,6 +8,7 @@ import sbtrelease.ReleasePlugin._
 import net.virtualvoid.sbt.graph.Plugin.graphSettings
 
 import Dependencies._
+import Publishing._
 
 object BuildSettings {
 
@@ -21,8 +20,6 @@ object BuildSettings {
 		licenses              := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.html")),
 		resolvers             := Seq(excilysNexus),
 		scalaVersion          := "2.10.3-RC2",
-		crossPaths            := false,
-		pomExtra              := scm ++ developersXml(developers),
 		scalacOptions         := Seq(
 			"-encoding",
 			"UTF-8",
@@ -38,23 +35,6 @@ object BuildSettings {
 	lazy val gatlingModuleSettings =
 		basicSettings ++ formattingSettings ++ graphSettings ++ Seq(
 			exportJars := true
-		)
-
-	/*************************/
-	/** Publishing settings **/
-	/*************************/
-
-	// TODO : split into snapshotSettings and releaseSettings
-	lazy val publishingSettings = 
-		aetherSettings ++ aetherPublishSettings ++ aetherPublishLocalSettings ++ Seq(
-			pomIncludeRepository := { _ => false },
-			wagons := {
-				if(isSnapshot.value) 
-					Seq(WagonWrapper("davs", "org.apache.maven.wagon.providers.webdav.WebDavWagon"))
-				else Seq.empty
-			},
-			publishTo := { if(isSnapshot.value) Some(cloudbeesSnapshots) else Some(excilysReleases) },
-			credentials += { if(isSnapshot.value) Credentials(file("/private/gatling/.credentials")) else Credentials(Path.userHome / ".sbt" / ".credentials") }
 		)
 
 	lazy val noCodeToPublish = Seq(
@@ -82,49 +62,6 @@ object BuildSettings {
 			compiledClassesMappings.filter { case (file, path) => !path.contains("io/gatling/charts/component/impl") }
 		}
 	)
-
-	/************************/
-	/** POM extra metadata **/
-	/************************/
-
-	private val scm = {
-		<scm>
-			<connection>scm:git:git@github.com:excilys/gatling.git</connection>
-			<developerConnection>scm:git:git@github.com:excilys/gatling.git</developerConnection>
-			<url>https://github.com/excilys/gatling</url>
-			<tag>HEAD</tag>
-		</scm>
-	}
-
-	case class GatlingDeveloper(emailAddress: String, name: String, isEbiz: Boolean)
-
-	val developers = Seq(
-		GatlingDeveloper("slandelle@excilys.com", "Stephane Landelle", true),
-		GatlingDeveloper("rsertelon@excilys.com", "Romain Sertelon", true),
-		GatlingDeveloper("ybenkhaled@excilys.com", "Yassine Ben Khaled", true),
-		GatlingDeveloper("hcordier@excilys.com", "Hugo Cordier", true),
-		GatlingDeveloper("nremond@gmail.com", "Nicolas Rémond", false),
-		GatlingDeveloper("skuenzli@gmail.com", "Stephen Kuenzli", false),
-		GatlingDeveloper("pdalpra@excilys.com", "Pierre Dal-Pra", true),
-		GatlingDeveloper("gcoutant@excilys.com", "Grégory Coutant", true),
-		GatlingDeveloper("blemale@excilys.com", "Bastien Lemale", true),
-		GatlingDeveloper("aduffy@gilt.com", "Andrew Duffy", false)
-	)
-
-	private def developersXml(devs: Seq[GatlingDeveloper]) = {
-		<developers>
-		{
-			for(dev <- devs)
-			yield {
-				<developer>
-					<id>{dev.emailAddress}</id>
-					<name>{dev.name}</name>
-					{ if (dev.isEbiz) <organization>eBusiness Information, Excilys Group</organization> }
-				</developer>
-			}
-		}
-		</developers>
-	}
 
 	/*************************/
 	/** Formatting settings **/

--- a/project/GatlingBuild.scala
+++ b/project/GatlingBuild.scala
@@ -18,7 +18,7 @@ object GatlingBuild extends Build {
 	lazy val root = Project("gatling-parent", file("."))
 		.aggregate(core, jdbc, redis, http, charts, metrics, app, recorder, bundle)
 		.settings(basicSettings: _*)
-		.settings(noCodeToPublish: _*) // Doesn't work with aether-deploy
+		.settings(noCodeToPublish: _*) // Still publish main JAR with aether-deploy
 		.settings(docSettings: _*)
 
 	/*************/
@@ -62,6 +62,6 @@ object GatlingBuild extends Build {
 	lazy val bundle = gatlingModule("gatling-bundle")
 		.dependsOn(Seq(app, recorder).map(_ % "runtime->runtime"): _*)
 		.settings(bundleSettings: _*)
-		.settings(noCodeToPublish: _*) // Doesn't work with aether-deploy
+		.settings(noCodeToPublish: _*) // Still publish main JAR with aether-deploy
 		.settings(exportJars := false) // Don't export gatling-bundle's jar 
 }

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -1,0 +1,84 @@
+import sbt._
+import sbt.Keys._
+
+import aether.WagonWrapper
+import aether.Aether._
+
+import Dependencies._
+
+object Publishing {
+
+	/*************************/
+	/** Publishing settings **/
+	/*************************/
+
+	lazy val allAetherSettings = aetherPublishSettings ++ aetherPublishLocalSettings
+
+	lazy val publishingSettings = allAetherSettings ++ Seq(
+		crossPaths           := false,
+		pomExtra             := scm ++ developersXml(developers),
+		pomIncludeRepository := { _ => false },
+		wagons := {
+			if(isSnapshot.value) 
+				Seq(WagonWrapper("davs", "org.apache.maven.wagon.providers.webdav.WebDavWagon"))
+			else
+				Seq.empty
+			},
+		publishTo := {
+			if(isSnapshot.value)
+				Some(cloudbeesSnapshots)
+			else
+				Some(excilysReleases)
+			},
+		credentials += {
+			if(isSnapshot.value)
+				Credentials(file("/private/gatling/.credentials"))
+			else
+				Credentials(Path.userHome / ".sbt" / ".credentials")
+			}
+		)
+
+	/************************/
+	/** POM extra metadata **/
+	/************************/
+
+	private val scm = {
+		<scm>
+			<connection>scm:git:git@github.com:excilys/gatling.git</connection>
+			<developerConnection>scm:git:git@github.com:excilys/gatling.git</developerConnection>
+			<url>https://github.com/excilys/gatling</url>
+			<tag>HEAD</tag>
+		</scm>
+	}
+
+	private case class GatlingDeveloper(emailAddress: String, name: String, isEbiz: Boolean)
+
+	private val developers = Seq(
+		GatlingDeveloper("slandelle@excilys.com", "Stephane Landelle", true),
+		GatlingDeveloper("rsertelon@excilys.com", "Romain Sertelon", true),
+		GatlingDeveloper("ybenkhaled@excilys.com", "Yassine Ben Khaled", true),
+		GatlingDeveloper("hcordier@excilys.com", "Hugo Cordier", true),
+		GatlingDeveloper("nremond@gmail.com", "Nicolas Rémond", false),
+		GatlingDeveloper("skuenzli@gmail.com", "Stephen Kuenzli", false),
+		GatlingDeveloper("pdalpra@excilys.com", "Pierre Dal-Pra", true),
+		GatlingDeveloper("gcoutant@excilys.com", "Grégory Coutant", true),
+		GatlingDeveloper("blemale@excilys.com", "Bastien Lemale", true),
+		GatlingDeveloper("aduffy@gilt.com", "Andrew Duffy", false)
+	)
+
+	private def developersXml(devs: Seq[GatlingDeveloper]) = {
+		<developers>
+		{
+			for(dev <- devs)
+			yield {
+				<developer>
+					<id>{dev.emailAddress}</id>
+					<name>{dev.name}</name>
+					{ if (dev.isEbiz) <organization>eBusiness Information, Excilys Group</organization> }
+				</developer>
+			}
+		}
+		</developers>
+	}
+
+}


### PR DESCRIPTION
- Move publishing related settings to a separate object
- Small change to `noCodeToPublish` comment, to reflect its real effect: this setting works _a bit_, as it avoids publishing sources & scaladoc, but the main artifact still get published with aether-deploy. 
