### PR TITLE
Clearer error message for exceptions happening in the Netty stack

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandler.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandler.scala
@@ -90,7 +90,11 @@ class AsyncHandler(tx: HttpTx) extends ProgressAsyncHandler[Unit] with AsyncHand
 	}
 
 	def sendOnThrowable(throwable: Throwable) {
-		val errorMessage = throwable.getClass.getName + Option(throwable.getMessage).map(": " + _).getOrElse("")
+		val className = throwable.getClass.getName
+		val errorMessage = throwable.getMessage match {
+			case null => className
+			case m => s"$className: $m"
+		}
 
 		if (logger.underlying.isInfoEnabled)
 			logger.warn(s"Request '${tx.requestName}' failed for user ${tx.session.userId}", throwable)


### PR DESCRIPTION
I got that message in the _error_ section of the report with a server that is messing stuff up with load. 
`For input string: "ilySubType>SINGLE_ENTRY4101919062Catￃﾩgorie"`

It's not really possible to understand the meaning without actually having the exception that was:

```
15:46:13.377 [WARN ] i.g.h.a.AsyncHandler - Request 'createOrUpdateOrder' failed
java.lang.NumberFormatException: For input string: "ilySubType><productFamilyType>SINGLE_ENTRY</productFamilyType><productId>410191906</productId><quantity>2</quantity><seatCategory>Catￃﾩgorie"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[na:1.7.0_45]
    at java.lang.Integer.parseInt(Integer.java:492) ~[na:1.7.0_45]
    at org.jboss.netty.handler.codec.http.HttpMessageDecoder.getChunkSize(HttpMessageDecoder.java:621) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.codec.http.HttpMessageDecoder.decode(HttpMessageDecoder.java:318) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.codec.http.HttpClientCodec$Decoder.decode(HttpClientCodec.java:143) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.codec.http.HttpClientCodec$Decoder.decode(HttpClientCodec.java:127) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.codec.replay.ReplayingDecoder.callDecode(ReplayingDecoder.java:500) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.codec.replay.ReplayingDecoder.messageReceived(ReplayingDecoder.java:485) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.codec.http.HttpClientCodec.handleUpstream(HttpClientCodec.java:92) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:268) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:255) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:88) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.socket.nio.AbstractNioWorker.process(AbstractNioWorker.java:109) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:312) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:90) ~[netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178) ~[netty-3.6.6.Final.jar:na]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_45]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_45]
    at java.lang.Thread.run(Thread.java:744) [na:1.7.0_45]
```
