### PR TITLE
Gather messages from all Failures

### DIFF
--- a/gatling-commons/src/main/scala/io/gatling/commons/validation/Validation.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/validation/Validation.scala
@@ -42,7 +42,7 @@ case class Success[+T](value: T) extends Validation[T] {
 case class Failure(message: String) extends Validation[Nothing] {
   def map[A](f: Nothing => A): Validation[A] = this
   def flatMap[A](f: Nothing => Validation[A]): Validation[A] = this
-  def mapError(f: String => String): Validation[Nothing] = Failure(f(message))
+  def mapError(f: String => String): Failure = Failure(f(message))
   def filter(p: Nothing => Boolean) = this
   def onSuccess(f: Nothing => Any): Unit = ()
   def onFailure(f: String => Any): Unit = f(message)

--- a/gatling-core/src/main/scala/io/gatling/core/check/Check.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/Check.scala
@@ -48,11 +48,12 @@ object Check {
                   checkRec(session, tail, update, failure)
               }
 
-            case f: Failure =>
+            case f @ Failure(msg) =>
               failure match {
                 case None =>
                   checkRec(session, tail, update, Some(f))
-                case _ => checkRec(session, tail, update, failure)
+                case Some(previous) =>
+                  checkRec(session, tail, update, Some(previous.mapError(oldmsg => s"$oldmsg\n$msg")))
               }
           }
         }

--- a/gatling-core/src/test/scala/io/gatling/core/check/CheckSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/check/CheckSpec.scala
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2011-2015 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.core.check
+
+import scala.collection.mutable
+
+import io.gatling.BaseSpec
+import io.gatling.commons.validation.Failure
+import io.gatling.commons.validation.Validation
+import io.gatling.core.session.Session
+
+class CheckSpec extends BaseSpec {
+
+  case class SimpleCheck(msg: String) extends Check[String] {
+    def check(response: String, session: Session)(implicit cache: mutable.Map[Any, Any]): Validation[CheckResult] = {
+      Failure(msg)
+    }
+  }
+
+  object SimpleSuccess extends Check[String] {
+    def check(response: String, session: Session)(implicit cache: mutable.Map[Any, Any]): Validation[CheckResult] = {
+      CheckResult.NoopCheckResultSuccess
+    }
+  }
+
+  "CheckSpec" should "gather messages from all failures" in {
+    val (_, failure) = Check.check("test", Session("test", 1),
+      List(SimpleCheck("first"), SimpleSuccess, SimpleCheck("second"), SimpleSuccess))
+    failure shouldBe a [Some[_]]
+    failure should contain (Failure("first\nsecond"))
+  }
+
+}


### PR DESCRIPTION
Current implementation of `Check.check` ignores all Failures except the 1st one. We could use `mapError` to combine all the messages from failures into the resulting `Failure`