### PR TITLE
Core: Exclude the right border of the injection time interval

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/scenario/Scenario.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/scenario/Scenario.scala
@@ -16,13 +16,14 @@
 package io.gatling.core.scenario
 
 import akka.actor.ActorRef
+
 import io.gatling.core.akka.AkkaDefaults
 import io.gatling.core.controller.Controller
 import io.gatling.core.controller.inject.InjectionProfile
 import io.gatling.core.result.message.Start
 import io.gatling.core.result.writer.UserMessage
 import io.gatling.core.session.Session
-import io.gatling.core.util.TimeHelper.zeroMs
+import io.gatling.core.util.TimeHelper._
 
 case class Scenario(name: String, entryPoint: ActorRef, injectionProfile: InjectionProfile) extends AkkaDefaults {
 
@@ -39,7 +40,8 @@ case class Scenario(name: String, entryPoint: ActorRef, injectionProfile: Inject
         if (startingTime == zeroMs)
           startUser(index)
         else
-          scheduler.scheduleOnce(startingTime) {
+          // Reduce the starting time to the millisecond precision to avoid flooding the scheduler
+          scheduler.scheduleOnce(toMillisPrecision(startingTime)) {
             startUser(index)
           }
     }

--- a/gatling-core/src/main/scala/io/gatling/core/util/TimeHelper.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/util/TimeHelper.scala
@@ -17,7 +17,7 @@ package io.gatling.core.util
 
 import java.lang.System.{ currentTimeMillis, nanoTime }
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration._
 
 object TimeHelper {
 
@@ -31,4 +31,10 @@ object TimeHelper {
   def computeTimeMillisFromNanos(nanos: Long) = (nanos - nanoTimeReference) / 1000000 + currentTimeMillisReference
   def nowMillis = computeTimeMillisFromNanos(nanoTime)
   def nowSeconds = computeTimeMillisFromNanos(nanoTime) / 1000
+
+  def toMillisPrecision(t: FiniteDuration): FiniteDuration =
+    t.unit match {
+      case MICROSECONDS | NANOSECONDS => t.toMillis.milliseconds
+      case _                          => t
+    }
 }


### PR DESCRIPTION
This PR fixes some injection rate computing bugs.
