### PR TITLE
JMS: Extend JMS request/response with custom reply queue and message matching

### DIFF
--- a/gatling-jms/src/main/scala/io/gatling/jms/JmsAttributes.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/JmsAttributes.scala
@@ -27,6 +27,8 @@ package io.gatling.jms
 case class JmsAttributes(
   requestName: String,
   queueName: String,
+  replyQueueName: Option[String],
+  messageMatcher: JmsMessageMatcher,
   message: JmsMessage,
   messageProperties: Map[String, Any] = Map.empty,
   checks: List[JmsCheck] = Nil)

--- a/gatling-jms/src/main/scala/io/gatling/jms/JmsMessageMatcher.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/JmsMessageMatcher.scala
@@ -1,0 +1,19 @@
+package io.gatling.jms
+
+import javax.jms.Message
+
+object JmsDefaultMessageMatcher extends JmsMessageMatcher {
+
+  override def request(msg: Message): String = msg.getJMSMessageID
+
+  override def response(msg: Message): String = msg.getJMSCorrelationID
+}
+
+/**
+ * define trait for message matching logic with separate request/response
+ * to see how it can be used check JmsDefaultMessageMatcher
+ */
+trait JmsMessageMatcher {
+  def request(msg: Message): String
+  def response(msg: Message): String
+}


### PR DESCRIPTION
add support for defining custom reply queue
enable custom logic for message matching (with default messageId <> correlationId)
fix issue with closing temporary queue (stop consumer first) 
