### PR TITLE
Unify Scaladoc using Unidoc plugin

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -5,6 +5,7 @@ import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.sbt.SbtSite.site
 import net.virtualvoid.sbt.graph.Plugin.graphSettings
+import sbtunidoc.Plugin.{ ScalaUnidoc, unidocSettings }
 
 import Resolvers._
 
@@ -52,7 +53,9 @@ object BuildSettings {
 	/** Documentation settings **/
 	/****************************/
 
-	lazy val docSettings = site.settings ++ site.sphinxSupport()
+	lazy val docSettings = unidocSettings ++ site.settings ++ site.sphinxSupport() ++ Seq(
+		site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "latest/api")
+	)
 
 	/**************************************/
 	/** gatling-charts specific settings **/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")


### PR DESCRIPTION
In this PR :
- Unify Scaladoc for all modules into a single directory (`gatling/target/unidoc` by default)
- Allow to preview Scaladoc using sbt-site's `previewSite`, the documentation will be available at `localhost:4000/latest/api/`
