### PR TITLE
HTTP: Session-Context sensitive SignatureCalculators

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocol.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocol.scala
@@ -183,7 +183,7 @@ case class HttpProtocolRequestPart(
   disableUrlEscaping: Boolean,
   silentURI: Option[Pattern],
   silentResources: Boolean,
-  signatureCalculator: Option[SignatureCalculator])
+  signatureCalculator: Option[Expression[SignatureCalculator]])
 
 case class HttpProtocolResponsePart(
   followRedirect: Boolean,

--- a/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocolBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/config/HttpProtocolBuilder.scala
@@ -21,8 +21,9 @@ import com.ning.http.client.{ RequestBuilderBase, Request, SignatureCalculator, 
 import com.typesafe.scalalogging.slf4j.StrictLogging
 
 import io.gatling.core.filter.{ BlackList, Filters, WhiteList }
-import io.gatling.core.session.Expression
+import io.gatling.core.session._
 import io.gatling.core.session.el.EL
+import io.gatling.core.validation._
 import io.gatling.http.HeaderNames._
 import io.gatling.http.ahc.ProxyConverter
 import io.gatling.http.check.HttpCheck
@@ -91,7 +92,8 @@ case class HttpProtocolBuilder(protocol: HttpProtocol) extends StrictLogging {
   def silentResources = newRequestPart(protocol.requestPart.copy(silentResources = true))
   def silentURI(regex: String) = newRequestPart(protocol.requestPart.copy(silentURI = Some(regex.r.pattern)))
   def disableUrlEscaping = newRequestPart(protocol.requestPart.copy(disableUrlEscaping = true))
-  def signatureCalculator(calculator: SignatureCalculator): HttpProtocolBuilder = newRequestPart(protocol.requestPart.copy(signatureCalculator = Some(calculator)))
+  def signatureCalculator(calculator: Expression[SignatureCalculator]): HttpProtocolBuilder = newRequestPart(protocol.requestPart.copy(signatureCalculator = Some(calculator)))
+  def signatureCalculator(calculator: SignatureCalculator): HttpProtocolBuilder = signatureCalculator(calculator.expression)
   def signatureCalculator(calculator: (Request, RequestBuilderBase[_]) => Unit): HttpProtocolBuilder = signatureCalculator(new SignatureCalculator {
     def calculateAndAddSignature(request: Request, requestBuilder: RequestBuilderBase[_]): Unit = calculator(request, requestBuilder)
   })

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestBuilder.scala
@@ -121,14 +121,14 @@ abstract class AbstractHttpRequestBuilder[B <: AbstractHttpRequestBuilder[B]](co
 
     val resolvedRequestExpression = request(protocol)
 
-    val resolvedSignatureCalculator = commonAttributes.signatureCalculator.orElse(protocol.requestPart.signatureCalculator)
+    val resolvedSignatureCalculatorExpression = commonAttributes.signatureCalculator.orElse(protocol.requestPart.signatureCalculator)
 
     val resolvedDiscardResponseChunks = httpAttributes.discardResponseChunks && protocol.responsePart.discardResponseChunks
 
     HttpRequestDef(
       commonAttributes.requestName,
       resolvedRequestExpression,
-      resolvedSignatureCalculator,
+      resolvedSignatureCalculatorExpression,
       HttpRequestConfig(
         checks = resolvedChecks,
         responseTransformer = resolvedResponseTransformer,

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestBuilder.scala
@@ -21,8 +21,9 @@ import com.ning.http.client._
 import com.ning.http.client.uri.UriComponents
 import com.typesafe.scalalogging.slf4j.StrictLogging
 
-import io.gatling.core.session.{ Expression, ExpressionWrapper }
+import io.gatling.core.session._
 import io.gatling.core.session.el.EL
+import io.gatling.core.validation._
 import io.gatling.http.check.status.HttpStatusCheckBuilder._
 import io.gatling.http.util.HttpHelper._
 import io.gatling.http.{ HeaderNames, HeaderValues }
@@ -42,7 +43,7 @@ case class CommonAttributes(
   address: Option[InetAddress] = None,
   proxy: Option[ProxyServer] = None,
   secureProxy: Option[ProxyServer] = None,
-  signatureCalculator: Option[SignatureCalculator] = None)
+  signatureCalculator: Option[Expression[SignatureCalculator]] = None)
 
 object RequestBuilder {
 
@@ -115,7 +116,8 @@ abstract class RequestBuilder[B <: RequestBuilder[B]](val commonAttributes: Comm
 
   def proxy(httpProxy: Proxy): B = newInstance(commonAttributes.copy(proxy = Some(httpProxy.proxyServer), secureProxy = httpProxy.secureProxyServer))
 
-  def signatureCalculator(calculator: SignatureCalculator): B = newInstance(commonAttributes.copy(signatureCalculator = Some(calculator)))
+  def signatureCalculator(calculator: Expression[SignatureCalculator]): B = newInstance(commonAttributes.copy(signatureCalculator = Some(calculator)))
+  def signatureCalculator(calculator: SignatureCalculator): B = signatureCalculator(calculator.expression)
   def signatureCalculator(calculator: (Request, RequestBuilderBase[_]) => Unit): B = signatureCalculator(new SignatureCalculator {
     def calculateAndAddSignature(request: Request, requestBuilder: RequestBuilderBase[_]): Unit = calculator(request, requestBuilder)
   })

--- a/gatling-http/src/test/scala/io/gatling/http/request/builder/HttpRequestBuilderSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/request/builder/HttpRequestBuilderSpec.scala
@@ -23,7 +23,8 @@ import com.ning.http.client.uri.UriComponents
 import com.ning.http.client.{ Request, RequestBuilderBase, SignatureCalculator }
 
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.validation.Success
+import io.gatling.core.session.{ Session, Expression }
+import io.gatling.core.validation.{ Success, Failure }
 import io.gatling.http.config.HttpProtocol
 
 class HttpRequestBuilderSpec extends FlatSpec with Matchers with MockitoSugar {
@@ -35,7 +36,7 @@ class HttpRequestBuilderSpec extends FlatSpec with Matchers with MockitoSugar {
 
   "request builder" should "set signature calculator object" in {
     var builder = new HttpRequestBuilder(mockComonAttributes(), HttpAttributes())
-    val sigCalc = mock[SignatureCalculator]
+    val sigCalc = mock[Expression[SignatureCalculator]]
     builder = builder.signatureCalculator(sigCalc)
 
     val httpRequest = builder.build(HttpProtocol.DefaultHttpProtocol, throttled = false)
@@ -48,12 +49,15 @@ class HttpRequestBuilderSpec extends FlatSpec with Matchers with MockitoSugar {
     builder = builder.signatureCalculator(sigCalcFunc)
 
     val httpRequest = builder.build(HttpProtocol.DefaultHttpProtocol, throttled = false)
-    val sigCalc = httpRequest.signatureCalculator.get
+    val sigCalc = (httpRequest.signatureCalculator.get)(mock[Session])
 
     val mockRequest = mock[Request]
     val mockRequestBuilder = mock[RequestBuilderBase[_]]
 
-    sigCalc.calculateAndAddSignature(mockRequest, mockRequestBuilder)
+    sigCalc match {
+      case Success(sc) => sc.calculateAndAddSignature(mockRequest, mockRequestBuilder)
+      case Failure(e)  => ()
+    }
     verify(sigCalcFunc, times(1)).apply(mockRequest, mockRequestBuilder)
   }
 }

--- a/src/sphinx/http/http_request.rst
+++ b/src/sphinx/http/http_request.rst
@@ -193,12 +193,16 @@ Gatling exposes AsyncHttpClient's ``SignatureCalculator`` API::
 
 So, basically, you have to read the proper information from the ``url`` and ``request`` parameters, compute the new information out of them, such as a HMAC header, and set it on the ``requestBuilder``.
 
-There's 2 ways to set a SignatureCalculator on a request::
+There's 3 ways to set a SignatureCalculator on a request::
 
   .signatureCalculator(calculator: SignatureCalculator)
 
-  // use this signature is you want to directly pass a function instead of a SignatureCalculator
+  // use this signature if you want to directly pass a function instead of a SignatureCalculator
   .signatureCalculator(calculator: (Request, RequestBuilderBase[_]) => Unit)
+
+  // use this signature if you need information from the session to compute the signature (e.g. user specific authentication keys)
+  // does not work with an anonymous function as in the second signature
+  .signatureCalculator(calculator: Expression[SignatureCalculator])
 
 .. _http-request-authentication:
 


### PR DESCRIPTION
adds the possibility to set a signatureCalculator as Expression[SignatureCalculator]

This allows you to e.g. use a user-specific key to sign a request. While it has to change a few internals, it leaves the API unchanged except for adding:
  signatureCalculator(Expression[SignatureCalculator]])
as a way to specify the signature calculator
