### PR TITLE
App: CLI options parser refactoring

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/ArgsParser.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/ArgsParser.scala
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2011-2014 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.app
+
+import scopt.{ OptionDef, OptionParser, Read }
+
+import io.gatling.app.CommandLineConstants._
+import io.gatling.core.config.GatlingPropertiesBuilder
+
+private[app] class ArgsParser(args: Array[String]) {
+
+  private class GatlingOptionParser extends OptionParser[Unit]("gatling") {
+    def help(constant: CommandLineConstant): OptionDef[Unit, Unit] =
+      help(constant.full).abbr(constant.abbr)
+
+    def opt[A: Read](constant: CommandLineConstant): OptionDef[A, Unit] =
+      opt[A](constant.full).abbr(constant.abbr)
+  }
+
+  val props = new GatlingPropertiesBuilder
+
+  private val cliOptsParser = new GatlingOptionParser {
+
+    help(Help).text("Show help (this message) and exit")
+
+    opt[Unit](NoReports)
+      .foreach(_ => props.noReports())
+      .text("Runs simulation but does not generate reports")
+
+    opt[Unit](Mute)
+      .foreach(_ => props.mute())
+      .text("Runs in mute mode: don't asks for run description nor simulation ID, use defaults")
+
+    opt[String](ReportsOnly)
+      .foreach(props.reportsOnly)
+      .valueName("<directoryName>")
+      .text("Generates the reports for the simulation in <directoryName>")
+
+    opt[String](DataFolder)
+      .foreach(props.dataDirectory)
+      .valueName("<directoryPath>")
+      .text("Uses <directoryPath> as the absolute path of the directory where feeders are stored")
+
+    opt[String](ResultsFolder)
+      .foreach(props.resultsDirectory)
+      .valueName("<directoryPath>")
+      .text("Uses <directoryPath> as the absolute path of the directory where results are stored")
+
+    opt[String](RequestBodiesFolder)
+      .foreach(props.requestBodiesDirectory)
+      .valueName("<directoryPath>")
+      .text("Uses <directoryPath> as the absolute path of the directory where request bodies are stored")
+
+    opt[String](SimulationsFolder)
+      .foreach(props.sourcesDirectory)
+      .valueName("<directoryPath>")
+      .text("Uses <directoryPath> to discover simulations that could be run")
+
+    opt[String](Simulation)
+      .foreach(props.simulationClass)
+      .valueName("<className>")
+      .text("Runs <className> simulation")
+
+    opt[String](OutputDirectoryBaseName)
+      .foreach(props.outputDirectoryBaseName)
+      .valueName("<name>")
+      .text("Use <name> for the base name of the output directory")
+
+    opt[String](SimulationDescription)
+      .foreach(props.runDescription)
+      .valueName("<description>")
+      .text("A short <description> of the run to include in the report")
+  }
+
+  def parseArguments: Either[ConfigOverrides, StatusCode] =
+    if (cliOptsParser.parse(args)) Left(props.build)
+    else Right(GatlingStatusCodes.InvalidArguments)
+}

--- a/gatling-app/src/main/scala/io/gatling/app/CommandLineConstants.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/CommandLineConstants.scala
@@ -15,18 +15,9 @@
  */
 package io.gatling.app
 
-import scopt.{ Read, OptionDef, OptionParser }
-
 case class CommandLineConstant(full: String, abbr: String)
 
 object CommandLineConstants {
-
-  trait CommandLineConstantsSupport[C] { self: OptionParser[C] =>
-
-    def help(constant: CommandLineConstant): OptionDef[Unit, C] = help(constant.full).abbr(constant.abbr)
-    def opt[A: Read](constant: CommandLineConstant): OptionDef[A, C] = opt[A](constant.full).abbr(constant.abbr)
-  }
-
   val Help = CommandLineConstant("help", "h")
   val NoReports = CommandLineConstant("no-reports", "nr")
   val ReportsOnly = CommandLineConstant("reports-only", "ro")

--- a/gatling-app/src/main/scala/io/gatling/app/package.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/package.scala
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2011-2014 eBusiness Information, Groupe Excilys (www.ebusinessinformation.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling
+
+import io.gatling.core.scenario.Simulation
+
+import scala.collection.mutable
+
+package object app {
+
+  type ConfigOverrides = mutable.Map[String, _]
+  type StatusCode = Int
+
+  type SelectedSingleSimulation = Option[Class[Simulation]]
+  type AllSimulations = List[Class[Simulation]]
+}


### PR DESCRIPTION
This PR :
- Cleans up Gatling's companion object by moving CLI arguments parsing to `ArgsParser`
- Reformat the args parser so enhance readability
- Un-deprecate `fromMap`, introduce a `fromArgs` function to align with `fromMap` and deprecate `runGatling` instead
- Introduces a few type aliases for some selected types
