### PR TITLE
fix usage of defaultHttpCheck

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestBuilder.scala
@@ -138,9 +138,9 @@ class HttpRequestBuilder(commonAttributes: CommonAttributes, val httpAttributes:
 
     val resolvedChecks =
       if (checks.exists(_.scope == Status))
-        checks ::: List(RequestBuilder.DefaultHttpCheck)
-      else
         checks
+      else
+        checks ::: List(RequestBuilder.DefaultHttpCheck)
 
     val resolvedFollowRedirect = protocol.responsePart.followRedirect && httpAttributes.followRedirect
 


### PR DESCRIPTION
The following commit inverted the logic concerning defaultHttpCheck 

https://github.com/gatling/gatling/commit/2f2753f09dc59ed2cf4c42660027f8fb90cac03c#diff-97f347b96182fceee3597f9d3c0c8a5dR110

Took me some time to spot it after most of my tests started failing with 2.1.0 
