### PR TITLE
Adding query paramters on redirect from previous request #1749

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandlerActor.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandlerActor.scala
@@ -225,7 +225,7 @@ class AsyncHandlerActor extends BaseActor with DataWriterClient {
                 val requestBuilder = new RequestBuilder("GET", originalRequest.isUseRawUrl)
                   .setURI(redirectURI)
                   .setBodyEncoding(configuration.core.encoding)
-                  .setQueryParameters(null.asInstanceOf[FluentStringsMap])
+                  .setQueryParameters(originalRequest.getQueryParams)
                   .setParameters(null.asInstanceOf[FluentStringsMap])
                   .setConnectionPoolKeyStrategy(tx.request.getConnectionPoolKeyStrategy)
                   .setInetAddress(originalRequest.getInetAddress)


### PR DESCRIPTION
With the change from #1749, redirects were no longer passing query parameters.
