### PR TITLE
Recorder: fix for exception in export proxy not shutdown

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/controller/RecorderController.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/controller/RecorderController.scala
@@ -92,9 +92,8 @@ class RecorderController extends StrictLogging {
         ScenarioExporter.saveScenario(scenario)
       }
 
-      proxy.shutdown()
-
     } finally {
+      proxy.shutdown()
       clearRecorderState()
       frontEnd.init()
     }


### PR DESCRIPTION
PR for Recorder: proxy is not shutdown on export exception #1864
