### PR TITLE
fix(SSE and wsAwait check): SSE blocking check does not stop after timeout

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/action/sse/SseHandler.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/sse/SseHandler.scala
@@ -43,6 +43,7 @@ class SseHandler(tx: SseTx, sseActor: ActorRef) extends AsyncHandler[Unit]
 
   override def onConnectionOpen(): Unit = {
     state = Open
+    sseActor ! OnOpen(tx, this, nowMillis)
   }
 
   override def onPoolConnection(): Unit = {}
@@ -65,7 +66,6 @@ class SseHandler(tx: SseTx, sseActor: ActorRef) extends AsyncHandler[Unit]
     logger.debug(s"Status $statusCode received for sse '${tx.requestName}")
 
     if (statusCode == OK.getCode) {
-      sseActor ! OnOpen(tx, this, nowMillis)
       CONTINUE
 
     } else {


### PR DESCRIPTION
The wsAwait check is not triggered and thus won't never timeout as long as the SSE server don't send at least one event. This comes from the fact that the SseHandler must send an "OnOpen" to the SseActor when the SseHandler connection received an "onConnectionOpen" and not when the SseHandler received a status from the SSE server ("onStatusReceived").