### PR TITLE
Core: Percentage/Total confusion

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/result/reader/FileDataReader.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/result/reader/FileDataReader.scala
@@ -302,6 +302,6 @@ class FileDataReader(runUuid: String) extends DataReader(runUuid) with StrictLog
   def errors(requestName: Option[String], group: Option[Group]): Seq[ErrorStats] = {
     val buff = resultsHolder.getErrorsBuffers(requestName, group)
     val total = buff.foldLeft(0)(_ + _._2)
-    buff.toSeq.map { case (name, count) => ErrorStats(name, count, count * 100 / total) }.sortWith(_.count > _.count)
+    buff.toSeq.map { case (name, count) => ErrorStats(name, count, total) }.sortWith(_.count > _.count)
   }
 }

--- a/gatling-charts/src/main/scala/io/gatling/charts/template/ConsoleTemplate.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/template/ConsoleTemplate.scala
@@ -23,7 +23,6 @@ import io.gatling.core.result.writer.ConsoleSummary.{ newBlock, outputLength, wr
 import io.gatling.core.util.StringHelper.{ eol, RichString }
 import io.gatling.core.result.writer.ConsoleErrorsWriter
 import io.gatling.core.result.reader.DataReader
-import io.gatling.core.result.ErrorStats
 
 object ConsoleTemplate {
 
@@ -37,11 +36,7 @@ object ConsoleTemplate {
   }
 
   def writeErrors(dataReader: DataReader): Fastring = {
-      def writeError(error: ErrorStats): Fastring = {
-        ConsoleErrorsWriter.writeError(error.message, error.count, error.percentage)
-      }
-
-    dataReader.errors(None, None).map(writeError).mkFastring(eol)
+    dataReader.errors(None, None).map(ConsoleErrorsWriter.writeError).mkFastring(eol)
   }
 
   def apply(dataReader: DataReader, requestStatistics: RequestStatistics): String = {

--- a/gatling-core/src/main/scala/io/gatling/core/result/package.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/result/package.scala
@@ -24,5 +24,7 @@ package result {
   }
   case class IntRangeVsTimePlot(time: Int, lower: Int, higher: Int)
   case class PieSlice(name: String, value: Double)
-  case class ErrorStats(message: String, count: Int, percentage: Int)
+  case class ErrorStats(message: String, count: Int, totalCount: Int) {
+    def percentage = count * 100.0 / totalCount
+  }
 }

--- a/gatling-core/src/main/scala/io/gatling/core/result/writer/ConsoleErrorsWriter.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/result/writer/ConsoleErrorsWriter.scala
@@ -17,6 +17,7 @@ package io.gatling.core.result.writer
 
 import com.dongxiguo.fastring.Fastring.Implicits._
 import io.gatling.core.util.StringHelper._
+import io.gatling.core.result.ErrorStats
 
 /**
  * Object for writing errors statistics to the console.
@@ -28,8 +29,9 @@ object ConsoleErrorsWriter {
   def formatPercent(percent: Double): String = f"$percent%3.2f"
   val OneHundredPercent: String = formatPercent(100)
 
-  def writeError(msg: String, count: Int, totalCount: Int): Fastring = {
-    val percent = if (count == totalCount) OneHundredPercent else formatPercent(count.toDouble * 100 / totalCount)
+  def writeError(errors: ErrorStats): Fastring = {
+    val ErrorStats(msg, count, _) = errors
+    val percent = formatPercent(errors.percentage)
 
     val currLen = errorMsgLen - 4
     val firstLineLen = currLen.min(msg.length)

--- a/gatling-core/src/main/scala/io/gatling/core/result/writer/ConsoleSummary.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/result/writer/ConsoleSummary.scala
@@ -25,6 +25,7 @@ import com.dongxiguo.fastring.Fastring.Implicits._
 
 import io.gatling.core.config.GatlingConfiguration.configuration
 import io.gatling.core.util.StringHelper.{ RichString, eol }
+import io.gatling.core.result.ErrorStats
 
 object ConsoleSummary {
 
@@ -68,7 +69,7 @@ object ConsoleSummary {
       def writeErrors(): Fastring =
         if (!errorsCounters.isEmpty) {
           fast"""${writeSubTitle("Errors")}
-${errorsCounters.toVector.sortBy(-_._2).map(err => ConsoleErrorsWriter.writeError(err._1, err._2, globalRequestCounters.failedCount)).mkFastring(eol)}
+${errorsCounters.toVector.sortBy(-_._2).map(err => ConsoleErrorsWriter.writeError(ErrorStats(err._1, err._2, globalRequestCounters.failedCount))).mkFastring(eol)}
 """
         } else {
           fast""


### PR DESCRIPTION
The third parameter of `ErrorStats` was being used inconsistently - as a percentage in some places, and as a total in others. This lead to non-sensical results, like error rates over 100% in "Global Information". Usage should now be consistent.
