### PR TITLE
Reports: Fix formatting of non-integer percentiles

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/util/NumberHelper.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/util/NumberHelper.scala
@@ -17,6 +17,8 @@ package io.gatling.core.util
 
 object NumberHelper {
 
+  val formatter = new java.text.DecimalFormat("###.###")
+
   def extractLongValue(s: String, start: Int): Long = {
     assume(start >= 0 && start < s.length, s"Start=$start is not an acceptable starting index for the string=$s")
 
@@ -45,15 +47,11 @@ object NumberHelper {
 
     def toRank: String =
       if (double == Math.floor(double))
-        double.toInt.toString + suffix(double.toInt)
+        toPrintableString + suffix(double.toInt)
       else
         toPrintableString + suffix((double * 100).toInt % 100)
 
-    def toPrintableString: String = double match {
-      case d if d >= 1000.0 => d.round.toString
-      case d if d >= 100.0  => f"$d%.1f"
-      case d                => f"$d%.2f"
-    }
+    def toPrintableString: String = formatter.format(double)
   }
 
   object IntString {

--- a/gatling-core/src/test/scala/io/gatling/core/util/NumberHelperSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/util/NumberHelperSpec.scala
@@ -97,6 +97,10 @@ class NumberHelperSpec extends FlatSpec with Matchers {
     99.0.toRank shouldBe "99th"
   }
 
+  it should "return '99.8th' for 99.8" in {
+    99.8.toRank shouldBe "99.8th"
+  }
+
   it should "return '99.99th' for 99.99" in {
     99.99.toRank shouldBe "99.99th"
   }


### PR DESCRIPTION
We expect "99.9th" rather than "99.90th" (note trailing zero)
