### PR TITLE
Update randomString example

### DIFF
--- a/src/sphinx/session/code/Feeders.scala
+++ b/src/sphinx/session/code/Feeders.scala
@@ -7,7 +7,7 @@ class Feeders {
   {
     //#random-mail-generator
     import scala.util.Random
-    val feeder = Iterator.continually(Map("email" -> (Random.nextString(20) + "@foo.com")))
+    val feeder = Iterator.continually(Map("email" -> Random.alphanumeric.take(20).mkString("","@foo.com","")))
     //#random-mail-generator
 
     //#feed


### PR DESCRIPTION
`Random.randomString(length)` returns non-ascii characters which will probably not work for most use-cases. 

I replaced it with `Random.alphanumeric.take(20).mkString(start,end,separator)` to only contain alphanumeric chars.