### PR TITLE
HTTP: Accept Jsonp format that ends with semicolon

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/check/body/HttpBodyJsonpJsonPathCheckBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/body/HttpBodyJsonpJsonPathCheckBuilder.scala
@@ -35,7 +35,7 @@ trait HttpBodyJsonpJsonPathOfType {
 
 object HttpBodyJsonpJsonPathCheckBuilder extends StrictLogging {
 
-  val JsonpRegex = """^\w+(?:\[\"\w+\"\]|\.\w+)*\((.*)\)$""".r
+  val JsonpRegex = """^\w+(?:\[\"\w+\"\]|\.\w+)*\((.*)\);?\s*$""".r
 
   val JsonParser = TheStringImplementation match {
     case DirectCharsBasedStringImplementation => Boon


### PR DESCRIPTION
Jsonp sometimes takes semicolon.
Following formats are proposed as "standard" in http://json-p.org/
- functionName({JSON});
- obj.functionName({JSON});
- obj["function-name"]({JSON});

Yep, I know PR need tests.
This is just a notice to your commiters rather than PR. thanks
