### PR TITLE
Add mute mode for SBT plugin

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/CommandLineConstants.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/CommandLineConstants.scala
@@ -39,4 +39,6 @@ object CommandLineConstants {
 	val OUTPUT_DIRECTORY_BASE_NAME_SHORT = "on"
 	val SIMULATION_DESCRIPTION = "simulation-description"
 	val SIMULATION_DESCRIPTION_SHORT = "sd"
+	val MUTE = "mute"
+	val MUTE_SHORT = "m"
 }

--- a/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
@@ -60,6 +60,7 @@ object Gatling {
 		val cliOptsParser = new OptionParser[Unit]("gatling") {
 			help(HELP).abbr(HELP_SHORT).text("Show help (this message) and exit")
 			opt[Unit](NO_REPORTS).abbr(NO_REPORTS_SHORT).foreach(_ => props.noReports).text("Runs simulation but does not generate reports")
+			opt[Unit](MUTE).abbr(MUTE_SHORT).foreach(_ => props.mute).text("Runs in mute mode : don't asks for run description nor simulation ID, use defaults").hidden()
 			opt[String](REPORTS_ONLY).abbr(REPORTS_ONLY_SHORT).foreach(props.reportsOnly).valueName("<directoryName>").text("Generates the reports for the simulation in <directoryName>")
 			opt[String](DATA_FOLDER).abbr(DATA_FOLDER_SHORT).foreach(props.dataDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where feeders are stored")
 			opt[String](RESULTS_FOLDER).abbr(RESULTS_FOLDER_SHORT).foreach(props.resultsDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where results are stored")
@@ -88,6 +89,7 @@ class Gatling(simulationClass: Option[Class[Simulation]]) extends StrictLogging 
 
 		def interactiveSelect(simulations: List[Class[Simulation]]): Selection = {
 
+			@tailrec
 			def selectSimulationClass(simulations: List[Class[Simulation]]): Class[Simulation] = {
 
 				def readSimulationNumber: Int =
@@ -199,7 +201,15 @@ class Gatling(simulationClass: Option[Class[Simulation]]) extends StrictLogging 
 						new Selection(simulation, outputDirectoryBaseName, runDescription)
 
 					case None =>
-						interactiveSelect(simulations)
+						if (configuration.core.muteMode)
+							simulationClass match {
+								case Some(clazz) =>
+									Selection(clazz, defaultOutputDirectoryBaseName(clazz), "")
+								case None =>
+									throw new UnsupportedOperationException("Mute mode is currently uses by Gatling SBT plugin only.")
+							}
+						else
+							interactiveSelect(simulations)
 				}
 
 				val (runId, simulation) = new Runner(selection).run

--- a/gatling-core/src/main/resources/gatling-defaults.conf
+++ b/gatling-core/src/main/resources/gatling-defaults.conf
@@ -11,6 +11,7 @@ gatling {
 		encoding = "utf-8"							# encoding for every file manipulation made in gatling
 		simulationClass = ""
 		disableCompiler = false						# set to true to pass a simulationClass to be loaded directly from classpath
+		mute = false
 		extract {
 			regex {
 				cache = true

--- a/gatling-core/src/main/scala/io/gatling/core/ConfigurationConstants.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/ConfigurationConstants.scala
@@ -22,6 +22,7 @@ object ConfigurationConstants {
 	val CONF_CORE_ENCODING = "gatling.core.encoding"
 	val CONF_CORE_SIMULATION_CLASS = "gatling.core.simulationClass"
 	val CONF_CORE_DISABLE_COMPILER = "gatling.core.disableCompiler"
+	val CONF_CORE_MUTE = "gatling.core.mute"
 
 	val CONF_CORE_EXTRACT_REGEXP_CACHE = "gatling.core.extract.regex.cache"
 	val CONF_CORE_EXTRACT_XPATH_CACHE = "gatling.core.extract.xpath.cache"

--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
@@ -57,6 +57,7 @@ object GatlingConfiguration {
 				encoding = config.getString(CONF_CORE_ENCODING),
 				simulationClass = config.getString(CONF_CORE_SIMULATION_CLASS).trimToOption,
 				disableCompiler = config.getBoolean(CONF_CORE_DISABLE_COMPILER),
+				muteMode = config.getBoolean(CONF_CORE_MUTE),
 				extract = ExtractConfiguration(
 					regex = RegexConfiguration(
 						cache = config.getBoolean(CONF_CORE_EXTRACT_REGEXP_CACHE)),
@@ -203,6 +204,7 @@ case class CoreConfiguration(
 	extract: ExtractConfiguration,
 	timeOut: TimeOutConfiguration,
 	directory: DirectoryConfiguration,
+	muteMode: Boolean,
 	zinc: ZincConfiguration) {
 
 	val charSet = Charset.forName(encoding)

--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingPropertiesBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingPropertiesBuilder.scala
@@ -23,6 +23,8 @@ class GatlingPropertiesBuilder {
 
 	private val props = mutable.Map.empty[String, Any]
 
+	def mute { props += CONF_CORE_MUTE -> true }
+
 	def noReports { props += CONF_CHARTING_NO_REPORTS -> true }
 
 	def reportsOnly(v: String) { props += CONF_CORE_DIRECTORY_REPORTS_ONLY -> v }


### PR DESCRIPTION
Brought back the current implementation of mute mode, as incomplete as it is.
Proper implementation and availability for all running mode will come along a major refactoring of Gatling's main method.
