### PR TITLE
Integer overflow when calculating standard deviation with slow requests

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/result/reader/buffers/GeneralStatsBuffers.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/result/reader/buffers/GeneralStatsBuffers.scala
@@ -72,7 +72,7 @@ class GeneralStatsBuffer(duration: Long) extends CountBuffer {
   override def update(time: Int): Unit = {
     super.update(time)
     digest.add(time)
-    sumOfSquares += time * time
+    sumOfSquares += time.toLong * time.toLong
     sum += time
   }
 


### PR DESCRIPTION
If requests take longer than 46340 ms, `time * time` overflows when calculating standard deviations, since `46341 * 46341 == 2147488281 > 2147483647 == Integer.MaxValue`.
