### PR TITLE
HTTP: Refactor extraInfoExtractor

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/Predef.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/Predef.scala
@@ -15,15 +15,15 @@
  */
 package io.gatling.http
 
-import io.gatling.core.result.message.{ KO, Status }
-import io.gatling.core.session.{ Expression, Session }
+import io.gatling.core.result.message.KO
+import io.gatling.core.session.Expression
 import io.gatling.http.action.{ AddCookieBuilder, CookieDSL }
 import io.gatling.http.cache.CacheHandling
 import io.gatling.http.check.HttpCheckSupport
 import io.gatling.http.config.HttpProtocolBuilder
 import io.gatling.http.cookie.CookieHandling
 import io.gatling.http.feeder.SitemapFeederSupport
-import io.gatling.http.request.BodyProcessors
+import io.gatling.http.request.{ ExtraInfo, BodyProcessors }
 import io.gatling.http.request.builder.Http
 import io.gatling.http.check.ws.WsCheckSupport
 import io.gatling.http.request.builder.ws.Ws
@@ -51,8 +51,8 @@ object Predef extends HttpCheckSupport with WsCheckSupport with SitemapFeederSup
   val gzipBody = BodyProcessors.Gzip
   val streamBody = BodyProcessors.Stream
 
-  def dumpSessionOnFailure(status: Status, session: Session, request: Request, response: Response): List[String] = status match {
-    case KO => List(session.toString)
+  val dumpSessionOnFailure: ExtraInfo => List[Any] = extraInfo => extraInfo.status match {
+    case KO => List(extraInfo.session)
     case _  => Nil
   }
 

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandlerActor.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/AsyncHandlerActor.scala
@@ -37,6 +37,7 @@ import io.gatling.http.check.{ HttpCheck, HttpCheckTarget }
 import io.gatling.http.cookie.CookieHandling
 import io.gatling.http.fetch.{ CssResourceFetched, RegularResourceFetched, ResourceFetcher }
 import io.gatling.http.referer.RefererHandling
+import io.gatling.http.request.ExtraInfo
 import io.gatling.http.response.Response
 import io.gatling.http.util.HttpHelper
 import io.gatling.http.util.HttpHelper.{ isCss, resolveFromURI }
@@ -119,7 +120,7 @@ class AsyncHandlerActor extends BaseActor with DataWriterClient {
 
       val extraInfo: List[Any] = try {
         tx.request.config.extraInfoExtractor match {
-          case Some(extractor) => extractor(tx.request.requestName, status, tx.session, tx.request.ahcRequest, response)
+          case Some(extractor) => extractor(ExtraInfo(tx.request.requestName, status, tx.session, tx.request.ahcRequest, response))
           case _               => Nil
         }
       } catch {

--- a/gatling-http/src/main/scala/io/gatling/http/request/package.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/package.scala
@@ -22,5 +22,13 @@ import io.gatling.core.session.Session
 import io.gatling.http.response.Response
 
 package object request {
-  type ExtraInfoExtractor = (String, Status, Session, Request, Response) => List[Any]
+
+  case class ExtraInfo(
+    requestName: String,
+    status: Status,
+    session: Session,
+    request: Request,
+    response: Response)
+
+  type ExtraInfoExtractor = ExtraInfo => List[Any]
 }

--- a/gatling-http/src/test/scala/io/gatling/http/HttpCompileTest.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/HttpCompileTest.scala
@@ -49,8 +49,10 @@ class HttpCompileTest extends Simulation {
     .warmUp("http://gatling.io")
     .inferHtmlResources(white = WhiteList(".*\\.html"))
 
+  val httpConfToVerifyDumpSessionOnFailureBuiltIn = http.extraInfoExtractor(dumpSessionOnFailure)
+
   val httpConfToVerifyUserProvidedInfoExtractors = http
-    .extraInfoExtractor((requestName, requestStatus, session, request, response) => Nil)
+    .extraInfoExtractor(extraInfo => List(extraInfo.requestName, extraInfo.response.body.string))
 
   val usersInformation = tsv("user_information.tsv")
 

--- a/gatling-http/src/test/scala/io/gatling/http/config/HttpProtocolBuilderSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/config/HttpProtocolBuilderSpec.scala
@@ -17,12 +17,8 @@ package io.gatling.http.config
 
 import org.scalatest.{ FlatSpec, Matchers }
 
-import com.ning.http.client.Request
-
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.result.message.Status
-import io.gatling.core.session.Session
-import io.gatling.http.response.Response
+import io.gatling.http.request.ExtraInfo
 
 class HttpProtocolBuilderSpec extends FlatSpec with Matchers {
 
@@ -30,7 +26,7 @@ class HttpProtocolBuilderSpec extends FlatSpec with Matchers {
 
   "http protocol configuration builder" should "support an optional extra info extractor" in {
 
-    val expectedExtractor = (requestName: String, status: Status, session: Session, request: Request, response: Response) => Nil
+    val expectedExtractor = (extraInfo: ExtraInfo) => Nil
 
     val builder = HttpProtocolBuilder.DefaultHttpProtocolBuilder
       .disableWarmUp

--- a/src/sphinx/http/http_protocol.rst
+++ b/src/sphinx/http/http_protocol.rst
@@ -238,17 +238,24 @@ Dumping custom data
 Some people might want more data than what Gatling normally dumps in the ``simulation.log`` file.
 
 Http protocol provide a hook for dumping extra data with ``extraInfoExtractor(f: ExtraInfoExtractor)``.
-``ExtraInfoExtractor`` is a shortcut for the function type: ``(String, Status, Session, Request, Response) => List[Any]``.
-Thus your extractor need to return a ``List[Any]``, ``Any`` is the equivalent of ``Object`` in Scala, and have access to:
+``ExtraInfoExtractor`` is a shortcut for the function type: ``(ExtraInfo) => List[Any]``.
+Thus your extractor need to return a ``List[Any]``, ``Any`` is the equivalent of ``Object`` in Scala.
+``ExtraInfo`` gives you access to :
 
-* The name of the request.
-* The status of the request, i.e. OK/KO.
-* The user Sesion.
-* The http request.
-* The http response.
+* ``requestName``: The name of the request.
+* ``status``: The status of the request, i.e. OK/KO.
+* ``session``: The user's Session.
+* ``request``: The http request.
+* ``response``: The http response.
 
 The extra data will be appended to the relative records in the ``simulation.log`` file and reports generation will ignore them.
 It's up to the user to build his own analysis system for them.
+
+For example, it you'd like the dump the response body's length to ``simulation.log``, you would do::
+
+  val httpProtocol = http.extraInfoExtractor(extraInfo => List(extraInfo.response.bodyLength))
+
+Gatling provides a built-in ``ExtraInfoExtractor``, ``dumpSessionOnFailure``, which dumps the user's session to ``simulation.log`` if the request failed.
 
 .. _http-protocol-processor:
 


### PR DESCRIPTION
This PR slightly modifies `extraInfoExtractor` to change its signature.
Instead of taking of `(String, Status, Session, Request, Response) => List[Any]` function parameter, it would take a `ExtraInfo => List[Any]` parameter, with `ExtraInfo` being a class which holds the values for what were previously the parameters.
