### PR TITLE
Use presence of embedded resource for split requests list.

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
@@ -32,10 +32,10 @@ object ScenarioDefinition extends StrictLogging {
 		}.flatten
 	}
 
-	private def hasHtmlContentType(t: (Long, RequestElement)) = t._2.headers.get(CONTENT_TYPE).collect { case htmlContentType(_) => true }.getOrElse(false)
+	private def hasEmbeddedResources(t: (Long, RequestElement)) = !t._2.embeddedResources.isEmpty
 
 	private def filterFetchedResources(requests: Seq[(Long, RequestElement)]): Seq[(Long, RequestElement)] = {
-		val groupedRequests = requests.splitWhen(hasHtmlContentType)
+		val groupedRequests = requests.splitWhen(hasEmbeddedResources)
 
 		groupedRequests.map {
 			case (time, request) :: t if !request.embeddedResources.isEmpty => {

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/ScenarioSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/ScenarioSpec.scala
@@ -44,12 +44,12 @@ class ScenarioSpec extends Specification {
 		}
 
 		"filter out embedded resources of HTML documents" in {
-			val r1 = RequestElement("http://gatling.io", "GET", Map(CONTENT_TYPE -> "text/html"), None, 200,
+			val r1 = RequestElement("http://gatling.io", "GET", Map.empty, None, 200,
 				List(CssResource(new URI("http://gatling.io/main.css")), RegularResource(new URI("http://gatling.io/img.jpg"))))
 			val r2 = RequestElement("http://gatling.io/main.css", "GET", Map.empty, None, 200, List.empty)
-			val r3 = RequestElement("http://gatling.io/img.jpg", "GET", Map(CONTENT_TYPE -> "text/css"), None, 200, List.empty)
+			val r3 = RequestElement("http://gatling.io/img.jpg", "GET", Map.empty, None, 200, List.empty)
 			val r4 = RequestElement("http://gatling.io/details.html", "GET", Map.empty, None, 200, List.empty)
-			val r5 = RequestElement("http://gatling.io", "GET", Map(CONTENT_TYPE -> "text/html;charset=UTF-8"), None, 200,
+			val r5 = RequestElement("http://gatling.io", "GET", Map.empty, None, 200,
 				List(CssResource(new URI("http://gatling.io/main.css"))))
 			val r6 = RequestElement("http://gatling.io/main.css", "GET", Map.empty, None, 200, List.empty)
 


### PR DESCRIPTION
As we don't have the content type of the response we have to use
the presence of embedded resources to split the requests list.
