### PR TITLE
Recorder: Privatize most Recorder classes

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
@@ -15,7 +15,7 @@
  */
 package io.gatling.recorder.config
 
-object ConfigKeys {
+private[recorder] object ConfigKeys {
 
   val ConfigRoot = "recorder"
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
@@ -17,8 +17,6 @@ package io.gatling.recorder.config
 
 import java.io.FileNotFoundException
 import java.nio.file.Path
-
-import io.gatling.recorder.RecorderMode
 import io.gatling.recorder.http.ssl.{ KeyStoreType, HttpsMode }
 
 import scala.collection.JavaConversions._
@@ -39,7 +37,7 @@ import io.gatling.core.util.StringHelper.RichString
 
 import scala.util.control.NonFatal
 
-object RecorderConfiguration extends StrictLogging {
+private[recorder] object RecorderConfiguration extends StrictLogging {
 
   implicit class IntOption(val value: Int) extends AnyVal {
     def toOption = if (value != 0) Some(value) else None
@@ -169,7 +167,7 @@ object RecorderConfiguration extends StrictLogging {
   }
 }
 
-case class FiltersConfiguration(
+private[recorder] case class FiltersConfiguration(
     filterStrategy: FilterStrategy,
     whiteList: WhiteList,
     blackList: BlackList) {
@@ -181,7 +179,7 @@ case class FiltersConfiguration(
   }
 }
 
-case class CoreConfiguration(
+private[recorder] case class CoreConfiguration(
   mode: RecorderMode,
   encoding: String,
   outputFolder: String,
@@ -191,46 +189,46 @@ case class CoreConfiguration(
   thresholdForPauseCreation: Duration,
   saveConfig: Boolean)
 
-case class HttpConfiguration(
+private[recorder] case class HttpConfiguration(
   automaticReferer: Boolean,
   followRedirect: Boolean,
   inferHtmlResources: Boolean,
   removeCacheHeaders: Boolean,
   checkResponseBodies: Boolean)
 
-case class KeyStoreConfiguration(
+private[recorder] case class KeyStoreConfiguration(
   path: String,
   password: String,
   keyStoreType: KeyStoreType)
 
-case class CertificateAuthorityConfiguration(
+private[recorder] case class CertificateAuthorityConfiguration(
   certificatePath: String,
   privateKeyPath: String)
 
-case class HttpsModeConfiguration(
+private[recorder] case class HttpsModeConfiguration(
   mode: HttpsMode,
   keyStore: KeyStoreConfiguration,
   certificateAuthority: CertificateAuthorityConfiguration)
 
-case class OutgoingProxyConfiguration(
+private[recorder] case class OutgoingProxyConfiguration(
   host: Option[String],
   username: Option[String],
   password: Option[String],
   port: Option[Int],
   sslPort: Option[Int])
 
-case class ProxyConfiguration(
+private[recorder] case class ProxyConfiguration(
   port: Int,
   https: HttpsModeConfiguration,
   outgoing: OutgoingProxyConfiguration)
 
-case class NettyConfiguration(
+private[recorder] case class NettyConfiguration(
   maxInitialLineLength: Int,
   maxHeaderSize: Int,
   maxChunkSize: Int,
   maxContentLength: Int)
 
-case class RecorderConfiguration(
+private[recorder] case class RecorderConfiguration(
   core: CoreConfiguration,
   filters: FiltersConfiguration,
   http: HttpConfiguration,

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderMode.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderMode.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gatling.recorder
+package io.gatling.recorder.config
 
 import io.gatling.core.util.ClassSimpleNameToString
 import io.gatling.recorder.util.Labelled

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
@@ -17,8 +17,6 @@ package io.gatling.recorder.config
 
 import java.util.{ List => JList }
 
-import io.gatling.recorder.RecorderMode
-
 import scala.collection.mutable
 
 import io.gatling.recorder.config.ConfigKeys._

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/controller/RecorderController.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/controller/RecorderController.scala
@@ -18,6 +18,8 @@ package io.gatling.recorder.controller
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import io.gatling.recorder.config.{ RecorderMode, RecorderConfiguration, RecorderPropertiesBuilder }
+
 import com.ning.http.client.uri.Uri
 import io.gatling.recorder.http.handler.remote.TimedHttpRequest
 
@@ -33,21 +35,20 @@ import com.typesafe.scalalogging.StrictLogging
 
 import io.gatling.core.validation.{ Failure, Success }
 import io.gatling.core.util.PathHelper._
-import io.gatling.recorder.RecorderMode._
+import RecorderMode._
 import io.gatling.recorder.config.RecorderConfiguration
-import io.gatling.recorder.config.RecorderPropertiesBuilder
 import io.gatling.recorder.http.HttpProxy
 import io.gatling.recorder.scenario._
 import io.gatling.recorder.ui._
 
-object RecorderController {
+private[recorder] object RecorderController {
   def apply(props: mutable.Map[String, _], recorderConfigFile: Option[Path] = None): Unit = {
     RecorderConfiguration.initialSetup(props, recorderConfigFile)
     new RecorderController
   }
 }
 
-class RecorderController extends StrictLogging {
+private[recorder] class RecorderController extends StrictLogging {
 
   private val frontEnd = RecorderFrontend.newFrontend(this)
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarMapping.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarMapping.scala
@@ -23,10 +23,9 @@ import com.ning.http.util.Base64
 import scala.util.Try
 
 import io.gatling.core.util.StringHelper.RichString
-import io.gatling.recorder.util.Json
-import io.gatling.recorder.util.Json.{ JsonToInt, JsonToString }
+import Json.{ JsonToInt, JsonToString }
 
-object HarMapping {
+private[har] object HarMapping {
 
   private val ProtectedValue = """"(.*)\"""".r
   private val Iso8601ZonedDateAndTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
@@ -95,24 +94,24 @@ object HarMapping {
 /*
  * HAR mapping is incomplete, as we deserialize only what is strictly necessary for building a simulation
  */
-case class HttpArchive(log: Log)
+private[har] case class HttpArchive(log: Log)
 
-case class Log(exchanges: Seq[Entry])
+private[har] case class Log(exchanges: Seq[Entry])
 
-case class Entry(sendTime: Long, arrivalTime: Long, request: Request, response: Response)
+private[har] case class Entry(sendTime: Long, arrivalTime: Long, request: Request, response: Response)
 
-case class Request(method: String, url: String, headers: Seq[Header], postData: Option[PostData])
+private[har] case class Request(method: String, url: String, headers: Seq[Header], postData: Option[PostData])
 
-case class Response(status: Int, content: Content)
+private[har] case class Response(status: Int, content: Content)
 
-case class Content(mimeType: String, text: Option[String]) {
+private[har] case class Content(mimeType: String, text: Option[String]) {
   def textAsBytes = text.map(_.getBytes(HarMapping.Charset))
 }
 
-case class Header(name: String, value: String)
+private[har] case class Header(name: String, value: String)
 
-case class PostData(mimeType: String, text: String, params: Seq[PostParam]) {
+private[har] case class PostData(mimeType: String, text: String, params: Seq[PostParam]) {
   def textAsBytes = text.trimToOption.map(_.getBytes(HarMapping.Charset))
 }
 
-case class PostParam(name: String, value: String)
+private[har] case class PostParam(name: String, value: String)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarReader.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarReader.scala
@@ -28,13 +28,12 @@ import io.gatling.http.HeaderNames._
 import io.gatling.http.fetch.HtmlParser
 import io.gatling.recorder.config.RecorderConfiguration
 import io.gatling.recorder.scenario._
-import io.gatling.recorder.util.Json
 import org.jboss.netty.handler.codec.http.HttpMethod
 
 /**
  * Implementation according to http://www.softwareishard.com/blog/har-12-spec/
  */
-object HarReader {
+private[recorder] object HarReader {
 
   def apply(path: String)(implicit config: RecorderConfiguration): ScenarioDefinition =
     withCloseable(new FileInputStream(path))(apply(_))

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/har/Json.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/har/Json.scala
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gatling.recorder.util
+package io.gatling.recorder.har
 
 import java.io.InputStream
 import java.util.{ List => JList, Map => JMap }
 
-import com.fasterxml.jackson.databind.ObjectMapper
-
 import scala.language.dynamics
 
-object Json {
+import com.fasterxml.jackson.databind.ObjectMapper
+
+private[har] object Json {
 
   val objectMapper = new ObjectMapper
 
@@ -33,14 +33,14 @@ object Json {
   implicit def JsonToDouble(s: Json) = s.toDouble
 }
 
-class JsonException(desc: String) extends Exception(desc)
+private[har] class JsonException(desc: String) extends Exception(desc)
 
-class JsonIterator(i: java.util.Iterator[Object]) extends Iterator[Json] {
+private[har] class JsonIterator(i: java.util.Iterator[Object]) extends Iterator[Json] {
   def hasNext = i.hasNext
   def next = new Json(i.next)
 }
 
-class Json(val o: Object) extends Seq[Json] with Dynamic {
+private[har] class Json(val o: Object) extends Seq[Json] with Dynamic {
 
   override def toString: String = if (o == null) "null" else o.toString
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/HttpProxy.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/HttpProxy.scala
@@ -23,7 +23,7 @@ import io.gatling.recorder.http.channel.BootstrapFactory.{ newRemoteBootstrap, n
 import io.gatling.recorder.http.ssl.SslServerContext
 import org.jboss.netty.channel.group.DefaultChannelGroup
 
-case class HttpProxy(controller: RecorderController)(implicit config: RecorderConfiguration) {
+private[recorder] case class HttpProxy(controller: RecorderController)(implicit config: RecorderConfiguration) {
 
   private def port = config.proxy.port
   def outgoingProxy =

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/channel/BootstrapFactory.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/channel/BootstrapFactory.scala
@@ -26,7 +26,7 @@ import org.jboss.netty.handler.codec.http._
 import org.jboss.netty.handler.ssl.SslHandler
 import com.typesafe.scalalogging.StrictLogging
 
-object BootstrapFactory extends StrictLogging {
+private[http] object BootstrapFactory extends StrictLogging {
 
   val CodecHandlerName = "codec"
   val SslHandlerName = "ssl"
@@ -43,7 +43,7 @@ object BootstrapFactory extends StrictLogging {
         logger.debug("Open new remote channel")
         val pipeline = Channels.pipeline
         if (ssl) {
-          val sslHandler = new SslHandler(SslClientContext.createSSLEngine)
+          val sslHandler = new SslHandler(SslClientContext.createSSLEngine())
           sslHandler.setCloseOnSSLException(true)
           pipeline.addLast(SslHandlerName, sslHandler)
         }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/ScalaChannelHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/ScalaChannelHandler.scala
@@ -21,7 +21,7 @@ import org.jboss.netty.channel.ChannelFutureListener
 import org.jboss.netty.channel.ChannelFuture
 import org.jboss.netty.handler.codec.http.{ DefaultHttpRequest, HttpRequest }
 
-trait ScalaChannelHandler {
+private[handler] trait ScalaChannelHandler {
 
   implicit def function2ChannelFutureListener(thunk: ChannelFuture => Any) = new ChannelFutureListener {
     def operationComplete(future: ChannelFuture): Unit = thunk(future)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/remote/RemoteHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/remote/RemoteHandler.scala
@@ -22,19 +22,19 @@ import io.gatling.core.util.TimeHelper.nowMillis
 import io.gatling.recorder.controller.RecorderController
 import io.gatling.recorder.http.channel.BootstrapFactory._
 import io.gatling.recorder.http.handler.ScalaChannelHandler
-import io.gatling.recorder.http.handler.user.SSLHandlerSetter
+import io.gatling.recorder.http.handler.user.SslHandlerSetter
 import io.gatling.recorder.http.ssl.{ SslClientContext, SslServerContext }
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.codec.http._
 import org.jboss.netty.handler.ssl.SslHandler
 
-case class TimedHttpRequest(httpRequest: HttpRequest, sendTime: Long = nowMillis)
+private[recorder] case class TimedHttpRequest(httpRequest: HttpRequest, sendTime: Long = nowMillis)
 
-class RemoteHandler(controller: RecorderController,
-                    sslServerContext: SslServerContext,
-                    userChannel: Channel,
-                    var performConnect: Boolean,
-                    reconnect: Boolean)
+private[handler] class RemoteHandler(controller: RecorderController,
+                                     sslServerContext: SslServerContext,
+                                     userChannel: Channel,
+                                     var performConnect: Boolean,
+                                     reconnect: Boolean)
     extends SimpleChannelHandler with ScalaChannelHandler with StrictLogging {
 
   override def messageReceived(ctx: ChannelHandlerContext, event: MessageEvent): Unit = {
@@ -57,7 +57,7 @@ class RemoteHandler(controller: RecorderController,
           if (!reconnect)
             remoteSslHandler.handshake.addListener { handshakeFuture: ChannelFuture =>
               val inetSocketAddress = handshakeFuture.getChannel.getRemoteAddress.asInstanceOf[InetSocketAddress]
-              userChannel.getPipeline.addFirst(SslHandlerName, new SSLHandlerSetter(inetSocketAddress.getHostString, sslServerContext))
+              userChannel.getPipeline.addFirst(SslHandlerName, new SslHandlerSetter(inetSocketAddress.getHostString, sslServerContext))
               userChannel.write(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK))
             }
         } else

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/HttpUserHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/HttpUserHandler.scala
@@ -25,7 +25,7 @@ import io.gatling.recorder.http.handler.ScalaChannelHandler
 import org.jboss.netty.channel.{ Channel, ChannelFuture }
 import org.jboss.netty.handler.codec.http.{ DefaultHttpResponse, HttpRequest, HttpResponseStatus, HttpVersion }
 
-class HttpUserHandler(proxy: HttpProxy) extends UserHandler(proxy) with ScalaChannelHandler {
+private[user] class HttpUserHandler(proxy: HttpProxy) extends UserHandler(proxy) with ScalaChannelHandler {
 
   private def buildRequestWithRelativeURI(request: HttpRequest): HttpRequest = {
     val relative = Uri.create(request.getUri).toRelativeUrl

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/HttpsUserHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/HttpsUserHandler.scala
@@ -28,7 +28,7 @@ import org.jboss.netty.channel.{ Channel, ChannelFuture, ChannelHandlerContext, 
 import org.jboss.netty.handler.codec.http.{ DefaultHttpResponse, HttpMethod, HttpRequest, HttpResponseStatus, HttpVersion }
 import org.jboss.netty.handler.ssl.SslHandler
 
-class HttpsUserHandler(proxy: HttpProxy) extends UserHandler(proxy) with ScalaChannelHandler with StrictLogging {
+private[user] class HttpsUserHandler(proxy: HttpProxy) extends UserHandler(proxy) with ScalaChannelHandler with StrictLogging {
 
   var targetHostUri: Uri = _
 
@@ -59,7 +59,7 @@ class HttpsUserHandler(proxy: HttpProxy) extends UserHandler(proxy) with ScalaCh
                           val inetSocketAddress = remoteChannel.getRemoteAddress.asInstanceOf[InetSocketAddress]
                           setupRemoteChannel(userChannel, remoteChannel, proxy.controller, performConnect = false, reconnect = reconnect)
                           if (!reconnect) {
-                            userChannel.getPipeline.addFirst(SslHandlerName, new SSLHandlerSetter(inetSocketAddress.getHostString, proxy.sslServerContext))
+                            userChannel.getPipeline.addFirst(SslHandlerName, new SslHandlerSetter(inetSocketAddress.getHostString, proxy.sslServerContext))
                             userChannel.write(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK))
                           } else
                             handlePropagatableRequest()

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/PortUnificationUserHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/PortUnificationUserHandler.scala
@@ -21,7 +21,7 @@ import io.gatling.recorder.http.channel.BootstrapFactory._
 import org.jboss.netty.channel.{ ChannelHandlerContext, ChannelPipeline, MessageEvent, SimpleChannelHandler }
 import org.jboss.netty.handler.codec.http.{ HttpMethod, HttpRequest }
 
-class PortUnificationUserHandler(proxy: HttpProxy, pipeline: ChannelPipeline) extends SimpleChannelHandler with StrictLogging {
+private[http] class PortUnificationUserHandler(proxy: HttpProxy, pipeline: ChannelPipeline) extends SimpleChannelHandler with StrictLogging {
 
   override def messageReceived(requestContext: ChannelHandlerContext, event: MessageEvent): Unit =
     try

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/SslHandlerSetter.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/SslHandlerSetter.scala
@@ -25,7 +25,7 @@ import org.jboss.netty.handler.ssl.SslHandler
  * Placed on the server side pipeline, it replaces itself with a SslHandler when it sees the 200 response to the CONNECT request
  * (as CONNECT happens over HTTP, not HTTPS)
  */
-class SSLHandlerSetter(domainAlias: String, sslServerContext: SslServerContext) extends ChannelDownstreamHandler with StrictLogging {
+private[handler] class SslHandlerSetter(domainAlias: String, sslServerContext: SslServerContext) extends ChannelDownstreamHandler with StrictLogging {
 
   override def handleDownstream(ctx: ChannelHandlerContext, e: ChannelEvent): Unit = {
     val sslHandler = new SslHandler(sslServerContext.createSSLEngine(domainAlias))

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/UserHandler.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/handler/user/UserHandler.scala
@@ -28,7 +28,7 @@ import io.gatling.recorder.http.handler.remote.{ TimedHttpRequest, RemoteHandler
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.codec.http.HttpRequest
 
-abstract class UserHandler(proxy: HttpProxy) extends SimpleChannelHandler with StrictLogging {
+private[user] abstract class UserHandler(proxy: HttpProxy) extends SimpleChannelHandler with StrictLogging {
 
   @volatile var _remoteChannel: Option[Channel] = None
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/HttpsMode.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/HttpsMode.scala
@@ -18,9 +18,9 @@ package io.gatling.recorder.http.ssl
 import io.gatling.core.util.ClassSimpleNameToString
 import io.gatling.recorder.util.Labelled
 
-sealed abstract class HttpsMode(val label: String) extends Labelled with ClassSimpleNameToString
+private[recorder] sealed abstract class HttpsMode(val label: String) extends Labelled with ClassSimpleNameToString
 
-case object HttpsMode {
+private[recorder] case object HttpsMode {
 
   case object SelfSignedCertificate extends HttpsMode("Self-signed Certificate")
   case object ProvidedKeyStore extends HttpsMode("Provided Keystore")

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/KeyManagerDelegate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/KeyManagerDelegate.scala
@@ -25,7 +25,7 @@ import com.typesafe.scalalogging.StrictLogging
 /**
  * Instructs to send server certificate according to the alias
  */
-class KeyManagerDelegate(manager: X509KeyManager, alias: String) extends X509ExtendedKeyManager with StrictLogging {
+private[ssl] class KeyManagerDelegate(manager: X509KeyManager, alias: String) extends X509ExtendedKeyManager with StrictLogging {
 
   override def chooseEngineServerAlias(keyType: String, issuers: Array[Principal], engine: SSLEngine): String = alias
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/KeyStoreType.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/KeyStoreType.scala
@@ -18,9 +18,9 @@ package io.gatling.recorder.http.ssl
 import io.gatling.core.util.ClassSimpleNameToString
 import io.gatling.recorder.util.Labelled
 
-sealed abstract class KeyStoreType(val label: String) extends Labelled with ClassSimpleNameToString
+private[recorder] sealed abstract class KeyStoreType(val label: String) extends Labelled with ClassSimpleNameToString
 
-object KeyStoreType {
+private[recorder] object KeyStoreType {
 
   case object JKS extends KeyStoreType("JKS")
   case object PKCS12 extends KeyStoreType("PKCS#12")

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslCertHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslCertHelper.scala
@@ -40,13 +40,13 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
 
-case class Ca(cert: X509Certificate, privKey: PrivateKey)
-case class Csr(cert: PKCS10CertificationRequest, privKey: PrivateKey)
+private[ssl] case class Ca(cert: X509Certificate, privKey: PrivateKey)
+private[ssl] case class Csr(cert: PKCS10CertificationRequest, privKey: PrivateKey)
 
 /**
  * Utility class to create SSL server certificate on the fly for the recorder keystore
  */
-object SslCertUtil extends StrictLogging {
+private[recorder] object SslCertUtil extends StrictLogging {
 
   Security.addProvider(new BouncyCastleProvider)
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslClientContext.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslClientContext.scala
@@ -17,7 +17,7 @@ package io.gatling.recorder.http.ssl
 
 import javax.net.ssl.{ SSLEngine, SSLContext }
 
-object SslClientContext {
+private[http] object SslClientContext {
 
   val SslContext = {
     val clientContext = SSLContext.getInstance(SslServerContext.Protocol)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslServerContext.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslServerContext.scala
@@ -27,7 +27,7 @@ import io.gatling.recorder.config.RecorderConfiguration
 import scala.collection.concurrent.TrieMap
 import scala.util.{ Failure, Try }
 
-sealed trait SslServerContext {
+private[http] sealed trait SslServerContext {
 
   def password: Array[Char]
 
@@ -42,7 +42,7 @@ sealed trait SslServerContext {
   }
 }
 
-object SslServerContext {
+private[recorder] object SslServerContext {
 
   val GatlingSelfSignedKeyStore = "gatling.jks"
   val GatlingKeyStoreType = KeyStoreType.JKS

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/TrustManagerFactory.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/TrustManagerFactory.scala
@@ -19,7 +19,7 @@ import java.security.KeyStore
 import java.security.cert.X509Certificate
 import javax.net.ssl._
 
-object TrustManagerFactory {
+private[ssl] object TrustManagerFactory {
 
   val LooseTrustManagers = Array[TrustManager](new X509TrustManager {
 
@@ -32,10 +32,10 @@ object TrustManagerFactory {
 }
 
 /**
- * Bogus {@link TrustManagerFactorySpi} which accepts any certificate even if it
+ * Bogus TrustManagerFactorySpi which accepts any certificate even if it
  * is invalid.
  */
-class TrustManagerFactory extends TrustManagerFactorySpi {
+private[ssl] class TrustManagerFactory extends TrustManagerFactorySpi {
 
   def engineGetTrustManagers = TrustManagerFactory.LooseTrustManagers
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ProtocolDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ProtocolDefinition.scala
@@ -17,7 +17,7 @@ package io.gatling.recorder.scenario
 
 import io.gatling.http.HeaderNames
 
-object ProtocolDefinition {
+private[scenario] object ProtocolDefinition {
 
   val BaseHeaders = Map(
     HeaderNames.Accept -> "acceptHeader",
@@ -31,4 +31,4 @@ object ProtocolDefinition {
     HeaderNames.UserAgent -> "userAgentHeader")
 }
 
-case class ProtocolDefinition(baseUrl: String, headers: Map[String, String])
+private[scenario] case class ProtocolDefinition(baseUrl: String, headers: Map[String, String])

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
@@ -23,11 +23,11 @@ import io.gatling.http.util.HttpHelper
 import io.gatling.recorder.config.RecorderConfiguration
 import io.gatling.recorder.util.collection.RichSeq
 
-case class ScenarioDefinition(elements: Seq[ScenarioElement]) {
+private[recorder] case class ScenarioDefinition(elements: Seq[ScenarioElement]) {
   def isEmpty = elements.isEmpty
 }
 
-object ScenarioDefinition extends StrictLogging {
+private[recorder] object ScenarioDefinition extends StrictLogging {
 
   private val ConsecutiveResourcesMaxIntervalInMillis = 1000
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioElement.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioElement.scala
@@ -34,21 +34,21 @@ import io.gatling.http.fetch.{ EmbeddedResource, HtmlParser }
 import io.gatling.http.util.HttpHelper.parseFormBody
 import io.gatling.recorder.config.RecorderConfiguration
 
-case class TimedScenarioElement[+T <: ScenarioElement](sendTime: Long, arrivalTime: Long, element: T)
+private[recorder] case class TimedScenarioElement[+T <: ScenarioElement](sendTime: Long, arrivalTime: Long, element: T)
 
-sealed trait RequestBody
-case class RequestBodyParams(params: List[(String, String)]) extends RequestBody
-case class RequestBodyBytes(bytes: Array[Byte]) extends RequestBody
+private[recorder] sealed trait RequestBody
+private[recorder] case class RequestBodyParams(params: List[(String, String)]) extends RequestBody
+private[recorder] case class RequestBodyBytes(bytes: Array[Byte]) extends RequestBody
 
-sealed trait ResponseBody
-case class ResponseBodyBytes(bytes: Array[Byte]) extends ResponseBody
+private[recorder] sealed trait ResponseBody
+private[recorder] case class ResponseBodyBytes(bytes: Array[Byte]) extends ResponseBody
 
-sealed trait ScenarioElement
+private[recorder] sealed trait ScenarioElement
 
-case class PauseElement(duration: FiniteDuration) extends ScenarioElement
-case class TagElement(text: String) extends ScenarioElement
+private[recorder] case class PauseElement(duration: FiniteDuration) extends ScenarioElement
+private[recorder] case class TagElement(text: String) extends ScenarioElement
 
-object RequestElement {
+private[recorder] object RequestElement {
 
   val HtmlContentType = """(?i)text/html\s*(;\s+charset=(.+))?""".r
 
@@ -100,14 +100,14 @@ object RequestElement {
   }
 }
 
-case class RequestElement(uri: String,
-                          method: String,
-                          headers: Map[String, String],
-                          body: Option[RequestBody],
-                          responseBody: Option[ResponseBody],
-                          statusCode: Int,
-                          embeddedResources: List[EmbeddedResource],
-                          nonEmbeddedResources: List[RequestElement] = Nil) extends ScenarioElement {
+private[recorder] case class RequestElement(uri: String,
+                                            method: String,
+                                            headers: Map[String, String],
+                                            body: Option[RequestBody],
+                                            responseBody: Option[ResponseBody],
+                                            statusCode: Int,
+                                            embeddedResources: List[EmbeddedResource],
+                                            nonEmbeddedResources: List[RequestElement] = Nil) extends ScenarioElement {
 
   val (baseUrl, pathQuery) = {
     val uriComponents = Uri.create(uri)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
@@ -32,7 +32,7 @@ import io.gatling.recorder.config.RecorderConfiguration
 import io.gatling.recorder.har.HarReader
 import io.gatling.recorder.scenario.template.SimulationTemplate
 
-object ScenarioExporter extends StrictLogging {
+private[recorder] object ScenarioExporter extends StrictLogging {
 
   private val EventsGrouping = 100
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ExtractedUris.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ExtractedUris.scala
@@ -21,9 +21,9 @@ import io.gatling.core.util.StringHelper._
 import io.gatling.recorder.scenario.{ RequestElement, ScenarioElement }
 import com.dongxiguo.fastring.Fastring.Implicits._
 
-case class Value(name: String, value: String)
+private[scenario] case class Value(name: String, value: String)
 
-case class SchemeHost(scheme: String, host: String)
+private[scenario] case class SchemeHost(scheme: String, host: String)
 
 /**
  * Extracts common URIs parts into vals. The algorithm is the following:
@@ -36,7 +36,7 @@ case class SchemeHost(scheme: String, host: String)
  *
  * @param scenarioElements - contains uris to extracts common parts from
  */
-class ExtractedUris(scenarioElements: Seq[ScenarioElement]) {
+private[scenario] class ExtractedUris(scenarioElements: Seq[ScenarioElement]) {
   var requestElements = scenarioElements.collect { case elem: RequestElement => elem }
   val uris = requestElements.map(_.uri) ++
     requestElements.map(_.embeddedResources).reduce(_ ++ _).map(_.url) ++

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/PauseTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/PauseTemplate.scala
@@ -17,7 +17,7 @@ package io.gatling.recorder.scenario.template
 
 import scala.concurrent.duration.{ DurationLong, FiniteDuration }
 
-object PauseTemplate {
+private[scenario] object PauseTemplate {
 
   def render(duration: FiniteDuration) = s"pause(${if (duration > 1.second) duration.toSeconds else duration})"
 }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
@@ -21,7 +21,7 @@ import io.gatling.recorder.scenario.ProtocolDefinition
 import io.gatling.recorder.scenario.ProtocolDefinition.BaseHeaders
 import com.dongxiguo.fastring.Fastring.Implicits._
 
-object ProtocolTemplate {
+private[scenario] object ProtocolTemplate {
 
   val Indent = "\t" * 2
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
@@ -21,7 +21,7 @@ import io.gatling.recorder.config.RecorderConfiguration
 import io.gatling.recorder.scenario.{ RequestBodyBytes, RequestBodyParams }
 import io.gatling.recorder.scenario.{ RequestElement, ScenarioExporter }
 
-object RequestTemplate {
+private[scenario] object RequestTemplate {
 
   val BuiltInHttpMethods = List("GET", "PUT", "PATCH", "HEAD", "DELETE", "OPTIONS", "POST")
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/SimulationTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/SimulationTemplate.scala
@@ -21,7 +21,7 @@ import io.gatling.recorder.scenario.{ ProtocolDefinition, ScenarioElement, TagEl
 import io.gatling.recorder.scenario.{ PauseElement, RequestElement }
 import io.gatling.recorder.config.RecorderConfiguration
 
-object SimulationTemplate {
+private[scenario] object SimulationTemplate {
 
   def render(packageName: String,
              simulationClassName: String,

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ValuesTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ValuesTemplate.scala
@@ -18,7 +18,7 @@ package io.gatling.recorder.scenario.template
 import com.dongxiguo.fastring.Fastring.Implicits._
 import io.gatling.core.util.StringHelper.Eol
 
-object ValuesTemplate {
+private[scenario] object ValuesTemplate {
   def render(values: Seq[Value]): Fastring =
     values.sortBy(_.name).map(value => fast"    val ${value.name} = ${protectWithTripleQuotes(value.value)}")
       .mkFastring(Eol)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/EventInfo.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/EventInfo.scala
@@ -20,14 +20,14 @@ import java.nio.charset.Charset
 import org.jboss.netty.handler.codec.http.{ HttpMessage, HttpRequest, HttpResponse }
 import scala.concurrent.duration.{ DurationLong, FiniteDuration }
 
-sealed trait EventInfo
+private[recorder] sealed trait EventInfo
 
-case class PauseInfo(duration: FiniteDuration) extends EventInfo {
+private[recorder] case class PauseInfo(duration: FiniteDuration) extends EventInfo {
   val toPrint = if (duration > 1.second) s"${duration.toSeconds}s" else s"${duration.length}ms"
   override def toString = s"PAUSE $toPrint"
 }
 
-case class RequestInfo(request: HttpRequest, response: HttpResponse)(implicit configuration: RecorderConfiguration) extends EventInfo {
+private[recorder] case class RequestInfo(request: HttpRequest, response: HttpResponse)(implicit configuration: RecorderConfiguration) extends EventInfo {
 
   private def getHttpBody(message: HttpMessage) = message.getContent.toString(Charset.forName(configuration.core.encoding))
 
@@ -38,8 +38,8 @@ case class RequestInfo(request: HttpRequest, response: HttpResponse)(implicit co
   override def toString = s"${request.getMethod} | ${request.getUri}"
 }
 
-case class SSLInfo(uri: String) extends EventInfo
+private[recorder] case class SSLInfo(uri: String) extends EventInfo
 
-case class TagInfo(tag: String) extends EventInfo {
+private[recorder] case class TagInfo(tag: String) extends EventInfo {
   override def toString = s"TAG | $tag"
 }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/RecorderFrontEnd.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/RecorderFrontEnd.scala
@@ -15,19 +15,18 @@
  */
 package io.gatling.recorder.ui
 
-import io.gatling.recorder.RecorderMode
-import io.gatling.recorder.config.RecorderConfiguration
+import io.gatling.recorder.config.{ RecorderMode, RecorderConfiguration }
 import io.gatling.recorder.controller.RecorderController
 import io.gatling.recorder.ui.swing.SwingFrontend
 
-object RecorderFrontend {
+private[recorder] object RecorderFrontend {
 
   // Currently hardwired to the Swing frontend
   // Will select the desired frontend when more are implemented
   def newFrontend(controller: RecorderController)(implicit configuration: RecorderConfiguration): RecorderFrontend =
     new SwingFrontend(controller)
 }
-abstract class RecorderFrontend(controller: RecorderController) {
+private[recorder] abstract class RecorderFrontend(controller: RecorderController) {
 
   /******************************/
   /**  Controller => Frontend  **/

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/Commons.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/Commons.scala
@@ -17,7 +17,7 @@ package io.gatling.recorder.ui.swing
 
 import scala.swing.Swing.Icon
 
-object Commons {
+private[swing] object Commons {
   val LogoSmall = Icon(getClass.getResource("img/logo_small.png"))
 
   private val IconsFiles = List("img/fav_small.png", "img/fav_big.png", "img/picto_small.png", "img/picto_big.png")

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/SwingFrontend.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/SwingFrontend.scala
@@ -25,7 +25,7 @@ import io.gatling.recorder.ui.{ RecorderFrontend, EventInfo }
 import io.gatling.recorder.ui.swing.component.DialogFileSelector
 import io.gatling.recorder.ui.swing.frame.{ ConfigurationFrame, RunningFrame }
 
-class SwingFrontend(controller: RecorderController)(implicit configuration: RecorderConfiguration) extends RecorderFrontend(controller) {
+private[ui] class SwingFrontend(controller: RecorderController)(implicit configuration: RecorderConfiguration) extends RecorderFrontend(controller) {
 
   private lazy val runningFrame = new RunningFrame(this)
   private lazy val configurationFrame = new ConfigurationFrame(this)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DialogFileSelector.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DialogFileSelector.scala
@@ -21,14 +21,14 @@ import scala.swing.BorderPanel.Position._
 import io.gatling.recorder.ui.swing.util.UIHelper._
 import io.gatling.recorder.ui.swing.frame.ConfigurationFrame
 
-object DialogFileSelector {
-  val message = """	|A Swing bug on Mac OS X prevents the Recorder from getting
-						|the correct path for file with some known extensions.
-						|Those files closely matches the file you selected, please select
-						|the correct one :
-						|""".stripMargin
+private[swing] object DialogFileSelector {
+  val message = """|A Swing bug on Mac OS X prevents the Recorder from getting
+                   |the correct path for file with some known extensions.
+                   |Those files closely matches the file you selected, please select
+                   |the correct one :
+                   |""".stripMargin
 }
-class DialogFileSelector(configurationFrame: ConfigurationFrame, possibleFiles: List[String]) extends Dialog(configurationFrame) {
+private[swing] class DialogFileSelector(configurationFrame: ConfigurationFrame, possibleFiles: List[String]) extends Dialog(configurationFrame) {
 
   var selectedFile: Option[String] = None
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DisplayedSelectionFileChooser.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DisplayedSelectionFileChooser.scala
@@ -29,11 +29,11 @@ private[component] class AcceptAllFileFilter extends FileFilter {
   override def getDescription = "Accept any file filter"
 }
 
-sealed trait ChooserType
-case object Open extends ChooserType
-case object Save extends ChooserType
+private[swing] sealed trait ChooserType
+private[swing] case object Open extends ChooserType
+private[swing] case object Save extends ChooserType
 
-class DisplayedSelectionFileChooser(
+private[swing] class DisplayedSelectionFileChooser(
   creator: Container,
   textFieldLength: Int,
   chooserType: ChooserType,

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/FilterTable.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/FilterTable.scala
@@ -25,7 +25,7 @@ import scala.util.{ Failure, Try }
 import javax.swing.{ JMenuItem, JPopupMenu }
 import javax.swing.table.DefaultTableModel
 
-class FilterTable(headerTitle: String) extends ScrollPane {
+private[swing] class FilterTable(headerTitle: String) extends ScrollPane {
 
   private val table = new Table {
     override def rendererComponent(isSelected: Boolean, focused: Boolean, row: Int, column: Int): Component = {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/TextAreaPanel.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/TextAreaPanel.scala
@@ -18,7 +18,7 @@ package io.gatling.recorder.ui.swing.component
 import scala.swing._
 import scala.swing.BorderPanel.Position._
 
-class TextAreaPanel(title: String, initialSize: Dimension) extends BorderPanel {
+private[swing] class TextAreaPanel(title: String, initialSize: Dimension) extends BorderPanel {
 
   preferredSize = initialSize
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
@@ -18,7 +18,8 @@ package io.gatling.recorder.ui.swing.frame
 import java.awt.Font
 import javax.swing.filechooser.FileNameExtensionFilter
 
-import io.gatling.recorder.RecorderMode.{ Har, Proxy }
+import io.gatling.recorder.config._
+import RecorderMode.{ Har, Proxy }
 
 import scala.collection.JavaConversions.seqAsJavaList
 import scala.swing._
@@ -29,7 +30,6 @@ import scala.util.Try
 
 import io.gatling.core.util.PathHelper._
 import io.gatling.core.util.StringHelper.RichString
-import io.gatling.recorder.RecorderMode
 import io.gatling.recorder.config._
 import io.gatling.recorder.config.FilterStrategy.BlacklistFirst
 import io.gatling.recorder.http.ssl.{ SslServerContext, SslCertUtil, HttpsMode, KeyStoreType }
@@ -42,7 +42,7 @@ import io.gatling.recorder.ui.swing.frame.ValidationHelper._
 import io.gatling.recorder.ui.swing.util._
 import io.gatling.recorder.ui.swing.util.UIHelper._
 
-class ConfigurationFrame(frontend: RecorderFrontend)(implicit configuration: RecorderConfiguration) extends MainFrame {
+private[swing] class ConfigurationFrame(frontend: RecorderFrontend)(implicit configuration: RecorderConfiguration) extends MainFrame {
 
   /************************************/
   /**           COMPONENTS           **/

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/RunningFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/RunningFrame.scala
@@ -31,7 +31,7 @@ import io.gatling.recorder.ui.swing.component.TextAreaPanel
 import io.gatling.recorder.ui.swing.Commons.IconList
 import io.gatling.recorder.ui.swing.util.UIHelper._
 
-class RunningFrame(frontend: RecorderFrontend) extends MainFrame with StrictLogging {
+private[swing] class RunningFrame(frontend: RecorderFrontend) extends MainFrame with StrictLogging {
 
   /************************************/
   /**           COMPONENTS           **/

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ValidationHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ValidationHelper.scala
@@ -24,7 +24,7 @@ import scala.util.Try
 
 import io.gatling.core.util.StringHelper.RichString
 
-object ValidationHelper {
+private[swing] object ValidationHelper {
 
   case class Validator(
     condition: String => Boolean,

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/util/CharsetHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/util/CharsetHelper.scala
@@ -19,7 +19,7 @@ import java.nio.charset.Charset
 
 import com.typesafe.scalalogging.StrictLogging
 
-object CharsetHelper extends StrictLogging {
+private[swing] object CharsetHelper extends StrictLogging {
   type Label = String
   type Name = String
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/util/LabelledComboBox.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/util/LabelledComboBox.scala
@@ -20,7 +20,7 @@ import io.gatling.recorder.util.Labelled
 import scala.swing.ComboBox
 import scala.swing.ListView.Renderer
 
-class LabelledComboBox[T <: Labelled](elements: List[T]) extends ComboBox[T](elements) {
+private[swing] class LabelledComboBox[T <: Labelled](elements: List[T]) extends ComboBox[T](elements) {
   selection.index = 0
   renderer = Renderer(_.label)
 }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/util/UIHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/util/UIHelper.scala
@@ -19,7 +19,7 @@ import scala.swing._
 
 import javax.swing.JComponent
 
-object UIHelper {
+private[swing] object UIHelper {
 
   def titledBorder(title: String) = Swing.TitledBorder(null, title)
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/util/Labelled.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/util/Labelled.scala
@@ -15,4 +15,4 @@
  */
 package io.gatling.recorder.util
 
-trait Labelled { def label: String }
+private[recorder] trait Labelled { def label: String }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/util/collection.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/util/collection.scala
@@ -15,7 +15,7 @@
  */
 package io.gatling.recorder.util
 
-object collection {
+private[recorder] object collection {
 
   implicit class RichSeq[T](val elts: Seq[T]) extends AnyVal {
 


### PR DESCRIPTION
This basically only leave public the classes that are used to run/configure the Recorder.