### PR TITLE
Fixed NPE in recorder. Resolves #1900

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/ClientPortUnifiedRequestHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/ClientPortUnifiedRequestHandler.scala
@@ -32,13 +32,10 @@ class ClientPortUnifiedRequestHandler(proxy: HttpProxy, pipeline: ChannelPipelin
           val uri = new URI(request.getUri)
           uri.getScheme match {
 
-            case "http" => BootstrapFactory.setGatlingProtocolHandler(pipeline, new ClientHttpsRequestHandler(proxy))
+            case "https" => BootstrapFactory.setGatlingProtocolHandler(pipeline, new ClientHttpsRequestHandler(proxy))
 
-            case _ =>
-              request.getMethod.toString match {
-                case "CONNECT" => BootstrapFactory.setGatlingProtocolHandler(pipeline, new ClientHttpRequestHandler(proxy))
-                case unknown   => logger.warn("Received unknown scheme (http|https): $unknown in " + request)
-              }
+            case _       => BootstrapFactory.setGatlingProtocolHandler(pipeline, new ClientHttpRequestHandler(proxy))
+
           }
 
         case unknown => logger.warn("Received unknown message: $unknown , in event : " + event)


### PR DESCRIPTION
Not sure if the fix is right, but at least it worth a try.
1. It seems that for "http" schema we create `ClientHttpsRequestHandler` (**Https**)
2. Firefox does not send a request with `CONNECT` method. See the following log from `master` branch:

```
20:13:02.035 [main] DEBUG i.g.r.config.RecorderConfiguration$ - configured RecorderConfiguration(CoreConfiguration(utf-8,/home/proger,./user-files/request-bodies,,RecordedSimulation,100 milliseconds,false),FiltersConfiguration(Disabled,WhiteList(List()),BlackList(List())),HttpConfiguration(true,true,false),ProxyConfiguration(8000,OutgoingProxyConfiguration(None,None,None,None,None)),Config(SimpleConfigObject({"awt":{"toolkit":"sun.awt.X11.XToolkit"},"file":{"encoding":{"pkg":"sun.io"},"separator":"/"},"idea":{"launcher":{"bin":{"path":"/opt/idea/bin"},"port":"7538"}},"java":{"awt":{"graphicsenv":"sun.awt.X11GraphicsEnvironment","printerjob":"sun.print.PSPrinterJob"},"class":{"path":"/usr/local/java/jdk1.7.0_55/jre/lib/jce.jar:/usr/local/java/jdk1.7.0_55/jre/lib/rt.jar:/usr/local/java/jdk1.7.0_55/jre/lib/jfxrt.jar:/usr/local/java/jdk1.7.0_55/jre/lib/deploy.jar:/usr/local/java/jdk1.7.0_55/jre/lib/charsets.jar:/usr/local/java/jdk1.7.0_55/jre/lib/jfr.jar:/usr/local/java/jdk1.7.0_55/jre/lib/resources.jar:/usr/local/java/jdk1.7.0_55/jre/lib/jsse.jar:/usr/local/java/jdk1.7.0_55/jre/lib/management-agent.jar:/usr/local/java/jdk1.7.0_55/jre/lib/plugin.jar:/usr/local/java/jdk1.7.0_55/jre/lib/javaws.jar:/usr/local/java/jdk1.7.0_55/jre/lib/ext/sunpkcs11.jar:/usr/local/java/jdk1.7.0_55/jre/lib/ext/zipfs.jar:/usr/local/java/jdk1.7.0_55/jre/lib/ext/localedata.jar:/usr/local/java/jdk1.7.0_55/jre/lib/ext/sunjce_provider.jar:/usr/local/java/jdk1.7.0_55/jre/lib/ext/dnsns.jar:/usr/local/java/jdk1.7.0_55/jre/lib/ext/sunec.jar:/home/proger/Projects/gatling/gatling-recorder/target/classes:/home/proger/Projects/gatling/gatling-core/target/classes:/home/proger/.ivy2/cache/ch.qos.logback/logback-classic/jars/logback-classic-1.1.2.jar:/home/proger/.ivy2/cache/ch.qos.logback/logback-core/jars/logback-core-1.1.2.jar:/home/proger/.ivy2/cache/com.dongxiguo/fastring_2.10/jars/fastring_2.10-0.2.2.jar:/home/proger/.ivy2/cache/com.fasterxml.jackson.core/jackson-annotations/jars/jackson-annotations-2.4.0-rc3.jar:/home/proger/.ivy2/cache/com.fasterxml.jackson.core/jackson-core/jars/jackson-core-2.4.0-rc3.jar:/home/proger/.ivy2/cache/com.fasterxml.jackson.core/jackson-databind/jars/jackson-databind-2.4.0-rc3.jar:/home/proger/.ivy2/cache/com.typesafe/config/jars/config-1.2.1.jar:/home/proger/.ivy2/cache/com.typesafe/scalalogging-slf4j_2.10/jars/scalalogging-slf4j_2.10-1.1.0.jar:/home/proger/.ivy2/cache/com.typesafe.akka/akka-actor_2.10/jars/akka-actor_2.10-2.2.4.jar:/home/proger/.ivy2/cache/commons-io/commons-io/jars/commons-io-2.4.jar:/home/proger/.ivy2/cache/io.fastjson/boon/jars/boon-0.17.jar:/home/proger/.ivy2/cache/io.gatling/jsonpath_2.10/jars/jsonpath_2.10-0.4.1.jar:/home/proger/.ivy2/cache/io.gatling/jsr166e/jars/jsr166e-1.0.jar:/home/proger/.ivy2/cache/io.gatling.uncommons.maths/uncommons-maths/jars/uncommons-maths-1.2.3.jar:/home/proger/.ivy2/cache/joda-time/joda-time/jars/joda-time-2.3.jar:/home/proger/.ivy2/cache/net.sf.opencsv/opencsv/jars/opencsv-2.3.jar:/home/proger/.ivy2/cache/net.sf.saxon/Saxon-HE/jars/Saxon-HE-9.5.1-5.jar:/home/proger/.ivy2/cache/net.sf.saxon/Saxon-HE/jars/Saxon-HE-9.5.1-5-compressed.jar:/home/proger/.ivy2/cache/org.joda/joda-convert/jars/joda-convert-1.5.jar:/home/proger/.ivy2/cache/org.jodd/jodd-core/jars/jodd-core-3.5.jar:/home/proger/.ivy2/cache/org.jodd/jodd-lagarto/jars/jodd-lagarto-3.5.jar:/home/proger/.ivy2/cache/org.jodd/jodd-log/jars/jodd-log-3.5.jar:/home/proger/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.10.4.jar:/home/proger/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar:/home/proger/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.10.4.jar:/home/proger/.ivy2/cache/org.slf4j/slf4j-api/jars/slf4j-api-1.7.7.jar:/home/proger/Projects/gatling/gatling-http/target/classes:/home/proger/.ivy2/cache/com.jcraft/jzlib/jars/jzlib-1.1.3.jar:/home/proger/.ivy2/cache/com.ning/async-http-client/jars/async-http-client-1.8.9.jar:/home/proger/.ivy2/cache/io.netty/netty/jars/netty-3.9.1.Final.jar:/home/proger/.ivy2/cache/com.github.scopt/scopt_2.10/jars/scopt_2.10-3.2.0.jar:/home/proger/.ivy2/cache/org.scala-lang/scala-swing/jars/scala-swing-2.10.4.jar:/opt/idea/lib/idea_rt.jar","version":"51.0"},"endorsed":{"dirs":"/usr/local/java/jdk1.7.0_55/jre/lib/endorsed"},"ext":{"dirs":"/usr/local/java/jdk1.7.0_55/jre/lib/ext:/usr/java/packages/lib/ext"},"home":"/usr/local/java/jdk1.7.0_55/jre","io":{"tmpdir":"/tmp"},"library":{"path":"/opt/idea/bin::/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib"},"runtime":{"name":"Java(TM) SE Runtime Environment","version":"1.7.0_55-b13"},"specification":{"name":"Java Platform API Specification","vendor":"Oracle Corporation","version":"1.7"},"vendor":{"url":{"bug":"http://bugreport.sun.com/bugreport/"}},"version":"1.7.0_55","vm":{"info":"mixed mode","name":"Java HotSpot(TM) 64-Bit Server VM","specification":{"name":"Java Virtual Machine Specification","vendor":"Oracle Corporation","version":"1.7"},"vendor":"Oracle Corporation","version":"24.55-b03"}},"line":{"separator":"\n"},"os":{"arch":"amd64","name":"Linux","version":"3.13.0-24-generic"},"path":{"separator":":"},"recorder":{"core":{"className":"RecordedSimulation","encoding":"utf-8","outputFolder":"","package":"","saveConfig":false,"thresholdForPauseCreation":100},"filters":{"blacklist":[],"filterStrategy":"Disabled","whitelist":[]},"http":{"automaticReferer":true,"fetchHtmlResources":false,"followRedirect":true},"proxy":{"outgoing":{"host":"","password":"","port":0,"sslPort":0,"username":""},"port":8000}},"sun":{"arch":{"data":{"model":"64"}},"boot":{"class":{"path":"/usr/local/java/jdk1.7.0_55/jre/lib/resources.jar:/usr/local/java/jdk1.7.0_55/jre/lib/rt.jar:/usr/local/java/jdk1.7.0_55/jre/lib/sunrsasign.jar:/usr/local/java/jdk1.7.0_55/jre/lib/jsse.jar:/usr/local/java/jdk1.7.0_55/jre/lib/jce.jar:/usr/local/java/jdk1.7.0_55/jre/lib/charsets.jar:/usr/local/java/jdk1.7.0_55/jre/lib/jfr.jar:/usr/local/java/jdk1.7.0_55/jre/classes"},"library":{"path":"/usr/local/java/jdk1.7.0_55/jre/lib/amd64"}},"cpu":{"endian":"little","isalist":""},"desktop":"gnome","io":{"unicode":{"encoding":"UnicodeLittle"}},"java":{"command":"com.intellij.rt.execution.application.AppMain io.gatling.recorder.GatlingRecorder","launcher":"SUN_STANDARD"},"jnu":{"encoding":"UTF-8"},"management":{"compiler":"HotSpot 64-Bit Tiered Compilers"},"os":{"patch":{"level":"unknown"}}},"user":{"country":"US","dir":"/home/proger/Projects/gatling","home":"/home/proger","language":"en","name":"proger","timezone":"Europe/Kiev"}})))
20:17:55.169 [New I/O server boss #51] DEBUG i.g.r.http.channel.BootstrapFactory$ - Open new server channel
20:17:55.247 [New I/O worker #35] INFO  i.g.r.h.h.ClientHttpsRequestHandler - Received GET on http://en.wikipedia.org/wiki/Main_Page
20:17:55.275 [New I/O worker #35] ERROR i.g.r.h.h.ClientHttpsRequestHandler - Exception caught
```
