### PR TITLE
HTTP: Refactored MockServerSupport

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/structure/StructureBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/structure/StructureBuilder.scala
@@ -23,7 +23,7 @@ import io.gatling.core.config.Protocols
  */
 trait StructureBuilder[B <: StructureBuilder[B]] extends Execs[B] with Pauses[B] with Feeds[B] with Loops[B] with ConditionalStatements[B] with Errors[B] with Groups[B] {
 
-  private[core] def build(exitPoint: ActorRef, protocols: Protocols): ActorRef =
+  private[gatling] def build(exitPoint: ActorRef, protocols: Protocols): ActorRef =
     actionBuilders.foldLeft(exitPoint) { (actorRef, actionBuilder) =>
       actionBuilder.build(actorRef, protocols)
     }

--- a/gatling-http/src/test/scala/io/gatling/http/integration/MockServerSupport.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/integration/MockServerSupport.scala
@@ -95,9 +95,8 @@ object MockServerSupport extends Fixture[TestKit with ImplicitSender] with Loggi
 
   def runScenario(sb: ScenarioBuilder, timeout: FiniteDuration = 10 seconds, protocols: Protocols = Protocols(httpProtocol))(implicit testKit: TestKit with ImplicitSender) = {
     import testKit._
-    val buildMethod = classOf[ScenarioBuilder].getMethod("build", classOf[ActorRef], classOf[Protocols])
-    buildMethod.setAccessible(true)
-    val actor = buildMethod.invoke(sb, testKit.self, protocols).asInstanceOf[ActorRef]
+
+    val actor = sb.build(testKit.self, protocols)
     actor ! Session("TestSession", "testUser")
     expectMsgClass(timeout, classOf[Session])
   }


### PR DESCRIPTION
It does not seem to break encapsulation, but definitely looks cleaner.
