### PR TITLE
Allow to get rid of the pause

### DIFF
--- a/gatling-bundle/src/universal/bin/gatling.bat
+++ b/gatling-bundle/src/universal/bin/gatling.bat
@@ -59,6 +59,6 @@ echo Please set GATLING_HOME and try to launch Gatling again.
 goto exit
 
 :exit
-pause
+if not defined NO_PAUSE pause
 endlocal
 exit /b 0


### PR DESCRIPTION
Useful to launch multiple gatling un a batch file
