### PR TITLE
Core: Adding per-million support to assertions

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionBuilders.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionBuilders.scala
@@ -46,6 +46,7 @@ class AssertionWithPathAndCountMetric(path: Path, metric: CountMetric) {
 
   def count = next(Count)
   def percent = next(Percent)
+  def perMillion = next(PerMillion)
 }
 
 class AssertionWithPathAndTarget(path: Path, target: Target) {

--- a/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionModel.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionModel.scala
@@ -99,6 +99,9 @@ case object Count extends CountSelection(serialize(CountTag)) {
 case object Percent extends CountSelection(serialize(PercentTag)) {
   def printable(configuration: GatlingConfiguration) = "percentage"
 }
+case object PerMillion extends CountSelection(serialize(PerMillionTag)) {
+  def printable(configuration: GatlingConfiguration) = "per_million"
+}
 case object Min extends TimeSelection(serialize(MinTag)) {
   def printable(configuration: GatlingConfiguration) = "min"
 }

--- a/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionParser.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionParser.scala
@@ -70,7 +70,7 @@ class AssertionParser extends JavaTokenParsers {
   // -- Selections parsers -- //
   // ------------------------ //
 
-  private val countSelection = anyOf(CountTag ^^^ Count, PercentTag ^^^ Percent)
+  private val countSelection = anyOf(CountTag ^^^ Count, PercentTag ^^^ Percent, PerMillionTag ^^^ PerMillion)
 
   private val timeSelection = anyOf(
     MinTag ^^^ Min,

--- a/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionTags.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionTags.scala
@@ -41,6 +41,7 @@ object AssertionTags {
 
   val CountTag = "COUNT"
   val PercentTag = "PERCENT"
+  val PerMillionTag = "PER_MILLION"
 
   val MinTag = "MIN"
   val MaxTag = "MAX"

--- a/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionValidator.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/assertion/AssertionValidator.scala
@@ -105,6 +105,10 @@ class AssertionValidator(implicit configuration: GatlingConfiguration) {
         val metricCountsAndAllCounts = resolvedStats.map(_.count).zip(stats(None).map(_.count))
         val percentages = metricCountsAndAllCounts.map { case (metricCount, allCount) => metricCount.toDouble / allCount * 100 }
         percentages.map(_.toInt)
+      case PerMillion =>
+        val metricCountsAndAllCounts = resolvedStats.map(_.count).zip(stats(None).map(_.count))
+        val percentages = metricCountsAndAllCounts.map { case (metricCount, allCount) => metricCount.toDouble / allCount * 1000000 }
+        percentages.map(_.toInt)
     }
   }
 

--- a/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionDSLSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionDSLSpec.scala
@@ -32,12 +32,15 @@ class AssertionDSLSpec extends BaseSpec with AssertionSupport {
 
     global.allRequests.count.is(20) shouldBe Assertion(Global, CountTarget(AllRequests, Count), Is(20))
     forAll.allRequests.percent.lessThan(5) shouldBe Assertion(ForAll, CountTarget(AllRequests, Percent), LessThan(5))
+    forAll.allRequests.perMillion.lessThan(5) shouldBe Assertion(ForAll, CountTarget(AllRequests, PerMillion), LessThan(5))
 
     global.failedRequests.count.greaterThan(10) shouldBe Assertion(Global, CountTarget(FailedRequests, Count), GreaterThan(10))
     details("Foo" / "Bar").failedRequests.percent.between(1, 5) shouldBe Assertion(Details(List("Foo", "Bar")), CountTarget(FailedRequests, Percent), Between(1, 5))
+    details("Foo" / "Bar").failedRequests.perMillion.between(1, 5) shouldBe Assertion(Details(List("Foo", "Bar")), CountTarget(FailedRequests, PerMillion), Between(1, 5))
 
     global.successfulRequests.count.in(1, 2, 2, 4) shouldBe Assertion(Global, CountTarget(SuccessfulRequests, Count), In(List(1, 2, 4)))
     global.successfulRequests.percent.is(6) shouldBe Assertion(Global, CountTarget(SuccessfulRequests, Percent), Is(6))
+    global.successfulRequests.perMillion.is(6) shouldBe Assertion(Global, CountTarget(SuccessfulRequests, PerMillion), Is(6))
 
     global.requestsPerSec.is(35) shouldBe Assertion(Global, MeanRequestsPerSecondTarget, Is(35))
 

--- a/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionParserSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionParserSpec.scala
@@ -33,7 +33,7 @@ trait AssertionGenerator {
   private val targetGen = {
     val countTargetGen = {
       val countMetricGen = Gen.oneOf(AllRequests, FailedRequests, SuccessfulRequests)
-      val countSelectionGen = Gen.oneOf(Count, Percent)
+      val countSelectionGen = Gen.oneOf(Count, Percent, PerMillion)
 
       for (metric <- countMetricGen; selection <- countSelectionGen) yield CountTarget(metric, selection)
     }

--- a/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionSerializationSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionSerializationSpec.scala
@@ -38,6 +38,7 @@ class AssertionSerializationSpec extends BaseSpec {
   it should "be able to serialize Selections" in {
     Count.serialized.toString shouldBe tabSeparated(CountTag)
     Percent.serialized.toString shouldBe tabSeparated(PercentTag)
+    PerMillion.serialized.toString shouldBe tabSeparated(PerMillionTag)
     Min.serialized.toString shouldBe tabSeparated(MinTag)
     Max.serialized.toString shouldBe tabSeparated(MaxTag)
     Mean.serialized.toString shouldBe tabSeparated(MeanTag)
@@ -58,6 +59,7 @@ class AssertionSerializationSpec extends BaseSpec {
 
   it should "be able to serialize Targets" in {
     CountTarget(AllRequests, Percent).serialized.toString shouldBe tabSeparated(AllRequestsTag, PercentTag)
+    CountTarget(AllRequests, PerMillion).serialized.toString shouldBe tabSeparated(AllRequestsTag, PerMillionTag)
     TimeTarget(ResponseTime, StandardDeviation).serialized.toString shouldBe tabSeparated(ResponseTimeTag, StandardDeviationTag)
     MeanRequestsPerSecondTarget.serialized.toString shouldBe tabSeparated(MeanRequestsPerSecondTag)
   }
@@ -71,6 +73,9 @@ class AssertionSerializationSpec extends BaseSpec {
 
     Assertion(ForAll, CountTarget(SuccessfulRequests, Percent), LessThan(5)).serialized.toString shouldBe
       tabSeparated(PathTag, ForAllTag, TargetTag, SuccessfulRequestsTag, PercentTag, ConditionTag, LessThanTag, "5")
+
+    Assertion(ForAll, CountTarget(SuccessfulRequests, PerMillion), LessThan(5)).serialized.toString shouldBe
+      tabSeparated(PathTag, ForAllTag, TargetTag, SuccessfulRequestsTag, PerMillionTag, ConditionTag, LessThanTag, "5")
 
     Assertion(Details(List("Group", "Request")), TimeTarget(ResponseTime, Max), In(List(1, 2, 3))).serialized.toString shouldBe
       tabSeparated(PathTag, DetailsTag, "Group", "Request", TargetTag,


### PR DESCRIPTION
When measuring the success rate in a Gatling test, the existing "percent" function is insufficient.  Most of my services require a maximum failure rate of one per thousand.

This pull request extends the "percent" concept with a per-million extension.  For my purposes, a success rate of 999000 (or a failure rate of 1000) is sufficient.  I believe that one per million is probably enough for almost any Gatling use case.