### PR TITLE
Fixed bug when generating reports with nested groups

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/report/StatsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/StatsReportGenerator.scala
@@ -89,19 +89,20 @@ class StatsReportGenerator(runOn: String, dataReader: DataReader, componentLibra
 		val groupStatsPaths = statsPaths.collect { case path: GroupStatsPath => path.group.hierarchy.reverse -> path }.toMap
 		val seenGroups = collection.mutable.HashSet.empty[List[String]]
 
-		@tailrec
 		def addGroupsRec(hierarchy: List[String]) {
 
 			if (!seenGroups.contains(hierarchy)) {
 				seenGroups += hierarchy
-				val group = groupStatsPaths(hierarchy).group
-				val stats = computeGroupStats(group.name, group)
-				rootContainer.addGroup(group, stats)
 
 				hierarchy match {
 					case head :: tail if !tail.isEmpty => addGroupsRec(tail)
 					case _ =>
 				}
+
+				val group = groupStatsPaths(hierarchy).group
+				val stats = computeGroupStats(group.name, group)
+				rootContainer.addGroup(group, stats)
+
 			}
 		}
 


### PR DESCRIPTION
When generating a report with nested groups, Gatling would die with an error about missing keys. This is because it assumed that parent groups were added before children, but parent groups were being added after children (possibly as a tail recursion optimisation), thus the keys were missing.
