### PR TITLE
Update link to maven plugin source code

### DIFF
--- a/src/sphinx/extensions/maven_plugin.rst
+++ b/src/sphinx/extensions/maven_plugin.rst
@@ -64,7 +64,7 @@ The example below shows the default values.
   <!--   <failOnError>true</failOnError> -->
   </configuration>
 
-See `source code <https://github.com/gatling/gatling-maven-plugin/blob/master/src/main/java/io/gatling/mojo/GatlingMojo.java>`_ for more documentation.
+See `source code <https://github.com/gatling/gatling-maven/blob/master/gatling-maven-plugin/src/main/java/io/gatling/mojo/GatlingMojo.java>`_ for more documentation.
 
 Override the logback.xml file
 =============================


### PR DESCRIPTION
The link to the source code of the gatling maven plugin pointed to https://github.com/gatling/gatling-maven-plugin, which I believe is not current. I've updated the link to point at https://github.com/gatling/gatling-maven instead.