### PR TITLE
Allow configuration of recording super class

### DIFF
--- a/gatling-recorder/src/main/resources/recorder-defaults.conf
+++ b/gatling-recorder/src/main/resources/recorder-defaults.conf
@@ -4,6 +4,7 @@ recorder {
     outputFolder = ""                # The folder where generated simulation will we written
     package = ""                     # The package's name of the generated simulation
     className = "RecordedSimulation" # The name of the generated Simulation class
+    superClassName = "Simulation"    # The fully-qualified name of the generated Simulation's super class
     thresholdForPauseCreation = 100  # The minimum time, in milliseconds, that must pass between requests to trigger a pause creation
     saveConfig = false               # When set to true, the configuration from the Recorder GUI overwrites this configuration
   }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/CommandLineConstants.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/CommandLineConstants.scala
@@ -35,6 +35,7 @@ object CommandLineConstants {
   val OutputFolder = CommandLineConstant("output-folder", "of")
   val RequestBodiesFolder = CommandLineConstant("request-bodies-folder", "rbf")
   val ClassName = CommandLineConstant("class-name", "cn")
+  val SuperClassName = CommandLineConstant("super-class-name", "scn")
   val Package = CommandLineConstant("package", "pkg")
   val Encoding = CommandLineConstant("encoding", "enc")
   val FollowRedirect = CommandLineConstant("follow-redirect", "fr")

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/GatlingRecorder.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/GatlingRecorder.scala
@@ -33,6 +33,7 @@ object GatlingRecorder {
     opt[String](OutputFolder).valueName("<folderName>").foreach(props.simulationOutputFolder).text("Uses <folderName> as the folder where generated simulations will be stored")
     opt[String](RequestBodiesFolder).valueName("<folderName>").foreach(props.requestBodiesFolder).text("Uses <folderName> as the folder where request bodies are stored")
     opt[String](ClassName).foreach(props.simulationClassName).text("Sets the name of the generated class")
+    opt[String](SuperClassName).foreach(props.simulationSuperClassName).text("Sets the superclass of the generated class")
     opt[String](Package).foreach(props.simulationPackage).text("Sets the package of the generated class")
     opt[String](Encoding).foreach(props.encoding).text("Sets the encoding used in the recorder")
     opt[Boolean](FollowRedirect).foreach(props.followRedirect).text("""Sets the "Follow Redirects" option to true""")

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
@@ -25,6 +25,7 @@ object ConfigKeys {
     val RequestBodiesFolder = "recorder.core.requestBodiesFolder"
     val Package = "recorder.core.package"
     val ClassName = "recorder.core.className"
+    val SuperClassName = "recorder.core.superClassName"
     val ThresholdForPauseCreation = "recorder.core.thresholdForPauseCreation"
     val SaveConfig = "recorder.core.saveConfig"
   }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
@@ -126,6 +126,7 @@ object RecorderConfiguration extends StrictLogging {
         requestBodiesFolder = getRequestBodiesFolder,
         pkg = config.getString(core.Package),
         className = config.getString(core.ClassName),
+        superClassName = config.getString(core.SuperClassName),
         thresholdForPauseCreation = config.getInt(core.ThresholdForPauseCreation) milliseconds,
         saveConfig = config.getBoolean(core.SaveConfig)),
       filters = FiltersConfiguration(
@@ -172,6 +173,7 @@ case class CoreConfiguration(
   requestBodiesFolder: String,
   pkg: String,
   className: String,
+  superClassName: String,
   thresholdForPauseCreation: Duration,
   saveConfig: Boolean)
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
@@ -38,6 +38,9 @@ class RecorderPropertiesBuilder {
   def simulationClassName(className: String): Unit =
     props += core.ClassName -> className
 
+  def simulationSuperClassName(superClassName: String): Unit =
+    props += core.SuperClassName -> superClassName
+
   def thresholdForPauseCreation(threshold: String): Unit =
     props += core.ThresholdForPauseCreation -> threshold
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
@@ -137,7 +137,7 @@ object ScenarioExporter extends StrictLogging {
 
     val newScenarioElements = getChains(elements)
 
-    SimulationTemplate.render(config.core.pkg, config.core.className, protocolConfigElement, headers, config.core.className, newScenarioElements)
+    SimulationTemplate.render(config.core.pkg, config.core.className, config.core.superClassName, protocolConfigElement, headers, config.core.className, newScenarioElements)
   }
 
   private def getBaseHeaders(requestElements: Seq[RequestElement]): Map[String, String] = {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/SimulationTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/SimulationTemplate.scala
@@ -26,6 +26,7 @@ object SimulationTemplate {
 
   def render(packageName: String,
              simulationClassName: String,
+             simulationSuperClassName: String,
              protocol: ProtocolDefinition,
              headers: Map[Int, Seq[(String, String)]],
              scenarioName: String,
@@ -112,7 +113,7 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import io.gatling.jdbc.Predef._
 
-class $simulationClassName extends Simulation {
+class $simulationClassName extends $simulationSuperClassName {
 
 	val httpProtocol = http${renderProtocol(protocol)}
 


### PR DESCRIPTION
Recorded simulations extend `Simulation` by default.  This adds an
option to change this super class.

Pair: @michealbottjer/@rnewstead1
