### PR TITLE
Publish Gatling to Sonatype OSS, close #1372

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -8,7 +8,6 @@ import sbtrelease.ReleasePlugin._
 import net.virtualvoid.sbt.graph.Plugin.graphSettings
 import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 
-import Dependencies._
 import Publishing._
 
 object BuildSettings {
@@ -19,7 +18,6 @@ object BuildSettings {
 		organizationHomepage  := Some(new URL("http://gatling.io")),
 		startYear             := Some(2011),
 		licenses              := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.html")),
-		resolvers             := Seq(excilysNexus),
 		scalaVersion          := "2.10.3",
 		scalacOptions         := Seq(
 			"-encoding",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,10 +1,6 @@
 import sbt._
 
-object Dependencies {
-
-	val excilysNexus = "Excilys Nexus" at "http://repository.excilys.com/content/groups/public"
-	val excilysReleases = "Excilys Releases" at "http://repository.excilys.com/content/repositories/releases"
-	val cloudbeesSnapshots = "Cloudbees Private Repository" at "davs://repository-gatling.forge.cloudbees.com/snapshot"
+object Dependencies { 
 
 	private val scalaCompiler     = "org.scala-lang"        % "scala-compiler"     % "2.10.3"
 	private val scalaReflect      = "org.scala-lang"        % "scala-reflect"      % "2.10.3"
@@ -45,7 +41,8 @@ object Dependencies {
 
 	val coreDeps = Seq(
 		scalaCompiler, akkaActor, saxon, jodaTime, jodaConvert, slf4jApi, scalalogging, scalaReflect, jsonSmart,
-		jaywayJsonPath, gatlingJsonpath, commonsMath, jsoup, joddLagarto, commonsIo, config, fastring, openCsv, logbackClassic) ++ testDeps
+		jaywayJsonPath, gatlingJsonpath, commonsMath, jsoup, joddLagarto, commonsIo, config, fastring, openCsv, logbackClassic
+	) ++ testDeps
 
 	val redisDeps = Seq(redisClient) ++ testDeps
 

--- a/project/GatlingBuild.scala
+++ b/project/GatlingBuild.scala
@@ -18,7 +18,7 @@ object GatlingBuild extends Build {
 	lazy val root = Project("gatling-parent", file("."))
 		.aggregate(core, jdbc, redis, http, charts, metrics, app, recorder, bundle)
 		.settings(basicSettings: _*)
-		.settings(noCodeToPublish: _*) // Still publish main JAR with aether-deploy
+		.settings(noCodeToPublish: _*)
 		.settings(docSettings: _*)
 
 	/*************/
@@ -63,6 +63,6 @@ object GatlingBuild extends Build {
 	lazy val bundle = gatlingModule("gatling-bundle")
 		.dependsOn(Seq(app, recorder).map(_ % "runtime->runtime"): _*)
 		.settings(bundleSettings: _*)
-		.settings(noCodeToPublish: _*) // Still publish main JAR with aether-deploy
+		.settings(noCodeToPublish: _*)
 		.settings(exportJars := false) // Don't export gatling-bundle's jar 
 }

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -1,10 +1,7 @@
 import sbt._
 import sbt.Keys._
 
-import aether.WagonWrapper
-import aether.Aether._
-
-import Dependencies._
+import Resolvers._
 
 object Publishing {
 
@@ -12,31 +9,14 @@ object Publishing {
 	/** Publishing settings **/
 	/*************************/
 
-	lazy val allAetherSettings = aetherPublishSettings ++ aetherPublishLocalSettings
-
-	lazy val publishingSettings = allAetherSettings ++ Seq(
+	lazy val publishingSettings = Seq(
 		crossPaths           := false,
 		pomExtra             := scm ++ developersXml(developers),
+		publishMavenStyle    := true,
 		pomIncludeRepository := { _ => false },
-		wagons := {
-			if(isSnapshot.value) 
-				Seq(WagonWrapper("davs", "org.apache.maven.wagon.providers.webdav.WebDavWagon"))
-			else
-				Seq.empty
-			},
-		publishTo := {
-			if(isSnapshot.value)
-				Some(cloudbeesSnapshots)
-			else
-				Some(excilysReleases)
-			},
-		credentials += {
-			if(isSnapshot.value)
-				Credentials(file("/private/gatling/.credentials"))
-			else
-				Credentials(Path.userHome / ".sbt" / ".credentials")
-			}
-		)
+		publishTo            := Some(if(isSnapshot.value) sonatypeSnapshots else sonatypeStaging),
+		credentials          += Credentials(Path.userHome / ".sbt" / ".credentials")
+	)
 
 	/************************/
 	/** POM extra metadata **/

--- a/project/Resolvers.scala
+++ b/project/Resolvers.scala
@@ -1,0 +1,9 @@
+import sbt._
+
+object Resolvers {
+
+	private val sonatypeRoot = "https://oss.sonatype.org/"
+
+	val sonatypeSnapshots = "Sonatype Snapshots" at sonatypeRoot + "content/repositories/snapshots/"
+	val sonatypeStaging   = "Sonatype Staging"   at sonatypeRoot + "service/local/staging/deploy/maven2/"
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,13 +4,10 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.6.2")
 
-addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % "0.10")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
-// Dependency needed for the WebDAV wagon
-libraryDependencies += "org.apache.maven.wagon" % "wagon-webdav-jackrabbit" % "2.4"
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")


### PR DESCRIPTION
This PR makes the necessary changes to SBT build definition to publish to Sonatype repositories :
- Revert to Saxon published in Central, to comply to Sonatype OSS dependency policy
- Removal of the Excilys Nexus resolvers, since all required dependencies are hosted in Central
- Removal of the aether-deploy plugin, which was needed for publishing to Cloudbees snapshots repositories.
- Add the sbt-pgp plugin, to sign published artifacts (public GPG keys are needed)

This also fixes an issue we had with the aether-deploy plugin: JARs were published for `gatling-parent` and `gatling-parent`, even if JAR publishing was explicitly disabled for those two modules.
