### PR TITLE
Fix unsafe RedisHelper.generateRedisProtocol

### DIFF
--- a/gatling-redis/src/main/scala/io/gatling/redis/util/RedisHelper.scala
+++ b/gatling-redis/src/main/scala/io/gatling/redis/util/RedisHelper.scala
@@ -18,6 +18,7 @@ package io.gatling.redis.util
 object RedisHelper {
 
   val Crlf = "\r\n"
+  val Charset = java.nio.charset.Charset.forName("UTF-8")
 
   /**
    * Generate Redis protocol required for mass insert
@@ -25,7 +26,10 @@ object RedisHelper {
    */
   def generateRedisProtocol(d: String*): String = {
     val protocol = new StringBuilder().append("*").append(d.length).append(Crlf)
-    d.foreach(x => protocol.append("$").append(x.length).append(Crlf).append(x).append(Crlf))
+    d.foreach { x =>
+      val length = x.getBytes(Charset).length
+      protocol.append("$").append(length).append(Crlf).append(x).append(Crlf)
+    }
     protocol.toString()
   }
 }

--- a/gatling-redis/src/test/scala/io/gatling/redis/util/RedisHelperSpec.scala
+++ b/gatling-redis/src/test/scala/io/gatling/redis/util/RedisHelperSpec.scala
@@ -26,4 +26,10 @@ class RedisHelperSpec extends FlatSpec with Matchers {
 
     generateRedisProtocol("SET", "mykey", "myvalue") shouldBe correctProtocol
   }
+
+  it should "count length by bytes length" in {
+    val correctProtocol = List("*3", "$3", "SET", "$5", "mykey", "$16", "もふもふmofu").mkString("", Crlf, Crlf)
+
+    generateRedisProtocol("SET", "mykey", "もふもふmofu") shouldBe correctProtocol
+  }
 }


### PR DESCRIPTION
On RESP, prefixed length of Bulk Strings should be bytes length, not UTF-16 length.

An example is [here](https://gist.github.com/okumin/0e7afd1b07db7810d79d).
