### PR TITLE
Make gatling-metrics classes package-private

### DIFF
--- a/gatling-metrics/src/main/scala/io/gatling/metrics/GraphiteDataWriter.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/GraphiteDataWriter.scala
@@ -27,14 +27,14 @@ import io.gatling.core.result.writer._
 import io.gatling.metrics.message._
 import io.gatling.metrics.types._
 
-object GraphiteDataWriter {
+private[metrics] object GraphiteDataWriter {
   import GraphitePath._
   val AllRequestsKey = graphitePath("allRequests")
   val UsersRootKey = graphitePath("users")
   val AllUsersKey = UsersRootKey / "allUsers"
 }
 
-class GraphiteDataWriter extends DataWriter {
+private[gatling] class GraphiteDataWriter extends DataWriter {
   import GraphiteDataWriter._
   import GraphitePath._
 

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/GraphitePath.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/GraphitePath.scala
@@ -17,7 +17,7 @@ package io.gatling.metrics
 
 import scala.collection.mutable
 
-object GraphitePath {
+private[metrics] object GraphitePath {
   private val sanitizeStringMemo = mutable.Map.empty[String, String]
   def sanitizeString(s: String) = sanitizeStringMemo.getOrElseUpdate(s, s.replace(' ', '_').replace('.', '-').replace('\\', '-'))
 
@@ -25,7 +25,7 @@ object GraphitePath {
   def graphitePath(path: List[String]) = new GraphitePath(path.map(sanitizeString))
 }
 
-case class GraphitePath private (path: List[String]) {
+private[metrics] case class GraphitePath private (path: List[String]) {
   import GraphitePath.sanitizeString
   def /(subPath: String) = new GraphitePath(sanitizeString(subPath) :: path)
   def pathKey = path.reverse.mkString(".")

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/message/GraphiteDataMessage.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/message/GraphiteDataMessage.scala
@@ -18,11 +18,11 @@ package io.gatling.metrics.message
 import io.gatling.metrics.GraphitePath
 import io.gatling.metrics.types.{ MetricByStatus, UsersBreakdown }
 
-sealed trait GraphiteDataMessage
+private[metrics] sealed trait GraphiteDataMessage
 
-case object Send extends GraphiteDataMessage
+private[metrics] case object Send extends GraphiteDataMessage
 
-case class SendMetrics(
+private[metrics] case class SendMetrics(
   requestMetrics: Map[GraphitePath, MetricByStatus],
   usersBreakdowns: Map[GraphitePath, UsersBreakdown])
     extends GraphiteDataMessage

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/message/MetricsSenderMessage.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/message/MetricsSenderMessage.scala
@@ -19,8 +19,8 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import akka.util.ByteString
 
-sealed trait MetricsSenderMessage
+private[metrics] sealed trait MetricsSenderMessage
 
-case class SendMetric[T: Numeric](metricPath: String, value: T, epoch: Long) extends MetricsSenderMessage {
+private[metrics] case class SendMetric[T: Numeric](metricPath: String, value: T, epoch: Long) extends MetricsSenderMessage {
   def byteString = ByteString(s"$metricPath $value $epoch\n", UTF_8.name)
 }

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/sender/MetricsSender.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/sender/MetricsSender.scala
@@ -25,7 +25,7 @@ import io.gatling.core.config.GatlingConfiguration.configuration
 import io.gatling.core.config._
 import io.gatling.metrics.message._
 
-object MetricsSender {
+private[metrics] object MetricsSender {
 
   def newMetricsSender: MetricsSender = {
     val remote = new InetSocketAddress(configuration.data.graphite.host, configuration.data.graphite.port)
@@ -36,7 +36,7 @@ object MetricsSender {
   }
 }
 
-abstract class MetricsSender extends BaseActor with Stash {
+private[metrics] abstract class MetricsSender extends BaseActor with Stash {
 
   def connected(connection: ActorRef): Receive = {
     case m: SendMetric[_] =>

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/sender/TcpSender.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/sender/TcpSender.scala
@@ -21,7 +21,7 @@ import akka.actor.ActorRef
 import akka.io.{ IO, Tcp }
 import akka.util.ByteString
 
-class TcpSender(remote: InetSocketAddress) extends MetricsSender {
+private[metrics] class TcpSender(remote: InetSocketAddress) extends MetricsSender {
 
   import Tcp._
 

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/sender/UdpSender.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/sender/UdpSender.scala
@@ -21,7 +21,7 @@ import akka.actor.ActorRef
 import akka.io.{ IO, Udp }
 import akka.util.ByteString
 
-class UdpSender(remote: InetSocketAddress) extends MetricsSender {
+private[metrics] class UdpSender(remote: InetSocketAddress) extends MetricsSender {
 
   import Udp._
 

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/types/RequestMetricsBuffer.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/types/RequestMetricsBuffer.scala
@@ -19,7 +19,7 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.result.message.{ KO, OK, Status }
 import com.tdunning.math.stats.{ AVLTreeDigest, TDigest }
 
-class RequestMetricsBuffer(implicit configuration: GatlingConfiguration) {
+private[metrics] class RequestMetricsBuffer(implicit configuration: GatlingConfiguration) {
 
   private val percentile1 = configuration.charting.indicators.percentile1 / 100.0
   private val percentile2 = configuration.charting.indicators.percentile2 / 100.0
@@ -63,5 +63,5 @@ class RequestMetricsBuffer(implicit configuration: GatlingConfiguration) {
   }
 }
 
-case class MetricByStatus(ok: Option[Metrics], ko: Option[Metrics], all: Option[Metrics])
-case class Metrics(count: Long, min: Int, max: Int, percentile1: Int, percentile2: Int, percentile3: Int, percentile4: Int)
+private[metrics] case class MetricByStatus(ok: Option[Metrics], ko: Option[Metrics], all: Option[Metrics])
+private[metrics] case class Metrics(count: Long, min: Int, max: Int, percentile1: Int, percentile2: Int, percentile3: Int, percentile4: Int)

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/types/UsersBreakdownBuffer.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/types/UsersBreakdownBuffer.scala
@@ -18,7 +18,7 @@ package io.gatling.metrics.types
 import io.gatling.core.result.message.{ End, Start }
 import io.gatling.core.result.writer.UserMessage
 
-class UsersBreakdownBuffer(val nbUsers: Int) {
+private[metrics] class UsersBreakdownBuffer(val nbUsers: Int) {
 
   private var _active = 0
   private var activeBuffer = 0
@@ -52,10 +52,10 @@ class UsersBreakdownBuffer(val nbUsers: Int) {
 
 }
 
-object UsersBreakdown {
+private[metrics] object UsersBreakdown {
   def apply(buf: UsersBreakdownBuffer): UsersBreakdown =
     UsersBreakdown(buf.nbUsers, buf.active, buf.waiting, buf.done)
 }
 
-case class UsersBreakdown(nbUsers: Int, active: Int, waiting: Int, done: Int)
+private[metrics] case class UsersBreakdown(nbUsers: Int, active: Int, waiting: Int, done: Int)
 


### PR DESCRIPTION
No classes of the whole `gatling-metrics` module needs to be exposed to users and, as a matter of fact, everything except `GraphiteDataWriter` itself needs to be used outside of the `gatling-metrics` module.
