### PR TITLE
Recorder: Load gatling.jks from current ClassLoader, rather than system ClassLoader

### DIFF
--- a/gatling-recorder/src/main/scala/org/jboss/netty/example/securechat/SecureChatSslContextFactory.scala
+++ b/gatling-recorder/src/main/scala/org/jboss/netty/example/securechat/SecureChatSslContextFactory.scala
@@ -71,7 +71,7 @@ object SecureChatSslContextFactory extends StrictLogging {
         new FileInputStream(keystorePath)
       }.getOrElse {
         logger.info("Loading default keystore gatling.jks")
-        ClassLoader.getSystemResourceAsStream("gatling.jks")
+        getClass.getResourceAsStream("gatling.jks")
       }
 
     val keystorePassphrase = System.getProperty(PropertyKeystorePassphrase, "gatling")


### PR DESCRIPTION
`SecureChatSslContextFactory` was loading `gatling.jks` from the system `ClassLoader`, rather than the local one. This meant it didn't work correctly when run from a non-system `ClassLoader`, such as Maven.
