### PR TITLE
Doc: Fix maven documentation : groupId

### DIFF
--- a/src/sphinx/extensions/maven_plugin.rst
+++ b/src/sphinx/extensions/maven_plugin.rst
@@ -20,7 +20,7 @@ Set up the gatling-maven-plugin
 
   <dependencies>
     <dependency>
-      <groupId>io.gatling</groupId>
+      <groupId>io.gatling.highcharts</groupId>
       <artifactId>gatling-charts-highcharts</artifactId>
       <version>X.Y.Z</version>
       <scope>test</scope>


### PR DESCRIPTION
groupId is wrong.
Should be `io.gatling.highcharts` as the sample
https://github.com/gatling/gatling-maven-plugin-demo/blob/master/pom.xml
