### PR TITLE
Allow to change the escapeChar of a csv feeder

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
@@ -30,18 +30,19 @@ trait FeederSupport {
   implicit def array2FeederBuilder[T](data: Array[Map[String, T]]): RecordSeqFeederBuilder[T] = RecordSeqFeederBuilder(data)
   implicit def feeder2FeederBuilder[T](feeder: Feeder[T]): FeederBuilder[T] = FeederWrapper(feeder)
 
-  def csv(fileName: String, rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(fileName, CommaSeparator, rawSplit = rawSplit, escapeChar = escapeChar)
-  def ssv(fileName: String, rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(fileName, SemicolonSeparator, rawSplit = rawSplit, escapeChar = escapeChar)
-  def tsv(fileName: String, rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(fileName, TabulationSeparator, rawSplit = rawSplit, escapeChar = escapeChar)
+  def csv(fileName: String, escapeChar: Char = '\u0000', rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(fileName, CommaSeparator, escapeChar = escapeChar, rawSplit = rawSplit)
 
-  def separatedValues(fileName: String, separator: Char, quoteChar: Char = '"', rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(Resource.feeder(fileName), separator, quoteChar, rawSplit, escapeChar)
+  def ssv(fileName: String, escapeChar: Char = '\u0000', rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(fileName, SemicolonSeparator, escapeChar = escapeChar, rawSplit = rawSplit)
 
-  def separatedValues(resource: Validation[Resource], separator: Char, quoteChar: Char, rawSplit: Boolean, escapeChar: Char)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    feederBuilder(resource)(SeparatedValuesParser.parse(_, separator, quoteChar, rawSplit, escapeChar))
+  def tsv(fileName: String, escapeChar: Char = '\u0000', rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(fileName, TabulationSeparator, escapeChar = escapeChar, rawSplit = rawSplit)
+
+  def separatedValues(fileName: String, separator: Char, quoteChar: Char = '"', escapeChar: Char = '\u0000', rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(Resource.feeder(fileName), separator, quoteChar, Option(escapeChar), rawSplit)
+  def separatedValues(resource: Validation[Resource], separator: Char, quoteChar: Char, escapeChar: Option[Char], rawSplit: Boolean)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    feederBuilder(resource)(SeparatedValuesParser.parse(_, separator, quoteChar, escapeChar, rawSplit))
 
   def jsonFile(fileName: String)(implicit configuration: GatlingConfiguration, jsonParsers: JsonParsers): RecordSeqFeederBuilder[Any] = jsonFile(Resource.feeder(fileName))
   def jsonFile(resource: Validation[Resource])(implicit jsonParsers: JsonParsers): RecordSeqFeederBuilder[Any] =

--- a/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
@@ -30,18 +30,18 @@ trait FeederSupport {
   implicit def array2FeederBuilder[T](data: Array[Map[String, T]]): RecordSeqFeederBuilder[T] = RecordSeqFeederBuilder(data)
   implicit def feeder2FeederBuilder[T](feeder: Feeder[T]): FeederBuilder[T] = FeederWrapper(feeder)
 
-  def csv(fileName: String, rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(fileName, CommaSeparator, rawSplit = rawSplit)
-  def ssv(fileName: String, rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(fileName, SemicolonSeparator, rawSplit = rawSplit)
-  def tsv(fileName: String, rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(fileName, TabulationSeparator, rawSplit = rawSplit)
+  def csv(fileName: String, rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(fileName, CommaSeparator, rawSplit = rawSplit, escapeChar = escapeChar)
+  def ssv(fileName: String, rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(fileName, SemicolonSeparator, rawSplit = rawSplit, escapeChar = escapeChar)
+  def tsv(fileName: String, rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(fileName, TabulationSeparator, rawSplit = rawSplit, escapeChar = escapeChar)
 
-  def separatedValues(fileName: String, separator: Char, quoteChar: Char = '"', rawSplit: Boolean = false)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    separatedValues(Resource.feeder(fileName), separator, quoteChar, rawSplit)
+  def separatedValues(fileName: String, separator: Char, quoteChar: Char = '"', rawSplit: Boolean = false, escapeChar: Char = '\\')(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    separatedValues(Resource.feeder(fileName), separator, quoteChar, rawSplit, escapeChar)
 
-  def separatedValues(resource: Validation[Resource], separator: Char, quoteChar: Char, rawSplit: Boolean)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
-    feederBuilder(resource)(SeparatedValuesParser.parse(_, separator, quoteChar, rawSplit))
+  def separatedValues(resource: Validation[Resource], separator: Char, quoteChar: Char, rawSplit: Boolean, escapeChar: Char)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
+    feederBuilder(resource)(SeparatedValuesParser.parse(_, separator, quoteChar, rawSplit, escapeChar))
 
   def jsonFile(fileName: String)(implicit configuration: GatlingConfiguration, jsonParsers: JsonParsers): RecordSeqFeederBuilder[Any] = jsonFile(Resource.feeder(fileName))
   def jsonFile(resource: Validation[Resource])(implicit jsonParsers: JsonParsers): RecordSeqFeederBuilder[Any] =

--- a/gatling-core/src/main/scala/io/gatling/core/feeder/SeparatedValuesParser.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/feeder/SeparatedValuesParser.scala
@@ -33,15 +33,15 @@ object SeparatedValuesParser {
   val SemicolonSeparator = ';'
   val TabulationSeparator = '\t'
 
-  def parse(resource: Resource, columnSeparator: Char, quoteChar: Char, rawSplit: Boolean)(implicit configuration: GatlingConfiguration): IndexedSeq[Record[String]] =
+  def parse(resource: Resource, columnSeparator: Char, quoteChar: Char, rawSplit: Boolean, escapeChar: Char)(implicit configuration: GatlingConfiguration): IndexedSeq[Record[String]] =
     withCloseable(resource.inputStream) { source =>
-      stream(source, columnSeparator, quoteChar, rawSplit).toVector
+      stream(source, columnSeparator, quoteChar, rawSplit, escapeChar).toVector
     }
 
-  def stream(is: InputStream, columnSeparator: Char, quoteChar: Char, rawSplit: Boolean): Iterator[Record[String]] = {
+  def stream(is: InputStream, columnSeparator: Char, quoteChar: Char, rawSplit: Boolean, escapeChar: Char): Iterator[Record[String]] = {
 
     val mapper = new CsvMapper().disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
-    val schema = CsvSchema.emptySchema.withHeader.withColumnSeparator(columnSeparator).withQuoteChar(quoteChar).withEscapeChar('\\')
+    val schema = CsvSchema.emptySchema.withHeader.withColumnSeparator(columnSeparator).withQuoteChar(quoteChar).withEscapeChar(escapeChar)
 
     val reader: ObjectReader = mapper.readerFor(classOf[JMap[_, _]])
 

--- a/gatling-core/src/main/scala/io/gatling/core/feeder/SeparatedValuesParser.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/feeder/SeparatedValuesParser.scala
@@ -33,15 +33,22 @@ object SeparatedValuesParser {
   val SemicolonSeparator = ';'
   val TabulationSeparator = '\t'
 
-  def parse(resource: Resource, columnSeparator: Char, quoteChar: Char, rawSplit: Boolean, escapeChar: Char)(implicit configuration: GatlingConfiguration): IndexedSeq[Record[String]] =
+  def parse(resource: Resource, columnSeparator: Char, quoteChar: Char, escapeChar: Option[Char], rawSplit: Boolean)(implicit configuration: GatlingConfiguration): IndexedSeq[Record[String]] =
     withCloseable(resource.inputStream) { source =>
-      stream(source, columnSeparator, quoteChar, rawSplit, escapeChar).toVector
+      stream(source, columnSeparator, quoteChar, escapeChar, rawSplit).toVector
     }
 
-  def stream(is: InputStream, columnSeparator: Char, quoteChar: Char, rawSplit: Boolean, escapeChar: Char): Iterator[Record[String]] = {
+  def stream(is: InputStream, columnSeparator: Char, quoteChar: Char, escapeChar: Option[Char], rawSplit: Boolean): Iterator[Record[String]] = {
 
     val mapper = new CsvMapper().disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
-    val schema = CsvSchema.emptySchema.withHeader.withColumnSeparator(columnSeparator).withQuoteChar(quoteChar).withEscapeChar(escapeChar)
+    var schema = CsvSchema.emptySchema.withHeader.withColumnSeparator(columnSeparator).withQuoteChar(quoteChar)
+    schema = escapeChar match {
+      case Some(ec) =>
+        schema.withEscapeChar(ec)
+
+      case _ =>
+        schema.withoutEscapeChar()
+    }
 
     val reader: ObjectReader = mapper.readerFor(classOf[JMap[_, _]])
 

--- a/gatling-core/src/test/resources/sample3.csv
+++ b/gatling-core/src/test/resources/sample3.csv
@@ -1,0 +1,2 @@
+id,payload
+"id","{""key"": ""\""value\""""}"

--- a/gatling-core/src/test/resources/sample3.csv
+++ b/gatling-core/src/test/resources/sample3.csv
@@ -1,2 +1,2 @@
 id,payload
-"id","{""key"": ""\""value\""""}"
+id,{"k1": "v1"\, "k2": "v2"}"

--- a/gatling-core/src/test/resources/sample4.csv
+++ b/gatling-core/src/test/resources/sample4.csv
@@ -1,0 +1,2 @@
+id,payload
+"id","{""key"": ""\""value\""""}"

--- a/gatling-core/src/test/scala/io/gatling/core/feeder/FeederBuilderSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/feeder/FeederBuilderSpec.scala
@@ -36,7 +36,7 @@ class FeederBuilderSpec extends BaseSpec with FeederSupport {
 
   "RecordSeqFeederBuilder" should "throw an exception when provided with bad resource" in {
     an[IllegalArgumentException] should be thrownBy
-      feederBuilder(Failure(""))(SeparatedValuesParser.parse(_, SeparatedValuesParser.CommaSeparator, '\'', rawSplit = false))
+      feederBuilder(Failure(""))(SeparatedValuesParser.parse(_, SeparatedValuesParser.CommaSeparator, '\'', rawSplit = false, escapeChar = '\\'))
   }
 
   "RecordSeqFeederBuilder" should "build a Feeder with a queue strategy" in {

--- a/gatling-core/src/test/scala/io/gatling/core/feeder/FeederBuilderSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/feeder/FeederBuilderSpec.scala
@@ -36,7 +36,7 @@ class FeederBuilderSpec extends BaseSpec with FeederSupport {
 
   "RecordSeqFeederBuilder" should "throw an exception when provided with bad resource" in {
     an[IllegalArgumentException] should be thrownBy
-      feederBuilder(Failure(""))(SeparatedValuesParser.parse(_, SeparatedValuesParser.CommaSeparator, '\'', rawSplit = false, escapeChar = '\\'))
+      feederBuilder(Failure(""))(SeparatedValuesParser.parse(_, SeparatedValuesParser.CommaSeparator, '\'', escapeChar = Option('\\'), rawSplit = false))
   }
 
   "RecordSeqFeederBuilder" should "build a Feeder with a queue strategy" in {

--- a/gatling-core/src/test/scala/io/gatling/core/feeder/SeparatedValuesFeederSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/feeder/SeparatedValuesFeederSpec.scala
@@ -62,6 +62,11 @@ class SeparatedValuesFeederSpec extends BaseSpec with FeederSupport {
   "SeparatedValuesParser" should "throw an exception when provided with bad resource" in {
     import io.gatling.core.feeder.SeparatedValuesParser._
     an[Exception] should be thrownBy
-      stream(this.getClass.getClassLoader.getResourceAsStream("empty.csv"), CommaSeparator, '\'', rawSplit = false)
+      stream(this.getClass.getClassLoader.getResourceAsStream("empty.csv"), CommaSeparator, '\'', rawSplit = false, escapeChar = '\\')
+  }
+
+  "SeparatedValuesParser" should "accept no escape char appart from double double-quotes" in {
+    val data = csv("sample3.csv", escapeChar = '\u0000').build(mock[ScenarioContext]).toArray
+    data shouldBe Array(Map("id" -> "id", "payload" -> """{"key": "\"value\""}"""))
   }
 }

--- a/gatling-core/src/test/scala/io/gatling/core/feeder/SeparatedValuesFeederSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/feeder/SeparatedValuesFeederSpec.scala
@@ -62,11 +62,16 @@ class SeparatedValuesFeederSpec extends BaseSpec with FeederSupport {
   "SeparatedValuesParser" should "throw an exception when provided with bad resource" in {
     import io.gatling.core.feeder.SeparatedValuesParser._
     an[Exception] should be thrownBy
-      stream(this.getClass.getClassLoader.getResourceAsStream("empty.csv"), CommaSeparator, '\'', rawSplit = false, escapeChar = '\\')
+      stream(this.getClass.getClassLoader.getResourceAsStream("empty.csv"), CommaSeparator, '\'', escapeChar = Option('\\'), rawSplit = false)
   }
 
-  "SeparatedValuesParser" should "accept no escape char appart from double double-quotes" in {
-    val data = csv("sample3.csv", escapeChar = '\u0000').build(mock[ScenarioContext]).toArray
+  "SeparatedValuesParser" should "be compliant with the RFC4180" in {
+    val data = csv("sample4.csv").build(mock[ScenarioContext]).toArray
     data shouldBe Array(Map("id" -> "id", "payload" -> """{"key": "\"value\""}"""))
+  }
+
+  "SeparatedValuesParser" should "allow an escape char" in {
+    val data = csv("sample3.csv", escapeChar = '\\').build(mock[ScenarioContext]).toArray
+    data shouldBe Array(Map("id" -> "id", "payload" -> """{"k1": "v1", "k2": "v2"}""""))
   }
 }

--- a/src/sphinx/session/code/Feeders.scala
+++ b/src/sphinx/session/code/Feeders.scala
@@ -69,7 +69,7 @@ class Feeders {
 
   {
     //#escape-char
-    val csvFeeder = csv("foo.csv", escapeChar = '\0')
+    val csvFeeder = csv("foo.csv", escapeChar = '\\')
     //#escape-char
   }
 

--- a/src/sphinx/session/code/Feeders.scala
+++ b/src/sphinx/session/code/Feeders.scala
@@ -68,6 +68,12 @@ class Feeders {
   }
 
   {
+    //#escape-char
+    val csvFeeder = csv("foo.csv", escapeChar = '\0')
+    //#escape-char
+  }
+
+  {
     //#json-feeders
     val jsonFileFeeder = jsonFile("foo.json")
     val jsonUrlFeeder = jsonUrl("http://me.com/foo.json")

--- a/src/sphinx/session/feeder.rst
+++ b/src/sphinx/session/feeder.rst
@@ -76,6 +76,11 @@ A solution can be to turn the parsing into a raw split:
 
 Of course, don't use ``csv`` for JSON with rawSplit as the JSON commas will be interpreted as separators !
 
+Also, in a JSON string, double-quotes are escaped with ``\``. So you might prefer Gatling not to escape the backslash and be fully compliant
+with the RFC and nothing more. In that case, you can do the following:
+
+.. includecode:: code/Feeders.scala#escape-char
+
 .. _feeder-json:
 
 JSON feeders

--- a/src/sphinx/session/feeder.rst
+++ b/src/sphinx/session/feeder.rst
@@ -54,8 +54,6 @@ By default, our parser respects `RFC4180 <https://www.ietf.org/rfc/rfc4180.txt>`
 
 For example, a very classic pitfall is trailing spaces in header names: they don't get trimmed.
 
-Besides escaping features described in the RFC, one can use a ``\`` character and escape characters that would match the separator or the double quotes.
-
 .. includecode:: code/Feeders.scala#sep-values-feeders
 
 Those built-ins returns ``RecordSeqFeederBuilder`` instances, meaning that the whole file is loaded in memory and parsed, so the resulting feeders doesn't read on disk during the simulation run.
@@ -76,8 +74,8 @@ A solution can be to turn the parsing into a raw split:
 
 Of course, don't use ``csv`` for JSON with rawSplit as the JSON commas will be interpreted as separators !
 
-Also, in a JSON string, double-quotes are escaped with ``\``. So you might prefer Gatling not to escape the backslash and be fully compliant
-with the RFC and nothing more. In that case, you can do the following:
+Besides escaping features described in the RFC, one can specify your own character in order to escape characters
+that would match the separator or the double quotes.
 
 .. includecode:: code/Feeders.scala#escape-char
 


### PR DESCRIPTION
This should do the trick. However, I must say that being fully compliant with the RFC as the default would have make more sense but would break backward compatibility.

Also, it might be possible that specifying no escape char instead of using \0 is cleaner.