### PR TITLE
HTTP: Added conditional comments parsing in HtmlParser. Resolves #1924

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/css/Jodd.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/css/Jodd.scala
@@ -29,15 +29,23 @@ object Jodd {
     .setEnableConditionalComments(false)
     .setCaseSensitive(false)
 
+  def getJoddConfig(ieVersion: Option[Float]): LagartoDomBuilderConfig = {
+    ieVersion match {
+      case Some(version) => JoddConfig.setEnableConditionalComments(true).setCondCommentIEVersion(version)
+
+      case None          => JoddConfig
+    }
+  }
+
   def newLagartoDomBuilder: LagartoDOMBuilder = {
     val domBuilder = new LagartoDOMBuilder
     domBuilder.setConfig(JoddConfig)
     domBuilder
   }
 
-  def newLagartoParser(chars: Array[Char]): LagartoParser = {
+  def newLagartoParser(chars: Array[Char], ieVersion: Option[Float]): LagartoParser = {
     val lagartoParser = new LagartoParser(chars, false)
-    lagartoParser.setConfig(JoddConfig)
+    lagartoParser.setConfig(getJoddConfig(ieVersion))
     lagartoParser
   }
 }

--- a/gatling-http/src/main/scala/io/gatling/http/fetch/UserAgent.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/fetch/UserAgent.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011-2014 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.http.fetch
+
+import com.ning.http.client.Request
+
+object UserAgent {
+  val IE = "MSIE"
+
+  private val USER_AGENT = "User-Agent"
+  private val MSIE_AGENT_REGEX = new scala.util.matching.Regex("MSIE ([0-9]+.[0-9]+)")
+
+  def getAgent(request: Request): Option[UserAgent] = {
+
+    if (request.getHeaders.containsKey(USER_AGENT)) {
+      val agentStr = request.getHeaders.getFirstValue(USER_AGENT)
+      parseFromHeader(agentStr)
+    } else
+      None
+  }
+
+  def parseFromHeader(userAgent: String): Option[UserAgent] = {
+    MSIE_AGENT_REGEX.findFirstMatchIn(userAgent) match {
+      case Some(res) => Some(UserAgent(UserAgent.IE, res.group(1).toFloat))
+      case None      => None
+    }
+  }
+}
+
+case class UserAgent(name: String, version: Float)

--- a/gatling-http/src/test/resources/resourceTest/indexIE.html
+++ b/gatling-http/src/test/resources/resourceTest/indexIE.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <title>IE conditional comments test</title>
+    <!--[if IE 9]>
+      <link rel="stylesheet" href="stylesheet.css" />
+    <![endif]-->
+
+  </head>
+  <body>
+    <h1>IE conditional comments test</h1>
+  </body>
+</html>

--- a/gatling-http/src/test/scala/io/gatling/http/fetch/UserAgentSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/fetch/UserAgentSpec.scala
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2014 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.http.fetch
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class UserAgentSpec extends Specification {
+  "extract IE 9.0 version" in {
+    val agent = UserAgent.parseFromHeader("Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))")
+    agent should be equalTo Some(UserAgent(UserAgent.IE, 9.0f))
+  }
+
+  "extract IE 8.0 version" in {
+    val agent = UserAgent.parseFromHeader("Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)")
+    agent should be equalTo Some(UserAgent(UserAgent.IE, 8.0f))
+  }
+
+  "don't parse Firefox version" in {
+    val agent = UserAgent.parseFromHeader("Mozilla/5.0 (X11; OpenBSD amd64; rv:28.0) Gecko/20100101 Firefox/28.0")
+    agent should beNone
+  }
+}

--- a/gatling-http/src/test/scala/io/gatling/http/integration/HttpIntegrationSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/integration/HttpIntegrationSpec.scala
@@ -89,5 +89,33 @@ class HttpIntegrationSpec extends Specification {
 
       success
     }
+
+    "fetch resources in conditional comments" in MockServerSupport { implicit testKit =>
+      import MockServerSupport._
+
+      serverMock({
+        case HttpRequest(GET, Uri.Path("/resourceTest/indexIE.html"), _, _, _) =>
+          HttpResponse(entity = file("resourceTest/indexIE.html", `text/html`))
+
+        case HttpRequest(GET, Uri.Path("/resourceTest/stylesheet.css"), _, _, _) =>
+          HttpResponse(entity = file("resourceTest/stylesheet.css"))
+      })
+
+      val session = runScenario(
+        scenario("Resource downloads")
+          .exec(
+            http("/resourceTest/indexIE.html")
+              .get("/resourceTest/indexIE.html")
+              .header("User-Agent",
+                "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))")),
+        protocols = Protocols(MockServerSupport.httpProtocol.inferHtmlResources()))
+
+      session.isFailed should beFalse
+
+      verifyRequestTo("/resourceTest/indexIE.html")
+      verifyRequestTo("/resourceTest/stylesheet.css")
+
+      success
+    }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   private val uncommonsMaths                 = "io.gatling.uncommons.maths" % "uncommons-maths"    % "1.2.3"      classifier "jdk6"
   private val joddLagarto                    = "org.jodd"                   % "jodd-lagarto"       % "3.6.0-BETA1"
   private val jzlib                          = "com.jcraft"                 % "jzlib"              % "1.1.3"
-  private val redisClient                    =  "net.debasishg"             %% "redisclient"       % "2.12"
+  private val redisClient                    = "net.debasishg"             %% "redisclient"        % "2.12"
   private val zinc                           = "com.typesafe.zinc"          % "zinc"               % "0.3.5"
   private val openCsv                        = "net.sf.opencsv"             % "opencsv"            % "2.3"
   private val jmsApi                         = "javax.jms"                  % "jms-api"            % "1.1-rev-1"


### PR DESCRIPTION
Currently jodd conditional comments matcher is invoked through reflection since its match method is protected. I've filled an issue about this and when it will be fix or if jodd's author will provide some workaround, I'll replace reflection with a usual method call.
