### PR TITLE
Upgrade logback.xml, more verbose response loggers by default close #2509

### DIFF
--- a/gatling-core/src/main/resources/logback.dummy
+++ b/gatling-core/src/main/resources/logback.dummy
@@ -10,8 +10,10 @@
 
 	<!-- Uncomment for logging ALL HTTP request and responses -->
 	<!-- 	<logger name="io.gatling.http.ahc" level="TRACE" /> -->
+	<!--    <logger name="io.gatling.http.response" level="TRACE" /> -->
 	<!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
 	<!-- 	<logger name="io.gatling.http.ahc" level="DEBUG" /> -->
+	<!--    <logger name="io.gatling.http.response" level="DEBUG" /> -->
 
 	<root level="WARN">
 		<appender-ref ref="CONSOLE" />

--- a/src/sphinx/general/configuration.rst
+++ b/src/sphinx/general/configuration.rst
@@ -19,7 +19,7 @@ logback.xml
 This file allows you to configure the log level of Gatling.
 For further information, you should have a look at `Logback Documentation <http://logback.qos.ch/manual/index.html>`_.
 
-.. note:: In order to log requests and responses, uncomment the dedicated logger in the `default logging configuration file <https://github.com/gatling/gatling/blob/master/gatling-core/src/main/resources/logback.dummy>`_.
+.. note:: In order to log requests and responses, uncomment the dedicated loggers in the `default logging configuration file <https://github.com/gatling/gatling/blob/master/gatling-core/src/main/resources/logback.dummy>`_.
 
 gatling.conf
 ------------


### PR DESCRIPTION
Added commented out `DEBUG` / `TRACE` `io.gatling.http.response` loggers to the default `logback.xml`