### PR TITLE
Graphite: Avoid having non-coherent metrics sent to Graphite

### DIFF
--- a/gatling-metrics/src/main/scala/io/gatling/metrics/GraphiteDataWriter.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/GraphiteDataWriter.scala
@@ -130,9 +130,7 @@ private class GraphiteSender(graphiteRootPathKey: String)(implicit configuration
                                     requestsMetrics: Map[GraphitePath, MetricByStatus],
                                     usersBreakdowns: Map[GraphitePath, UsersBreakdown]): Unit = {
 
-      def sendToGraphite(metricPath: GraphitePath, value: Long): Unit =
-        metricsSender.sendToGraphite(metricPath.pathKeyWithPrefix(graphiteRootPathKey), value, epoch)
-      def sendFloatToGraphite(metricPath: GraphitePath, value: Double): Unit =
+      def sendToGraphite[T: Numeric](metricPath: GraphitePath, value: T): Unit =
         metricsSender.sendToGraphite(metricPath.pathKeyWithPrefix(graphiteRootPathKey), value, epoch)
 
       def sendUserMetrics(userMetricPath: GraphitePath, userMetric: UsersBreakdown): Unit = {
@@ -146,10 +144,10 @@ private class GraphiteSender(graphiteRootPathKey: String)(implicit configuration
           case None => sendToGraphite(metricPath / "count", 0)
           case Some(m) =>
             sendToGraphite(metricPath / "count", m.count)
-            sendFloatToGraphite(metricPath / "max", m.max)
-            sendFloatToGraphite(metricPath / "min", m.min)
-            sendFloatToGraphite(metricPath / percentiles1Name, m.percentile1)
-            sendFloatToGraphite(metricPath / percentiles2Name, m.percentile2)
+            sendToGraphite(metricPath / "max", m.max)
+            sendToGraphite(metricPath / "min", m.min)
+            sendToGraphite(metricPath / percentiles1Name, m.percentile1)
+            sendToGraphite(metricPath / percentiles2Name, m.percentile2)
         }
 
       def sendRequestMetrics(metricPath: GraphitePath, metricByStatus: MetricByStatus): Unit = {


### PR DESCRIPTION
Imagine having the two following metrics "foo_bar" and "foo.bar". Two different stats are computed for each of them, and then, the paths clash when sent to Graphite. Indeed "foo.bar" will be sanitized as "foo_bar".

Also, the sender was using `configuration.core.charset` which is a non-sens. The Graphite protocol only accept one and only one encoding. 
