### PR TITLE
SSE close action needs to wait a last event before being executed

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/action/sse/SseActor.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/sse/SseActor.scala
@@ -222,6 +222,9 @@ class SseActor(sseName: String) extends BaseActor with DataWriterClient {
           .applyUpdates(session)
           .copy(requestName = requestName, start = nowMillis, next = next)
 
+        logRequest(session, requestName, OK, newTx.start, nowMillis)
+        next ! session.remove(sseName)
+
         context.become(closingState(newTx))
 
       case OnThrowable(ttx, message, end) =>
@@ -239,9 +242,6 @@ class SseActor(sseName: String) extends BaseActor with DataWriterClient {
 
   def closingState(tx: SseTx): Receive = {
     case OnClose =>
-      import tx._
-      logRequest(session, requestName, OK, start, nowMillis)
-      next ! session.remove(sseName)
       context.stop(self)
 
     case unexpected =>


### PR DESCRIPTION
Hello,
When using the SSE protocol, the ```close()``` action has to wait another event sent by the SSE server before being triggered. In other words, as long as the sse server has not sent another event, the close action is not executed.

For instance, if you take the example below:  

```scala
class ProxyStockmarketSimulation extends Simulation {
  val httpConf = http
                 .baseURL("http://blablabl.com")
                 .doNotTrackHeader("1")

  val scn = scenario(this.getClass.getSimpleName)
            .exec(sse("sse").open("/app/stockmarket/prices"))
            .exec(sse("close").close())

  setUp(scn.inject(rampUsers(1) over 1)).protocols(httpConf)
}
```
The SSE server will sent one event when ```open()``` is called but the ```close()``` will not been triggered as long as the SSE server has not sent another event.  Which is not the expected behaviour.

The pull request fixes the issue.

Best regards,
Cédric