### PR TITLE
Exclude App & Recorder from public Scaladoc

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -3,9 +3,13 @@ import sbt.Keys._
 
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+
 import com.typesafe.sbt.SbtSite.site
+
 import net.virtualvoid.sbt.graph.Plugin.graphSettings
+
 import sbtunidoc.Plugin.{ ScalaUnidoc, unidocSettings }
+import sbtunidoc.Plugin.UnidocKeys.{ unidoc, unidocProjectFilter }
 
 import Resolvers._
 
@@ -50,6 +54,10 @@ object BuildSettings {
   lazy val docSettings = unidocSettings ++ site.settings ++ site.sphinxSupport() ++ Seq(
     site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "latest/api")
   ) ++ scaladocSettings
+
+  def excludeFromUnidoc(projects: Project*) = Seq (
+    unidocProjectFilter in (ScalaUnidoc, unidoc) := projects.foldLeft(inAnyProject)(_ -- inProjects(_))
+  )
 
   /**************************************/
   /** gatling-charts specific settings **/

--- a/project/GatlingBuild.scala
+++ b/project/GatlingBuild.scala
@@ -21,6 +21,7 @@ object GatlingBuild extends Build {
     .settings(basicSettings: _*)
     .settings(noCodeToPublish: _*)
     .settings(docSettings: _*)
+    .settings(excludeFromUnidoc(app, recorder): _*)
 
   /*************/
   /** Modules **/


### PR DESCRIPTION
As App & Recorder APIs are not meant to be consumed by users directly, this PR excludes them from the unified Scaladoc generated by sbt-unidoc.
