### PR TITLE
App: Add OptionParser wrapper that takes CommandLineConstants

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/CommandLineConstants.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/CommandLineConstants.scala
@@ -15,9 +15,17 @@
  */
 package io.gatling.app
 
+import scopt.{ Read, OptionDef, OptionParser }
+
 case class CommandLineConstant(full: String, abbr: String)
 
 object CommandLineConstants {
+
+  trait CommandLineConstantsSupport[C] { self: OptionParser[C] =>
+
+    def help(constant: CommandLineConstant): OptionDef[Unit, C] = help(constant.full).abbr(constant.abbr)
+    def opt[A: Read](constant: CommandLineConstant): OptionDef[A, C] = opt[A](constant.full).abbr(constant.abbr)
+  }
 
   val Help = CommandLineConstant("help", "h")
   val NoReports = CommandLineConstant("no-reports", "nr")

--- a/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
@@ -58,19 +58,19 @@ object Gatling {
   def runGatling(args: Array[String], simulationClass: Option[Class[Simulation]]): Int = {
     val props = new GatlingPropertiesBuilder
 
-    val cliOptsParser = new OptionParser[Unit]("gatling") {
-      help(Help.full).abbr(Help.abbr).text("Show help (this message) and exit")
-      opt[Unit](NoReports.full).abbr(NoReports.abbr).foreach(_ => props.noReports()).text("Runs simulation but does not generate reports")
-      opt[Unit](Mute.full).abbr(Mute.abbr).foreach(_ => props.mute()).text("Runs in mute mode: don't asks for run description nor simulation ID, use defaults").hidden()
-      opt[String](ReportsOnly.full).abbr(ReportsOnly.abbr).foreach(props.reportsOnly).valueName("<directoryName>").text("Generates the reports for the simulation in <directoryName>")
-      opt[String](DataFolder.full).abbr(DataFolder.abbr).foreach(props.dataDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where feeders are stored")
-      opt[String](ResultsFolder.full).abbr(ResultsFolder.abbr).foreach(props.resultsDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where results are stored")
-      opt[String](RequestBodiesFolder.full).abbr(RequestBodiesFolder.abbr).foreach(props.requestBodiesDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where request bodies are stored")
-      opt[String](SimulationsFolder.full).abbr(SimulationsFolder.abbr).foreach(props.sourcesDirectory).valueName("<directoryPath>").text("Uses <directoryPath> to discover simulations that could be run")
-      opt[String](SimulationsBinariesFolder.full).abbr(SimulationsBinariesFolder.abbr).foreach(props.binariesDirectory).valueName("<directoryPath>").text("Uses <directoryPath> to discover already compiled simulations")
-      opt[String](Simulation.full).abbr(Simulation.abbr).foreach(props.simulationClass).valueName("<className>").text("Runs <className> simulation")
-      opt[String](OutputDirectoryBaseName.full).abbr(OutputDirectoryBaseName.abbr).foreach(props.outputDirectoryBaseName).valueName("<name>").text("Use <name> for the base name of the output directory")
-      opt[String](SimulationDescription.full).abbr(SimulationDescription.abbr).foreach(props.runDescription).valueName("<description>").text("A short <description> of the run to include in the report")
+    val cliOptsParser = new OptionParser[Unit]("gatling") with CommandLineConstantsSupport[Unit] {
+      help(Help).text("Show help (this message) and exit")
+      opt[Unit](NoReports).foreach(_ => props.noReports()).text("Runs simulation but does not generate reports")
+      opt[Unit](Mute).foreach(_ => props.mute()).text("Runs in mute mode: don't asks for run description nor simulation ID, use defaults").hidden()
+      opt[String](ReportsOnly).foreach(props.reportsOnly).valueName("<directoryName>").text("Generates the reports for the simulation in <directoryName>")
+      opt[String](DataFolder).foreach(props.dataDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where feeders are stored")
+      opt[String](ResultsFolder).foreach(props.resultsDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where results are stored")
+      opt[String](RequestBodiesFolder).foreach(props.requestBodiesDirectory).valueName("<directoryPath>").text("Uses <directoryPath> as the absolute path of the directory where request bodies are stored")
+      opt[String](SimulationsFolder).foreach(props.sourcesDirectory).valueName("<directoryPath>").text("Uses <directoryPath> to discover simulations that could be run")
+      opt[String](SimulationsBinariesFolder).foreach(props.binariesDirectory).valueName("<directoryPath>").text("Uses <directoryPath> to discover already compiled simulations")
+      opt[String](Simulation).foreach(props.simulationClass).valueName("<className>").text("Runs <className> simulation")
+      opt[String](OutputDirectoryBaseName).foreach(props.outputDirectoryBaseName).valueName("<name>").text("Use <name> for the base name of the output directory")
+      opt[String](SimulationDescription).foreach(props.runDescription).valueName("<description>").text("A short <description> of the run to include in the report")
     }
 
     // if arguments are incorrect, usage message is displayed
@@ -81,7 +81,7 @@ object Gatling {
 
 class Gatling(simulationClass: Option[Class[Simulation]]) extends StrictLogging {
 
-  def start = {
+  def start: Int = {
 
       def defaultOutputDirectoryBaseName(clazz: Class[Simulation]) =
         configuration.core.outputDirectoryBaseName.getOrElse(clazz.getSimpleName.clean)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/CommandLineConstants.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/CommandLineConstants.scala
@@ -15,9 +15,17 @@
  */
 package io.gatling.recorder
 
+import scopt.{ OptionDef, Read, OptionParser }
+
 case class CommandLineConstant(full: String, abbr: String)
 
 object CommandLineConstants {
+
+  trait CommandLineConstantsSupport[C] { self: OptionParser[C] =>
+
+    def help(constant: CommandLineConstant): OptionDef[Unit, C] = help(constant.full).abbr(constant.abbr)
+    def opt[A: Read](constant: CommandLineConstant): OptionDef[A, C] = opt[A](constant.full).abbr(constant.abbr)
+  }
 
   val Help = CommandLineConstant("help", "h")
   val LocalPort = CommandLineConstant("local-port", "lp")

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/GatlingRecorder.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/GatlingRecorder.scala
@@ -24,20 +24,20 @@ object GatlingRecorder {
 
   private val props = new RecorderPropertiesBuilder
 
-  private val cliOptsParser = new OptionParser[Unit]("gatling-recorder") {
-    help(Help.full).abbr(Help.abbr).text("Show help (this message) and exit")
-    opt[Int](LocalPort.full).abbr(LocalPort.abbr).valueName("<port>").foreach(props.localPort).text("Local port used by Gatling Proxy for HTTP")
-    opt[String](ProxyHost.full).abbr(ProxyHost.abbr).valueName("<host>").foreach(props.proxyHost).text("Outgoing proxy host")
-    opt[Int](ProxyPort.full).abbr(ProxyPort.abbr).valueName("<port>").foreach(props.proxyPort).text("Outgoing proxy port for HTTP")
-    opt[Int](ProxyPortSsl.full).abbr(ProxyPortSsl.abbr).valueName("<port>").foreach(props.proxySslPort).text("Outgoing proxy port for HTTPS")
-    opt[String](OutputFolder.full).abbr(OutputFolder.abbr).valueName("<folderName>").foreach(props.simulationOutputFolder).text("Uses <folderName> as the folder where generated simulations will be stored")
-    opt[String](RequestBodiesFolder.full).abbr(RequestBodiesFolder.abbr).valueName("<folderName>").foreach(props.requestBodiesFolder).text("Uses <folderName> as the folder where request bodies are stored")
-    opt[String](ClassName.full).abbr(ClassName.abbr).foreach(props.simulationClassName).text("Sets the name of the generated class")
-    opt[String](Package.full).abbr(Package.abbr).foreach(props.simulationPackage).text("Sets the package of the generated class")
-    opt[String](Encoding.full).abbr(Encoding.abbr).foreach(props.encoding).text("Sets the encoding used in the recorder")
-    opt[Boolean](FollowRedirect.full).abbr(FollowRedirect.abbr).foreach(props.followRedirect).text("""Sets the "Follow Redirects" option to true""")
-    opt[Boolean](AutomaticReferer.full).abbr(AutomaticReferer.abbr).foreach(props.automaticReferer).text("""Sets the "Automatic Referers" option to true""")
-    opt[Boolean](InferHtmlResources.full).abbr(InferHtmlResources.abbr).foreach(props.inferHtmlResources).text("""Sets the "Fetch html resources" option to true""")
+  private val cliOptsParser = new OptionParser[Unit]("gatling-recorder") with CommandLineConstantsSupport[Unit] {
+    help(Help).text("Show help (this message) and exit")
+    opt[Int](LocalPort).valueName("<port>").foreach(props.localPort).text("Local port used by Gatling Proxy for HTTP")
+    opt[String](ProxyHost).valueName("<host>").foreach(props.proxyHost).text("Outgoing proxy host")
+    opt[Int](ProxyPort).valueName("<port>").foreach(props.proxyPort).text("Outgoing proxy port for HTTP")
+    opt[Int](ProxyPortSsl).valueName("<port>").foreach(props.proxySslPort).text("Outgoing proxy port for HTTPS")
+    opt[String](OutputFolder).valueName("<folderName>").foreach(props.simulationOutputFolder).text("Uses <folderName> as the folder where generated simulations will be stored")
+    opt[String](RequestBodiesFolder).valueName("<folderName>").foreach(props.requestBodiesFolder).text("Uses <folderName> as the folder where request bodies are stored")
+    opt[String](ClassName).foreach(props.simulationClassName).text("Sets the name of the generated class")
+    opt[String](Package).foreach(props.simulationPackage).text("Sets the package of the generated class")
+    opt[String](Encoding).foreach(props.encoding).text("Sets the encoding used in the recorder")
+    opt[Boolean](FollowRedirect).foreach(props.followRedirect).text("""Sets the "Follow Redirects" option to true""")
+    opt[Boolean](AutomaticReferer).foreach(props.automaticReferer).text("""Sets the "Automatic Referers" option to true""")
+    opt[Boolean](InferHtmlResources).foreach(props.inferHtmlResources).text("""Sets the "Fetch html resources" option to true""")
   }
 
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
Couldn’t resolve to move duplicated code into core and add scopt dependency there
