### PR TITLE
HTTPS requests don't need to be relativized - fixes #2111

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/server/HttpsServerHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/server/HttpsServerHandler.scala
@@ -77,7 +77,7 @@ class HttpsServerHandler(proxy: HttpProxy) extends ServerHandler(proxy) with Sca
           case Some(clientChannel) if clientChannel.isConnected && clientChannel.isOpen =>
             // set full uri so that it's correctly recorded
             val loggedRequest = buildRequestWithAbsoluteURI(request, targetHostURI)
-            writeRequestToClient(clientChannel, buildRequestWithRelativeURI(request), loggedRequest)
+            writeRequestToClient(clientChannel, request, loggedRequest)
 
           case _ =>
             _clientChannel = None


### PR DESCRIPTION
HTTPS requests don't need to be made relative. HTTP requests do, since Gatling Recorder receives messages intended for the proxy, but for HTTPS, the request to the proxy is a CONNECT, and the subsequent GET/POST/whatever via the CONNECTed channel is already to a relative address.
