### PR TITLE
HTTP: support regex for current location checks

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/check/HttpCheckBuilders.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/HttpCheckBuilders.scala
@@ -38,4 +38,5 @@ object HttpCheckBuilders {
   val PassThroughResponsePreparer: Preparer[Response, Response] = (r: Response) => r.success
   val ResponseBodyStringPreparer: Preparer[Response, String] = (response: Response) => response.body.string.success
   val ResponseBodyBytesPreparer: Preparer[Response, Array[Byte]] = (response: Response) => response.body.bytes.success
+  val UrlStringPreparer: Preparer[Response, String] = (response: Response) => response.request.getUrl.success
 }

--- a/gatling-http/src/main/scala/io/gatling/http/check/HttpCheckSupport.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/HttpCheckSupport.scala
@@ -21,7 +21,7 @@ import io.gatling.http.check.checksum.HttpChecksumCheckBuilder
 import io.gatling.http.check.header.{ HttpHeaderCheckBuilder, HttpHeaderRegexCheckBuilder }
 import io.gatling.http.check.status.HttpStatusCheckBuilder
 import io.gatling.http.check.time.HttpResponseTimeCheckBuilder
-import io.gatling.http.check.url.CurrentLocationCheckBuilder
+import io.gatling.http.check.url.{ CurrentLocationRegexCheckBuilder, CurrentLocationCheckBuilder }
 
 trait HttpCheckSupport {
 
@@ -45,6 +45,7 @@ trait HttpCheckSupport {
   val status = HttpStatusCheckBuilder.Status
 
   val currentLocation = CurrentLocationCheckBuilder.CurrentLocation
+  val currentLocationRegex = CurrentLocationRegexCheckBuilder.currentLocationRegex _
 
   val md5 = HttpChecksumCheckBuilder.Md5
   val sha1 = HttpChecksumCheckBuilder.Sha1

--- a/gatling-http/src/main/scala/io/gatling/http/check/url/CurrentLocationRegexCheckBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/url/CurrentLocationRegexCheckBuilder.scala
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2011-2014 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.http.check.url
+
+import io.gatling.core.check.DefaultMultipleFindCheckBuilder
+import io.gatling.core.check.extractor.regex.{ CountRegexExtractor, MultipleRegexExtractor, SingleRegexExtractor, GroupExtractor }
+import io.gatling.core.session._
+import io.gatling.http.check.HttpCheck
+import io.gatling.http.check.HttpCheckBuilders._
+import io.gatling.http.response.Response
+
+trait CurrentLocationRegexOfType { self: CurrentLocationRegexCheckBuilder[String] =>
+
+  def ofType[X: GroupExtractor] = new CurrentLocationRegexCheckBuilder[X](expression)
+}
+
+object CurrentLocationRegexCheckBuilder {
+
+  def currentLocationRegex(expression: Expression[String]) = new CurrentLocationRegexCheckBuilder[String](expression) with CurrentLocationRegexOfType
+}
+
+/**
+ * Gatling check builder that allows for validating request URLs
+ * with regex patterns.
+ *
+ * @param expression
+ * @tparam X
+ */
+class CurrentLocationRegexCheckBuilder[X: GroupExtractor](private[url] val expression: Expression[String])
+    extends DefaultMultipleFindCheckBuilder[HttpCheck, Response, CharSequence, X](
+      StringBodyCheckFactory,
+      UrlStringPreparer) {
+
+  def findExtractor(occurrence: Int) = expression.map(new SingleRegexExtractor(_, occurrence))
+  def findAllExtractor = expression.map(new MultipleRegexExtractor(_))
+  def countExtractor = expression.map(new CountRegexExtractor(_))
+}


### PR DESCRIPTION
Adds regex pattern matching checks for the current location similar to how regex body checks are done.

fixes https://github.com/gatling/gatling/issues/2169
