### PR TITLE
Fix recorder embedded resources fetching

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
@@ -2,11 +2,15 @@ package io.gatling.recorder.scenario
 
 import scala.concurrent.duration.{ Duration, DurationLong }
 
+import org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
+
 import com.typesafe.scalalogging.slf4j.StrictLogging
 
 import io.gatling.http.util.HttpHelper
 import io.gatling.recorder.config.RecorderConfiguration
+import io.gatling.recorder.scenario.RequestElement.htmlContentType
 import io.gatling.recorder.util.collection.RichSeq
+
 
 case class ScenarioDefinition(elements: Seq[ScenarioElement]) {
 	def isEmpty = elements.isEmpty
@@ -23,16 +27,16 @@ object ScenarioDefinition extends StrictLogging {
 		groupedRequests.map {
 			case (firstArrivalTime, firstReq) :: redirectedReqs if !redirectedReqs.isEmpty => {
 				val (lastArrivalTime, lastReq) = redirectedReqs.last
-				(firstArrivalTime, firstReq.copy(statusCode = lastReq.statusCode)) :: Nil
+				(firstArrivalTime, firstReq.copy(statusCode = lastReq.statusCode, embeddedResources = lastReq.embeddedResources)) :: Nil
 			}
 			case reqs => reqs
 		}.flatten
 	}
 
-	private def hasEmbeddedResources(t: (Long, RequestElement)) = t._2.embeddedResources.isEmpty
+	private def hasHtmlContentType(t: (Long, RequestElement)) = t._2.headers.get(CONTENT_TYPE).collect{case htmlContentType(_) => true}.getOrElse(false)
 
 	private def filterFetchedResources(requests: Seq[(Long, RequestElement)]): Seq[(Long, RequestElement)] = {
-		val groupedRequests = requests.splitWhen(hasEmbeddedResources)
+		val groupedRequests = requests.splitWhen(hasHtmlContentType)
 
 		groupedRequests.map {
 			case (time, request) :: t if !request.embeddedResources.isEmpty => {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioElement.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioElement.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConversions.asScalaBuffer
 import scala.concurrent.duration.FiniteDuration
 import scala.io.Codec.UTF8
 
-import org.jboss.netty.handler.codec.http.{ HttpRequest, HttpResponse }
+import org.jboss.netty.handler.codec.http.{HttpMessage, HttpRequest, HttpResponse}
 import org.jboss.netty.handler.codec.http.HttpHeaders.Names.{ AUTHORIZATION, CONTENT_TYPE }
 import org.jboss.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED
 
@@ -45,21 +45,22 @@ object RequestElement {
 
 	val htmlContentType = """(?i)text/html\s*(;\s+charset=(.+))?""".r
 
-	def apply(request: HttpRequest, response: HttpResponse): RequestElement = {
-		val requestHeaders: Map[String, String] = request.headers.entries.map { entry => (entry.getKey, entry.getValue) }.toMap
-		val responseContentType = requestHeaders.get(CONTENT_TYPE)
+  private def extractContent(message: HttpMessage)=
+    if (message.getContent.readableBytes > 0) {
+      val bufferBytes = new Array[Byte](message.getContent.readableBytes)
+      message.getContent.getBytes(message.getContent.readerIndex, bufferBytes)
+      Some(bufferBytes)
+    } else None
 
-		val contentBuff = if (request.getContent.readableBytes > 0) {
-			val bufferBytes = new Array[Byte](request.getContent.readableBytes)
-			request.getContent.getBytes(request.getContent.readerIndex, bufferBytes)
-			Some(bufferBytes)
-		} else None
+  def apply(request: HttpRequest, response: HttpResponse): RequestElement = {
+    val requestHeaders: Map[String, String] = request.headers.entries.map { entry => (entry.getKey, entry.getValue) }.toMap
+    val responseContentType = Option(response.headers().get(CONTENT_TYPE))
 
-		val resources = responseContentType.collect {
+    val resources = responseContentType.collect {
 			case htmlContentType(_, headerCharset) => {
 				val charsetName = Option(headerCharset).filter(Charset.isSupported).getOrElse(UTF8.name)
 				val charset = Charset.forName(charsetName)
-				contentBuff.map(bytes => {
+        extractContent(response).map(bytes => {
 					val htmlBuff = new String(bytes, charset).toCharArray
 					HtmlParser.getEmbeddedResources(new URI(request.getUri), htmlBuff)
 				})
@@ -67,7 +68,8 @@ object RequestElement {
 		}.flatten.getOrElse(Nil)
 
 		val containsFormParams = responseContentType.exists(_.contains(APPLICATION_X_WWW_FORM_URLENCODED))
-		val body = contentBuff.map(content =>
+
+    val requestBody = extractContent(request).map(content =>
 			if (containsFormParams)
 				// The payload consists of a Unicode string using only characters in the range U+0000 to U+007F
 				// cf: http://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-decoding-algorithm
@@ -75,7 +77,7 @@ object RequestElement {
 			else
 				RequestBodyBytes(content))
 
-		RequestElement(new String(request.getUri), request.getMethod.toString, requestHeaders, body, response.getStatus.getCode, resources)
+		RequestElement(new String(request.getUri), request.getMethod.toString, requestHeaders, requestBody, response.getStatus.getCode, resources)
 	}
 }
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
@@ -16,6 +16,7 @@
 package io.gatling.recorder.scenario.template
 
 import io.gatling.recorder.enumeration.FilterStrategy._
+import io.gatling.core.util.StringHelper.emptyFastring
 import io.gatling.core.util.StringHelper.eol
 import io.gatling.recorder.config.RecorderConfiguration
 import io.gatling.recorder.scenario.ProtocolDefinition.baseHeaders
@@ -60,7 +61,7 @@ object ProtocolTemplate {
 			val patterns = filtersConfig.filterStrategy match {
 				case WHITELIST_FIRST => fast"$whitelistPatterns, $backlistPatterns"
 				case BLACKLIST_FIRST => fast"$backlistPatterns, $whitelistPatterns"
-				case DISABLED => fast"white = WhiteList()"
+				case DISABLED => emptyFastring
 			}
 
 			fast"$eol$indent.fetchHtmlResources($patterns)"

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/util/collection.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/util/collection.scala
@@ -16,7 +16,7 @@ object collection {
 		def splitWhen(p: T => Boolean): List[List[T]] =
 			elts.foldLeft(List.empty[List[T]])({
 				case (Nil, x) => List(x) :: Nil
-				case (l @ (h :: t), x) => if (p(x)) (x :: h) :: t else List(x) :: l
-			}).map(_.reverse).reverse
+				case (l @ (h :: t), x) => if (p(x)) List(x) :: l else (x :: h) :: t
+      }).map(_.reverse).reverse
 	}
 }

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/ScenarioSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/ScenarioSpec.scala
@@ -17,6 +17,7 @@ package io.gatling.recorder.scenario
 
 import java.net.URI
 
+import org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -43,14 +44,18 @@ class ScenarioSpec extends Specification {
 		}
 
 		"filter out embedded resources of HTML documents" in {
-			val r1 = RequestElement("http://gatling.io", "GET", Map.empty, None, 200,
+			val r1 = RequestElement("http://gatling.io", "GET", Map(CONTENT_TYPE -> "text/html"), None, 200,
 				List(CssResource(new URI("http://gatling.io/main.css")), RegularResource(new URI("http://gatling.io/img.jpg"))))
 			val r2 = RequestElement("http://gatling.io/main.css", "GET", Map.empty, None, 200, List.empty)
-			val r3 = RequestElement("http://gatling.io/img.jpg", "GET", Map.empty, None, 200, List.empty)
+			val r3 = RequestElement("http://gatling.io/img.jpg", "GET", Map(CONTENT_TYPE -> "text/css"), None, 200, List.empty)
 			val r4 = RequestElement("http://gatling.io/details.html", "GET", Map.empty, None, 200, List.empty)
+      val r5 = RequestElement("http://gatling.io", "GET", Map(CONTENT_TYPE -> "text/html;charset=UTF-8"), None, 200,
+        List(CssResource(new URI("http://gatling.io/main.css"))))
+      val r6 = RequestElement("http://gatling.io/main.css", "GET", Map.empty, None, 200, List.empty)
 
-			val scn = ScenarioDefinition(List(1l -> r1, 2l -> r2, 3l -> r3, 4l -> r4), List.empty)
-			scn.elements should beEqualTo(List(r1, r4))
+
+			val scn = ScenarioDefinition(List(1l -> r1, 2l -> r2, 3l -> r3, 4l -> r4, 5l -> r5, 6l -> r6), List.empty)
+			scn.elements should beEqualTo(List(r1, r4, r5))
 		}
 	}
 

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/util/RichSeqSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/util/RichSeqSpec.scala
@@ -44,7 +44,7 @@ class RichSeqSpec extends Specification {
 		"split the current sequence everytime the predicate applies" in {
 			val xs = List(1, 2, 2, 3, 3, 4, 4, 5)
 			val rs = xs.splitWhen((x: Int) => x % 2 == 0)
-			rs must beEqualTo(List(List(1, 2, 2), List(3), List(3, 4, 4), List(5)))
+			rs must beEqualTo(List(List(1), List(2), List(2, 3, 3), List(4), List(4, 5)))
 		}
 	}
 


### PR DESCRIPTION
- Remove white = WhiteList() if filter strategy is disabled.
- Parse response body for embedded resources instead of request body.
- Copy embedded resources in resulting RequestElement on redirection filtering.
- Fix splitWhen function : split Seq when predicate is true, not false.
- Use Html content type to split requests instead of embedded resources presence.
