### PR TITLE
HTTP: Use "infer" instead of "fetch" for automatically inferred HTML resources

### DIFF
--- a/gatling-bundle/src/universal/conf/recorder.conf
+++ b/gatling-bundle/src/universal/conf/recorder.conf
@@ -1,28 +1,31 @@
 recorder {
-    http {
-        #followRedirect=true
-        #automaticReferer=true
+  core {
+    #encoding = "utf-8"
+    #outputFolder = ""
+    #package = ""
+    #className = "RecordedSimulation"
+    #thresholdForPauseCreation = 100               # in milliseconds
+    #saveConfig=false
+  }
+  filters {
+    #filterStrategy = "Disabled"
+    #whitelist = []
+    #blacklist = []
+  }
+  http {
+    #automaticReferer = true
+    #followRedirect = true
+    #inferHtmlResources = false
+    #removeConditionalCache = true
+  }
+  proxy {
+    #port = 8000
+    outgoing {
+      #host = ""
+      #username = ""
+      #password = ""
+      #port = 0
+      #sslPort = 0
     }
-    proxy {
-        #port=8000
-        outgoing {
-            #port=0
-            #username=""
-            #host=""
-            #sslPort=0
-            #password=""
-        }
-    }
-    core {
-        #package=""
-        #outputFolder=""
-        #encoding="UTF-8"
-        #className="RecordedSimulation"
-        #thresholdForPauseCreation = 100               # in milliseconds
-    }
-    filters {
-        #patterns=[]
-        #patternsType=[]
-        #filterStrategy=NONE
-    }
+  }
 }

--- a/gatling-http/src/main/scala/io/gatling/http/action/HttpRequestAction.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/HttpRequestAction.scala
@@ -52,7 +52,7 @@ object HttpRequestAction extends StrictLogging {
 
       case Some(expire) if nowMillis > expire => startHttpTransaction(tx.copy(session = CacheHandling.clearExpire(tx.session, uri)))
 
-      case _ if tx.protocol.responsePart.fetchHtmlResources =>
+      case _ if tx.protocol.responsePart.inferHtmlResources =>
         val explicitResources = HttpRequest.buildNamedRequests(tx.explicitResources, tx.session)
 
         ResourceFetcher.fromCache(tx.request.getURI, tx, explicitResources) match {

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandlerActor.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandlerActor.scala
@@ -161,8 +161,8 @@ class AsyncHandlerActor extends BaseActor with DataWriterClient {
         tx.next ! updatedSession.increaseDrift(nowMillis - response.lastByteReceived).logGroupRequest(response.reponseTimeInMillis, status)
       }
 
-      def fetchPageResources(tx: HttpTx, response: Response): Boolean =
-        tx.protocol.responsePart.fetchHtmlResources && response.isReceived && isHtml(response.headers)
+      def inferPageResources(tx: HttpTx, response: Response): Boolean =
+        tx.protocol.responsePart.inferHtmlResources && response.isReceived && isHtml(response.headers)
 
     // FIXME rewrite with extractors
     if (tx.resourceFetching) {
@@ -181,13 +181,13 @@ class AsyncHandlerActor extends BaseActor with DataWriterClient {
         else
           Nil
 
-      val pageResources =
-        if (fetchPageResources(tx, response))
+      val inferredResources =
+        if (inferPageResources(tx, response))
           ResourceFetcher.resourcesFromPage(response, tx)
         else
           Nil
 
-      ResourceFetcher.resourceFetcher(tx, pageResources, explicitResources) match {
+      ResourceFetcher.resourceFetcher(tx, inferredResources, explicitResources) match {
         case Some(resourceFetcher) => actor(context)(resourceFetcher())
         case None                  => regularExecuteNext()
       }

--- a/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocol.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocol.scala
@@ -64,8 +64,8 @@ object HttpProtocol {
       responseTransformer = None,
       checks = Nil,
       extraInfoExtractor = None,
-      fetchHtmlResources = false,
-      htmlResourcesFetchingFilters = None),
+      inferHtmlResources = false,
+      htmlResourcesInferringFilters = None),
     wsPart = HttpProtocolWsPart(
       wsBaseURLs = Nil,
       reconnect = false,
@@ -187,8 +187,8 @@ case class HttpProtocolResponsePart(
   responseTransformer: Option[ResponseTransformer],
   checks: List[HttpCheck],
   extraInfoExtractor: Option[ExtraInfoExtractor],
-  fetchHtmlResources: Boolean,
-  htmlResourcesFetchingFilters: Option[Filters])
+  inferHtmlResources: Boolean,
+  htmlResourcesInferringFilters: Option[Filters])
 
 case class HttpProtocolWsPart(
     wsBaseURLs: List[String],

--- a/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocolBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocolBuilder.scala
@@ -102,11 +102,11 @@ case class HttpProtocolBuilder(protocol: HttpProtocol) extends StrictLogging {
   def extraInfoExtractor(f: ExtraInfoExtractor) = newResponsePart(protocol.responsePart.copy(extraInfoExtractor = Some(f)))
   def transformResponse(responseTransformer: ResponseTransformer) = newResponsePart(protocol.responsePart.copy(responseTransformer = Some(responseTransformer)))
   def check(checks: HttpCheck*) = newResponsePart(protocol.responsePart.copy(checks = protocol.responsePart.checks ::: checks.toList))
-  def fetchHtmlResources(): HttpProtocolBuilder = fetchHtmlResources(None)
-  def fetchHtmlResources(white: WhiteList): HttpProtocolBuilder = fetchHtmlResources(Some(Filters(white, BlackList())))
-  def fetchHtmlResources(white: WhiteList, black: BlackList): HttpProtocolBuilder = fetchHtmlResources(Some(Filters(white, black)))
-  def fetchHtmlResources(black: BlackList, white: WhiteList = WhiteList(Nil)): HttpProtocolBuilder = fetchHtmlResources(Some(Filters(black, white)))
-  private def fetchHtmlResources(filters: Option[Filters]) = newResponsePart(protocol.responsePart.copy(fetchHtmlResources = true, htmlResourcesFetchingFilters = filters))
+  def inferHtmlResources(): HttpProtocolBuilder = inferHtmlResources(None)
+  def inferHtmlResources(white: WhiteList): HttpProtocolBuilder = inferHtmlResources(Some(Filters(white, BlackList())))
+  def inferHtmlResources(white: WhiteList, black: BlackList): HttpProtocolBuilder = inferHtmlResources(Some(Filters(white, black)))
+  def inferHtmlResources(black: BlackList, white: WhiteList = WhiteList(Nil)): HttpProtocolBuilder = inferHtmlResources(Some(Filters(black, white)))
+  private def inferHtmlResources(filters: Option[Filters]) = newResponsePart(protocol.responsePart.copy(inferHtmlResources = true, htmlResourcesInferringFilters = filters))
 
   // wsPart
   private def newWsPart(wsPart: HttpProtocolWsPart) = copy(protocol = copy(protocol.copy(wsPart = wsPart)))

--- a/gatling-http/src/main/scala/io/gatling/http/response/ResponseBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/response/ResponseBuilder.scala
@@ -52,11 +52,11 @@ object ResponseBuilder extends StrictLogging {
 
     val storeBodyParts = IsDebugEnabled || !protocol.responsePart.discardResponseChunks || !responseBodyUsageStrategies.isEmpty
 
-    request: Request => new ResponseBuilder(request, checksumChecks, responseBodyUsageStrategies, responseTransformer, storeBodyParts, protocol.responsePart.fetchHtmlResources)
+    request: Request => new ResponseBuilder(request, checksumChecks, responseBodyUsageStrategies, responseTransformer, storeBodyParts, protocol.responsePart.inferHtmlResources)
   }
 }
 
-class ResponseBuilder(request: Request, checksumChecks: List[ChecksumCheck], bodyUsageStrategies: Set[ResponseBodyUsageStrategy], responseProcessor: Option[ResponseTransformer], storeBodyParts: Boolean, fetchHtmlResources: Boolean) {
+class ResponseBuilder(request: Request, checksumChecks: List[ChecksumCheck], bodyUsageStrategies: Set[ResponseBodyUsageStrategy], responseProcessor: Option[ResponseTransformer], storeBodyParts: Boolean, inferHtmlResources: Boolean) {
 
   val computeChecksums = !checksumChecks.isEmpty
   var storeHtmlOrCss = false
@@ -103,7 +103,7 @@ class ResponseBuilder(request: Request, checksumChecks: List[ChecksumCheck], bod
 
   def accumulate(headers: HttpResponseHeaders): Unit = {
     this.headers = headers.getHeaders
-    storeHtmlOrCss = fetchHtmlResources && (isHtml(headers.getHeaders) || isCss(headers.getHeaders))
+    storeHtmlOrCss = inferHtmlResources && (isHtml(headers.getHeaders) || isCss(headers.getHeaders))
     updateLastByteReceived()
   }
 

--- a/gatling-http/src/test/scala/io/gatling/http/HttpCompileTest.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/HttpCompileTest.scala
@@ -47,7 +47,7 @@ class HttpCompileTest extends Simulation {
     .disableCaching
     .disableWarmUp
     .warmUp("http://gatling.io")
-    .fetchHtmlResources(white = WhiteList(".*\\.html"))
+    .inferHtmlResources(white = WhiteList(".*\\.html"))
 
   val httpConfToVerifyUserProvidedInfoExtractors = http
     .extraInfoExtractor((requestName, requestStatus, session, request, response) => Nil)

--- a/gatling-http/src/test/scala/io/gatling/http/integration/HttpIntegrationSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/integration/HttpIntegrationSpec.scala
@@ -87,7 +87,7 @@ class HttpIntegrationSpec extends Specification {
               .check(
                 css("h1").is("Resource Test"),
                 regex("<title>Resource Test</title>"))),
-        protocols = Protocols(WireMockSupport.httpProtocol.fetchHtmlResources(BlackList(".*/bad_resource.png"))))
+        protocols = Protocols(WireMockSupport.httpProtocol.inferHtmlResources(BlackList(".*/bad_resource.png"))))
 
       session.isFailed should_== false
       verify(getRequestedFor(urlEqualTo("/resourceTest/index.html")))

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/CommandLineConstants.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/CommandLineConstants.scala
@@ -31,5 +31,5 @@ object CommandLineConstants {
   val Encoding = CommandLineConstant("encoding", "enc")
   val FollowRedirect = CommandLineConstant("follow-redirect", "fr")
   val AutomaticReferer = CommandLineConstant("automatic-referer", "ar")
-  val FetchHtmlResources = CommandLineConstant("fetch-html-resources", "fhr")
+  val InferHtmlResources = CommandLineConstant("infer-html-resources", "ihr")
 }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/GatlingRecorder.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/GatlingRecorder.scala
@@ -37,7 +37,7 @@ object GatlingRecorder {
     opt[String](Encoding.full).abbr(Encoding.abbr).foreach(props.encoding).text("Sets the encoding used in the recorder")
     opt[Boolean](FollowRedirect.full).abbr(FollowRedirect.abbr).foreach(props.followRedirect).text("""Sets the "Follow Redirects" option to true""")
     opt[Boolean](AutomaticReferer.full).abbr(AutomaticReferer.abbr).foreach(props.automaticReferer).text("""Sets the "Automatic Referers" option to true""")
-    opt[Boolean](FetchHtmlResources.full).abbr(FetchHtmlResources.abbr).foreach(props.fetchHtmlResources).text("""Sets the "Fetch html resources" option to true""")
+    opt[Boolean](InferHtmlResources.full).abbr(InferHtmlResources.abbr).foreach(props.inferHtmlResources).text("""Sets the "Fetch html resources" option to true""")
   }
 
   def main(args: Array[String]): Unit = {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
@@ -36,7 +36,7 @@ object ConfigKeys {
   object http {
     val AutomaticReferer = "recorder.http.automaticReferer"
     val FollowRedirect = "recorder.http.followRedirect"
-    val FetchHtmlResources = "recorder.http.fetchHtmlResources"
+    val InferHtmlResources = "recorder.http.inferHtmlResources"
     val RemoveConditionalCache = "recorder.http.removeConditionalCache"
   }
   object proxy {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
@@ -137,7 +137,7 @@ object RecorderConfiguration extends StrictLogging {
       http = HttpConfiguration(
         automaticReferer = config.getBoolean(http.AutomaticReferer),
         followRedirect = config.getBoolean(http.FollowRedirect),
-        fetchHtmlResources = config.getBoolean(http.FetchHtmlResources),
+        inferHtmlResources = config.getBoolean(http.InferHtmlResources),
         removeConditionalCache = config.getBoolean(http.RemoveConditionalCache)),
       proxy = ProxyConfiguration(
         port = config.getInt(proxy.Port),
@@ -175,7 +175,7 @@ case class CoreConfiguration(
 case class HttpConfiguration(
   automaticReferer: Boolean,
   followRedirect: Boolean,
-  fetchHtmlResources: Boolean,
+  inferHtmlResources: Boolean,
   removeConditionalCache: Boolean)
 
 case class OutgoingProxyConfiguration(

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
@@ -59,8 +59,8 @@ class RecorderPropertiesBuilder {
   def followRedirect(status: Boolean): Unit =
     props += http.FollowRedirect -> status
 
-  def fetchHtmlResources(status: Boolean): Unit =
-    props += http.FetchHtmlResources -> status
+  def inferHtmlResources(status: Boolean): Unit =
+    props += http.InferHtmlResources -> status
 
   def removeConditionalCache(status: Boolean): Unit =
     props += http.RemoveConditionalCache -> status

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
@@ -31,7 +31,7 @@ object ScenarioDefinition extends StrictLogging {
     }.flatten
   }
 
-  private def filterFetchedResources(requests: Seq[TimedScenarioElement[RequestElement]]): Seq[TimedScenarioElement[RequestElement]] = {
+  private def filterInferredResources(requests: Seq[TimedScenarioElement[RequestElement]]): Seq[TimedScenarioElement[RequestElement]] = {
 
     val groupChainedRequests: List[List[TimedScenarioElement[RequestElement]]] = {
       var globalAcc = List.empty[List[TimedScenarioElement[RequestElement]]]
@@ -101,10 +101,10 @@ object ScenarioDefinition extends StrictLogging {
     val sortedRequests = requests.sortBy(_.arrivalTime)
 
     val requests1 = if (config.http.followRedirect) filterRedirection(sortedRequests) else sortedRequests
-    val requests2 = if (config.http.fetchHtmlResources) filterFetchedResources(requests1) else requests1
+    val requests2 = if (config.http.inferHtmlResources) filterInferredResources(requests1) else requests1
 
     if (config.http.followRedirect) logger.debug(s"Cleaning redirections: ${requests.size}->${requests1.size} requests")
-    if (config.http.fetchHtmlResources) logger.debug(s"Cleaning automatically fetched HTML resources: ${requests1.size}->${requests2.size} requests")
+    if (config.http.inferHtmlResources) logger.debug(s"Cleaning automatically fetched HTML resources: ${requests1.size}->${requests2.size} requests")
 
     val allElements = mergeWithPauses(requests2, tags, config.core.thresholdForPauseCreation)
     apply(allElements)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
@@ -50,7 +50,7 @@ object ProtocolTemplate {
 
       def renderFollowRedirect = if (!config.http.followRedirect) fast"$eol$Indent.disableFollowRedirect" else fast""
 
-      def renderFetchHtmlResources = if (config.http.fetchHtmlResources) {
+      def renderInferHtmlResources = if (config.http.inferHtmlResources) {
         val filtersConfig = config.filters
 
           def quotedStringList(xs: Seq[String]): String = xs.map(p => "\"\"\"" + p + "\"\"\"").mkString(", ")
@@ -63,7 +63,7 @@ object ProtocolTemplate {
           case FilterStrategy.Disabled       => emptyFastring
         }
 
-        fast"$eol$Indent.fetchHtmlResources($patterns)"
+        fast"$eol$Indent.inferHtmlResources($patterns)"
       } else fast""
 
       def renderAutomaticReferer = if (!config.http.automaticReferer) fast"$eol$Indent.disableAutoReferer" else fast""
@@ -74,6 +74,6 @@ object ProtocolTemplate {
       }
 
     fast"""
-		.baseURL("${protocol.baseUrl}")$renderProxy$renderFollowRedirect$renderFetchHtmlResources$renderAutomaticReferer$renderHeaders""".toString
+		.baseURL("${protocol.baseUrl}")$renderProxy$renderFollowRedirect$renderInferHtmlResources$renderAutomaticReferer$renderHeaders""".toString
   }
 }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
@@ -67,7 +67,7 @@ class ConfigurationFrame(frontend: RecorderFrontend) extends MainFrame {
   private val simulationPackage = new TextField(30)
   private val simulationClassName = new TextField(30)
   private val followRedirects = new CheckBox("Follow Redirects?")
-  private val fetchHtmlResources = new CheckBox("Fetch html resources?")
+  private val inferHtmlResources = new CheckBox("Infer html resources?")
   private val removeConditionalCache = new CheckBox("Remove conditional cache headers?")
   private val automaticReferers = new CheckBox("Automatic Referers?")
 
@@ -184,7 +184,7 @@ class ConfigurationFrame(frontend: RecorderFrontend) extends MainFrame {
         layout(config) = North
         layout(new BorderPanel {
           layout(followRedirects) = West
-          layout(fetchHtmlResources) = East
+          layout(inferHtmlResources) = East
         }) = West
         layout(automaticReferers) = East
         layout(removeConditionalCache) = South
@@ -391,7 +391,7 @@ class ConfigurationFrame(frontend: RecorderFrontend) extends MainFrame {
     simulationClassName.text = configuration.core.className
     filterStrategies.selection.item = configuration.filters.filterStrategy
     followRedirects.selected = configuration.http.followRedirect
-    fetchHtmlResources.selected = configuration.http.fetchHtmlResources
+    inferHtmlResources.selected = configuration.http.inferHtmlResources
     removeConditionalCache.selected = configuration.http.removeConditionalCache
     automaticReferers.selected = configuration.http.automaticReferer
     configuration.filters.blackList.patterns.foreach(blackListTable.addRow)
@@ -453,7 +453,7 @@ class ConfigurationFrame(frontend: RecorderFrontend) extends MainFrame {
       props.simulationPackage(simulationPackage.text)
       props.simulationClassName(simulationClassName.text.trim)
       props.followRedirect(followRedirects.selected)
-      props.fetchHtmlResources(fetchHtmlResources.selected)
+      props.inferHtmlResources(inferHtmlResources.selected)
       props.removeConditionalCache(removeConditionalCache.selected)
       props.automaticReferer(automaticReferers.selected)
       props.simulationOutputFolder(outputFolderPath.text.trim)

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/har/HarReaderSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/har/HarReaderSpec.scala
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import io.gatling.recorder.config.ConfigKeys.http.FetchHtmlResources
+import io.gatling.recorder.config.ConfigKeys.http.InferHtmlResources
 import io.gatling.recorder.config.RecorderConfiguration.fakeConfig
 import io.gatling.recorder.scenario.{ PauseElement, RequestElement }
 
@@ -32,10 +32,10 @@ class HarReaderSpec extends Specification {
 
   "HarReader" should {
 
-    val configWithResourcesFiltering = fakeConfig(Map(FetchHtmlResources -> true))
+    val configWithResourcesFiltering = fakeConfig(Map(InferHtmlResources -> true))
 
     // By default, we assume that we don't want to filter out the HTML resources
-    implicit val config = fakeConfig(Map(FetchHtmlResources -> false))
+    implicit val config = fakeConfig(Map(InferHtmlResources -> false))
 
     "work with empty JSON" in {
       HarReader(resourceAsStream("har/empty.har")) must beEmpty

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/ScenarioSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/ScenarioSpec.scala
@@ -25,7 +25,7 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 import io.gatling.http.fetch.{ CssResource, RegularResource }
-import io.gatling.recorder.config.ConfigKeys.http.{ FetchHtmlResources, FollowRedirect }
+import io.gatling.recorder.config.ConfigKeys.http.{ InferHtmlResources, FollowRedirect }
 import io.gatling.recorder.config.RecorderConfiguration.fakeConfig
 
 @RunWith(classOf[JUnitRunner])
@@ -33,7 +33,7 @@ class ScenarioSpec extends Specification {
 
   "Scenario" should {
 
-    implicit val config = fakeConfig(Map(FollowRedirect -> true, FetchHtmlResources -> true))
+    implicit val config = fakeConfig(Map(FollowRedirect -> true, InferHtmlResources -> true))
 
     "remove HTTP redirection " in {
       val r1 = RequestElement("http://gatling.io/", "GET", Map.empty, None, 200, List.empty)


### PR DESCRIPTION
The term "fetch" is wrong as user can provide explicit resources that will be fetched too. 
