### PR TITLE
Core: Stringify FastCharSequence in EL

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/util/FastCharSequence.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/util/FastCharSequence.scala
@@ -32,4 +32,6 @@ class FastCharSequence(chars: Array[Char], offset: Int, count: Int) extends Char
   def charAt(index: Int): Char = chars(offset + index)
 
   def subSequence(start: Int, end: Int): CharSequence = new FastCharSequence(chars, offset + start, end - start)
+
+  override def toString: String = String.valueOf(chars, offset, count)
 }


### PR DESCRIPTION
Hi, all!
It seems EL doesn't care FastCharSequence. (snapshot-2.0.0-20140921.195443)
https://gist.github.com/maiha/bea79ddc4225e2fefd37

Please add a test :)

Maiha
