### PR TITLE
Fix gatling configuration not being resolved.

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/util/ConfigHelper.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/util/ConfigHelper.scala
@@ -28,5 +28,5 @@ object ConfigHelper {
    * @return the configuration with its fallback configs configured
    */
   def configChain(config: Config, fallbacks: Config*) =
-    fallbacks.foldLeft(config)(_ withFallback _)
+    fallbacks.foldLeft(config)(_ withFallback _).resolve
 }


### PR DESCRIPTION
This bug prevented from using environment variables in `gatling.conf` or any other dynamically resolved variables.