### PR TITLE
Clean up dependencies handling

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -18,6 +18,7 @@ object BuildSettings {
     startYear             := Some(2011),
     licenses              := Seq("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     scalaVersion          := "2.10.4",
+    autoScalaLibrary      := false,
     resolvers             := Seq(Resolver.mavenLocal, sonatypeSnapshots),
     javacOptions          := Seq("-Xlint:-options","-source", "1.6", "-target", "1.6"),
     scalacOptions         := Seq(
@@ -43,7 +44,7 @@ object BuildSettings {
   /****************************/
 
   lazy val scaladocSettings = Seq(
-    apiMappings += scalaInstance.value.libraryJar -> url(s"http://www.scala-lang.org/api/${scalaVersion.value}/")
+    autoAPIMappings := true
   )
 
   lazy val docSettings = unidocSettings ++ site.settings ++ site.sphinxSupport() ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
 
   private val akkaVersion                    = "2.2.4"
 
+  private def scalaLibrary(version: String)  = "org.scala-lang"             % "scala-library"          % version
   private def scalaCompiler(version: String) = "org.scala-lang"             % "scala-compiler"         % version
   private def scalaReflect(version: String)  = "org.scala-lang"             % "scala-reflect"          % version
   private def scalaSwing(version: String)    = "org.scala-lang"             % "scala-swing"            % version
@@ -55,10 +56,15 @@ object Dependencies {
   /** Dependencies by module **/
   /****************************/
 
-  def coreDependencies(scalaVersion: String) = Seq(
-    scalaCompiler(scalaVersion), jsr166e, akkaActor, saxon, jodaTime, jodaConvert, slf4jApi, scalalogging,
-    scalaReflect(scalaVersion), jsonpath, jackson, boon, uncommonsMaths, joddLagarto, config, fastring,
-    openCsv, logbackClassic) ++ testDeps
+  def coreDependencies(scalaVersion: String) = {
+    def scalaLibs(version: String) = Seq(scalaLibrary _, scalaCompiler _, scalaReflect _).map(_(version))
+    val loggingLibs = Seq(slf4jApi, scalalogging, logbackClassic)
+    val checksLibs = Seq(jsonpath, jackson, boon, saxon, joddLagarto)
+    val dateLibs = Seq(jodaTime, jodaConvert)
+
+    Seq(jsr166e, akkaActor, uncommonsMaths, config, fastring, openCsv) ++
+    scalaLibs(scalaVersion) ++ loggingLibs ++ checksLibs ++ dateLibs ++ testDeps
+  }
 
   val redisDependencies = redisClient +: testDeps
 


### PR DESCRIPTION
List of changes : 
- Remove automatic dependency on scala-library, set it manually => autoApiMappings works now with Scala's standard library
- Regroup core dependencies by "topic"
