### PR TITLE
If the entered 'simulation id' isn't proper, ask again.

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
@@ -16,9 +16,13 @@
 package io.gatling.app
 
 import java.lang.System.currentTimeMillis
+
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.util.Try
+
 import com.typesafe.scalalogging.slf4j.StrictLogging
+
 import io.gatling.app.CommandLineConstants._
 import io.gatling.charts.report.ReportsGenerator
 import io.gatling.core.assertion.Assertion
@@ -30,7 +34,6 @@ import io.gatling.core.runner.{ Runner, Selection }
 import io.gatling.core.scenario.Simulation
 import io.gatling.core.util.StringHelper.RichString
 import scopt.OptionParser
-import scala.annotation.tailrec
 
 /**
  * Object containing entry point of application


### PR DESCRIPTION
Before, the following exception was thrown : 

```
[] nre@~/Desktop/gatling-charts-highcharts-2.0.0-M3a/bin: ./gatling.sh 
GATLING_HOME is set to /home/nre/Desktop/gatling-charts-highcharts-2.0.0-M3a
basic.ItrNihonSimulation is the only simulation, executing it.
Select simulation id (default is 'itrnihonsimulation'). Accepted characters are a-z, A-Z, 0-9, - and _
^[[A
Exception in thread "main" java.lang.IllegalArgumentException: requirement failed: [A contains illegal characters
    at scala.Predef$.require(Predef.scala:233)
    at io.gatling.app.Gatling.io$gatling$app$Gatling$$interactiveSelect$1(Gatling.scala:137)
    at io.gatling.app.Gatling$$anonfun$18$$anonfun$21.apply(Gatling.scala:186)
    at io.gatling.app.Gatling$$anonfun$18$$anonfun$21.apply(Gatling.scala:186)
    at scala.Option.getOrElse(Option.scala:120)
    at io.gatling.app.Gatling$$anonfun$18.apply(Gatling.scala:186)
    at io.gatling.app.Gatling$$anonfun$18.apply(Gatling.scala:180)
    at scala.Option.getOrElse(Option.scala:120)
    at io.gatling.app.Gatling.start(Gatling.scala:180)
    at io.gatling.app.Gatling$.fromMap(Gatling.scala:59)
    at io.gatling.app.Gatling$.runGatling(Gatling.scala:80)
    at io.gatling.app.Gatling$.main(Gatling.scala:54)
    at io.gatling.app.Gatling.main(Gatling.scala)
```
