### PR TITLE
Fixed two issues in BytesInputStream.read

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/util/BytesInputStream.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/util/BytesInputStream.scala
@@ -59,10 +59,10 @@ class BytesInputStream(array: Array[Byte]) extends InputStream {
 	}
 
 	override def read(b: Array[Byte], offset: Int, length: Int): Int = {
-		if (length == position) {
+		if (this.length == position) {
 			if (length == 0) 0 else -1
 		} else {
-			val n = math.min(length, length - position)
+			val n = math.min(length, available)
 			System.arraycopy(array, offset + position, b, offset, n)
 			position += n
 			n

--- a/gatling-core/src/test/scala/io/gatling/core/util/BytesInputStreamSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/util/BytesInputStreamSpec.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2011-2013 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.core.util
+
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+
+import io.gatling.core.test.ValidationSpecification
+
+@RunWith(classOf[JUnitRunner])
+class BytesInputStreamSpec extends ValidationSpecification {
+
+	"BytesInputStream" should {
+
+		val bytes = "test string".getBytes("utf-8")
+
+		"signal eof when all bytes are read" in {
+			val byteStream = new BytesInputStream(bytes)
+			byteStream.read(bytes, 0, bytes.length)
+			byteStream.read(bytes, 0, 1) should beEqualTo(-1)
+		}
+
+		"not allow to read more than available bytes" in {
+			val byteStream = new BytesInputStream(bytes)
+			byteStream.read(bytes, 0, bytes.length + 1) should beEqualTo(bytes.length)
+		}
+	}
+}


### PR DESCRIPTION
The check to determine if all bytes were read used the wrong length
variable (local instead of field). This potentially caused the stream to never
report eof and some stream operations would never terminate.

The check to prevent reading more bytes than available also used the
wrong lenght variable (local instead of field). This caused an
ArrayIndexOutOfBoudsException in System.arraycopy().
