### PR TITLE
Make gatling.jks location absolute

### DIFF
--- a/gatling-recorder/src/main/scala/org/jboss/netty/example/securechat/SecureChatSslContextFactory.scala
+++ b/gatling-recorder/src/main/scala/org/jboss/netty/example/securechat/SecureChatSslContextFactory.scala
@@ -59,7 +59,7 @@ object SecureChatSslContextFactory extends StrictLogging {
   val Protocol = "TLS"
   val PropertyKeystorePath = "gatling.recorder.keystore.path"
   val PropertyKeystorePassphrase = "gatling.recorder.keystore.passphrase"
-  val DefaultKeyStore = "gatling.jks"
+  val DefaultKeyStore = "/gatling.jks"
   val DefaultKeyStorePassphrase = "gatling"
 
   val ServerContext: SSLContext = {


### PR DESCRIPTION
Make gatling.jks location absolute. Otherwise, `Class.getResource` resolves it to "org/jboss/netty/example/securechat/gatling.jks".
