### PR TITLE
Gatling JMS client concurrency issue

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestExpressionBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestExpressionBuilder.scala
@@ -79,7 +79,7 @@ abstract class RequestExpressionBuilder(commonAttributes: CommonAttributes, http
         //
         // [fl]
         _.setNameResolver(nameResolver)
-      }
+    }
 
   // FIXME resolve proxy presence once
   private def configureProxy(requestBuilder: AhcRequestBuilder, uri: Uri): Validation[AhcRequestBuilder] = {

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/JmsReqReplyAction.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/JmsReqReplyAction.scala
@@ -67,6 +67,7 @@ class JmsReqReplyAction(attributes: JmsAttributes, protocol: JmsProtocol, tracke
               tracker ! MessageReceived(messageMatcher.responseID(msg), nowMillis, msg)
               logMessage(s"Message received ${msg.getJMSMessageID}", msg)
             case _ =>
+              tracker ! FailureReceivingMessage()
               throw BlockingReceiveReturnedNull
           }
         }

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/JmsRequestTrackerActor.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/JmsRequestTrackerActor.scala
@@ -15,15 +15,9 @@
  */
 package io.gatling.jms.action
 
-import java.util.concurrent.{TimeUnit, Executors, ConcurrentHashMap}
-import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
 import javax.jms.Message
 
-import com.typesafe.scalalogging.LazyLogging
-import io.gatling.jms.action.RequestResponseCorrelator._
-
-import scala.collection.mutable
-
+import akka.actor.{ ActorRef, Props }
 import io.gatling.commons.stats.{ KO, OK, Status }
 import io.gatling.commons.util.TimeHelper.nowMillis
 import io.gatling.commons.validation.Failure
@@ -34,7 +28,7 @@ import io.gatling.core.stats.StatsEngine
 import io.gatling.core.stats.message.ResponseTimings
 import io.gatling.jms._
 
-import akka.actor.{ ActorRef, Props }
+import scala.collection.mutable
 
 /**
  * Advise actor a message was sent to JMS provider
@@ -61,126 +55,6 @@ case class FailureReceivingMessage()
 
 object JmsRequestTrackerActor {
   def props(statsEngine: StatsEngine) = Props(new JmsRequestTrackerActor(statsEngine))
-}
-
-object RequestResponseCorrelator extends LazyLogging {
-
-  import collection.JavaConverters._
-
-  var statsEngine: StatsEngine = null
-  val messageReceiveFailed: AtomicBoolean = new AtomicBoolean(false)
-  val msgsOut: AtomicInteger = new AtomicInteger(0)
-  val msgsIn: AtomicInteger = new AtomicInteger(0)
-  val totalActorNotifications: AtomicInteger = new AtomicInteger(0)
-  val sentMessages = new ConcurrentHashMap[String, (Long, List[JmsCheck], Session, ActorRef, String)].asScala
-  val receivedMessages = new ConcurrentHashMap[String, (Long, Message)].asScala
-  val correlator = Executors.newScheduledThreadPool(16)
-
-  val correlationActivity = new Runnable {
-    override def run(): Unit = {
-      if (statsEngine != null) {
-        //go through the received messages and if any are found corresponding to the sent then
-        //pump them out for processing and remove them from both lists
-        if (messageReceiveFailed.get()) {
-          logger.debug("!!!!!!!!!!!!!!!!Message Receive Filure set and needs to be processed!!!!!!!!!!!!!!!! sent: " + sentMessages.size + " received: " + receivedMessages.size)
-          for ((key, value) <- sentMessages) {
-            logger.debug("=======>Processing a sent message: " + key)
-            receivedMessages.get(key) match {
-              case Some((receivedDate, message)) => {
-                logger.debug("=======>Recieved message found for sent message key: " + key)
-                sentMessages.get(key) match {
-                  case Some((startDate, checks, session, next, title)) => {
-                    logger.debug("=======>Sent message matches a received message: " + key)
-                    processMessage(session, startDate, receivedDate, checks, message, next, title)
-                    sentMessages.remove(key)
-                    receivedMessages.remove(key)
-                  }
-                  case None => {
-                    logger.debug("=======>No sent message matches the received messge: " + key)
-                    //should never get here
-                  }
-                }
-              }
-              case None => {
-                logger.debug("=======>No Recieved message found for sent message key: " + key)
-                //clean out the sent message as timed out
-                sentMessages.get(key) match {
-                  case Some((startDate, checks, session, next, title)) => {
-                    logger.debug("=======>... but we still have the sent message... must have been a timeout: " + key)
-                    processMessage(session, startDate, System.currentTimeMillis, checks, null, next, title)
-                    sentMessages.remove(key)
-                  }
-                  case None => {
-                    logger.debug("=======>... where did the sent message go: " + key)
-                    //should never get here
-                  }
-                }
-
-              }
-            }
-          }
-        } else {
-          logger.debug(":-)    All good     :-)")
-          for ((key, value) <- sentMessages) {
-
-            receivedMessages.get(key) match {
-              case Some((receivedDate, message)) => {
-                logger.debug("=======>Processing a received message: " + key)
-                sentMessages.get(key) match {
-                  case Some((startDate, checks, session, next, title)) => {
-                    logger.debug("=======>Received message matches sent message: " + key)
-                    processMessage(session, startDate, receivedDate, checks, message, next, title)
-                    sentMessages.remove(key)
-                    receivedMessages.remove(key)
-                  }
-                  case None => {
-                    logger.debug("=======>!!!Received Does not match sent message: " + key)
-                    //should never get here
-                  }
-                }
-              }
-              case None => {
-                logger.debug("No received message for this key: " + key)
-                //might receive the message later so do nothing for now
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  correlator.scheduleWithFixedDelay(correlationActivity, 5, 5, TimeUnit.SECONDS)
-
-  def processMessage(
-                      session:      Session,
-                      startDate:    Long,
-                      receivedDate: Long,
-                      checks:       List[JmsCheck],
-                      message:      Message,
-                      next:         ActorRef,
-                      title:        String
-                      ): Unit = {
-
-    def executeNext(updatedSession: Session, status: Status, message: Option[String] = None) = {
-      val timings = ResponseTimings(startDate, receivedDate)
-      statsEngine.logResponse(updatedSession, title, timings, status, None, message)
-      next ! updatedSession.logGroupRequest(timings.responseTime, status).increaseDrift(nowMillis - receivedDate)
-    }
-
-    // run all the checks, advise the Gatling API that it is complete and move to next
-    val (checkSaveUpdate, error) = Check.check(message, session, checks)
-    val newSession = checkSaveUpdate(session)
-    error match {
-      case None                   => executeNext(newSession, OK)
-      case Some(Failure(message)) => executeNext(newSession.markAsFailed, KO, Some(message))
-    }
-  }
-
-  def entryProcessor(key: String, value: String) = {
-
-  }
-
 }
 
 /**

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/JmsRequestTrackerActor.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/JmsRequestTrackerActor.scala
@@ -15,7 +15,12 @@
  */
 package io.gatling.jms.action
 
+import java.util.concurrent.{TimeUnit, Executors, ConcurrentHashMap}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
 import javax.jms.Message
+
+import com.typesafe.scalalogging.LazyLogging
+import io.gatling.jms.action.RequestResponseCorrelator._
 
 import scala.collection.mutable
 
@@ -58,6 +63,126 @@ object JmsRequestTrackerActor {
   def props(statsEngine: StatsEngine) = Props(new JmsRequestTrackerActor(statsEngine))
 }
 
+object RequestResponseCorrelator extends LazyLogging {
+
+  import collection.JavaConverters._
+
+  var statsEngine: StatsEngine = null
+  val messageReceiveFailed: AtomicBoolean = new AtomicBoolean(false)
+  val msgsOut: AtomicInteger = new AtomicInteger(0)
+  val msgsIn: AtomicInteger = new AtomicInteger(0)
+  val totalActorNotifications: AtomicInteger = new AtomicInteger(0)
+  val sentMessages = new ConcurrentHashMap[String, (Long, List[JmsCheck], Session, ActorRef, String)].asScala
+  val receivedMessages = new ConcurrentHashMap[String, (Long, Message)].asScala
+  val correlator = Executors.newScheduledThreadPool(16)
+
+  val correlationActivity = new Runnable {
+    override def run(): Unit = {
+      if (statsEngine != null) {
+        //go through the received messages and if any are found corresponding to the sent then
+        //pump them out for processing and remove them from both lists
+        if (messageReceiveFailed.get()) {
+          logger.debug("!!!!!!!!!!!!!!!!Message Receive Filure set and needs to be processed!!!!!!!!!!!!!!!! sent: " + sentMessages.size + " received: " + receivedMessages.size)
+          for ((key, value) <- sentMessages) {
+            logger.debug("=======>Processing a sent message: " + key)
+            receivedMessages.get(key) match {
+              case Some((receivedDate, message)) => {
+                logger.debug("=======>Recieved message found for sent message key: " + key)
+                sentMessages.get(key) match {
+                  case Some((startDate, checks, session, next, title)) => {
+                    logger.debug("=======>Sent message matches a received message: " + key)
+                    processMessage(session, startDate, receivedDate, checks, message, next, title)
+                    sentMessages.remove(key)
+                    receivedMessages.remove(key)
+                  }
+                  case None => {
+                    logger.debug("=======>No sent message matches the received messge: " + key)
+                    //should never get here
+                  }
+                }
+              }
+              case None => {
+                logger.debug("=======>No Recieved message found for sent message key: " + key)
+                //clean out the sent message as timed out
+                sentMessages.get(key) match {
+                  case Some((startDate, checks, session, next, title)) => {
+                    logger.debug("=======>... but we still have the sent message... must have been a timeout: " + key)
+                    processMessage(session, startDate, System.currentTimeMillis, checks, null, next, title)
+                    sentMessages.remove(key)
+                  }
+                  case None => {
+                    logger.debug("=======>... where did the sent message go: " + key)
+                    //should never get here
+                  }
+                }
+
+              }
+            }
+          }
+        } else {
+          logger.debug(":-)    All good     :-)")
+          for ((key, value) <- sentMessages) {
+
+            receivedMessages.get(key) match {
+              case Some((receivedDate, message)) => {
+                logger.debug("=======>Processing a received message: " + key)
+                sentMessages.get(key) match {
+                  case Some((startDate, checks, session, next, title)) => {
+                    logger.debug("=======>Received message matches sent message: " + key)
+                    processMessage(session, startDate, receivedDate, checks, message, next, title)
+                    sentMessages.remove(key)
+                    receivedMessages.remove(key)
+                  }
+                  case None => {
+                    logger.debug("=======>!!!Received Does not match sent message: " + key)
+                    //should never get here
+                  }
+                }
+              }
+              case None => {
+                logger.debug("No received message for this key: " + key)
+                //might receive the message later so do nothing for now
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  correlator.scheduleWithFixedDelay(correlationActivity, 5, 5, TimeUnit.SECONDS)
+
+  def processMessage(
+                      session:      Session,
+                      startDate:    Long,
+                      receivedDate: Long,
+                      checks:       List[JmsCheck],
+                      message:      Message,
+                      next:         ActorRef,
+                      title:        String
+                      ): Unit = {
+
+    def executeNext(updatedSession: Session, status: Status, message: Option[String] = None) = {
+      val timings = ResponseTimings(startDate, receivedDate)
+      statsEngine.logResponse(updatedSession, title, timings, status, None, message)
+      next ! updatedSession.logGroupRequest(timings.responseTime, status).increaseDrift(nowMillis - receivedDate)
+    }
+
+    // run all the checks, advise the Gatling API that it is complete and move to next
+    val (checkSaveUpdate, error) = Check.check(message, session, checks)
+    val newSession = checkSaveUpdate(session)
+    error match {
+      case None                   => executeNext(newSession, OK)
+      case Some(Failure(message)) => executeNext(newSession.markAsFailed, KO, Some(message))
+    }
+  }
+
+  def entryProcessor(key: String, value: String) = {
+
+  }
+
+}
+
 /**
  * Bookkeeping actor to correlate request and response JMS messages
  * Once a message is correlated, it publishes to the Gatling core DataWriter
@@ -67,46 +192,21 @@ class JmsRequestTrackerActor(statsEngine: StatsEngine) extends BaseActor {
   // messages to be tracked through this HashMap - note it is a mutable hashmap
   val sentMessages = mutable.HashMap.empty[String, (Long, List[JmsCheck], Session, ActorRef, String)]
   val receivedMessages = mutable.HashMap.empty[String, (Long, Message)]
+  RequestResponseCorrelator.statsEngine = statsEngine
 
   // Actor receive loop
   def receive = {
 
     // message was sent; add the timestamps to the map
     case MessageSent(corrId, startDate, checks, session, next, title) =>
-      receivedMessages.get(corrId) match {
-        case Some((receivedDate, message)) =>
-          // message was received out of order, lets just deal with it
-          processMessage(session, startDate, receivedDate, checks, message, next, title)
-          receivedMessages -= corrId
-
-        case None =>
-          // normal path
-          val sentMessage = (startDate, checks, session, next, title)
-          sentMessages += corrId -> sentMessage
-      }
+      RequestResponseCorrelator.sentMessages.putIfAbsent(corrId, (startDate, checks, session, next, title))
 
     // message was received; publish to the datawriter and remove from the hashmap
     case MessageReceived(corrId, receivedDate, message) =>
-      sentMessages.get(corrId) match {
-        case Some((startDate, checks, session, next, title)) =>
-          processMessage(session, startDate, receivedDate, checks, message, next, title)
-          sentMessages -= corrId
-
-        case None =>
-          // failed to find message; early receive? or bad return correlation id?
-          // let's add it to the received messages buffer just in case
-          val receivedMessage = (receivedDate, message)
-          receivedMessages += corrId -> receivedMessage
-      }
+      RequestResponseCorrelator.receivedMessages.putIfAbsent(corrId, (receivedDate, message))
 
     case FailureReceivingMessage() =>
-      //Fail all the sent messages because we do not even have a correlation id
-      val keys = sentMessages.keySet
-      keys.foreach((corrId) => {
-        val Some((startDate, checks, session, next, title)) = sentMessages.get(corrId)
-        processMessage(session, startDate, System.currentTimeMillis, checks, null, next, title)
-        sentMessages -= corrId
-      })
+      RequestResponseCorrelator.messageReceiveFailed.set(true)
   }
 
   /**

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/JmsRequestTrackerActor.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/JmsRequestTrackerActor.scala
@@ -72,12 +72,16 @@ class JmsRequestTrackerActor(statsEngine: StatsEngine) extends BaseActor {
   def receive = {
 
     // message was sent; add the timestamps to the map
-    case MessageSent(corrId, startDate, checks, session, next, title) =>
-      RequestResponseCorrelator.sentMessages.putIfAbsent(corrId, (startDate, checks, session, next, title))
+    case MessageSent(corrId, startDate, checks, session, next, title) => {
+      logger.debug("====> tracker sent message")
+      RequestResponseCorrelator.sentMessages.put(corrId, (startDate, checks, session, next, title))
+    }
 
     // message was received; publish to the datawriter and remove from the hashmap
-    case MessageReceived(corrId, receivedDate, message) =>
-      RequestResponseCorrelator.receivedMessages.putIfAbsent(corrId, (receivedDate, message))
+    case MessageReceived(corrId, receivedDate, message) => {
+      logger.debug("====> tracker received message")
+      RequestResponseCorrelator.receivedMessages.put(corrId, (receivedDate, message))
+    }
 
     case FailureReceivingMessage() =>
       RequestResponseCorrelator.messageReceiveFailed.set(true)

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/RequestResponseCorrelator.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/RequestResponseCorrelator.scala
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2011-2016 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.jms.action
+
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+import java.util.concurrent.{ ConcurrentHashMap, Executors, TimeUnit }
+import javax.jms.Message
+
+import akka.actor.ActorRef
+import com.typesafe.scalalogging.LazyLogging
+import io.gatling.commons.stats.{ KO, OK, Status }
+import io.gatling.commons.util.TimeHelper._
+import io.gatling.commons.validation.Failure
+import io.gatling.core.Predef._
+import io.gatling.core.check.Check
+import io.gatling.core.stats.StatsEngine
+import io.gatling.core.stats.message.ResponseTimings
+import io.gatling.jms._
+
+/**
+ * Created by abrahamkiggundu on 18/02/2016.
+ */
+object RequestResponseCorrelator extends LazyLogging {
+
+  import scala.collection.JavaConverters._
+
+  var statsEngine: StatsEngine = null
+  val messageReceiveFailed: AtomicBoolean = new AtomicBoolean(false)
+  val msgsOut: AtomicInteger = new AtomicInteger(0)
+  val msgsIn: AtomicInteger = new AtomicInteger(0)
+  val totalActorNotifications: AtomicInteger = new AtomicInteger(0)
+  val sentMessages = new ConcurrentHashMap[String, (Long, List[JmsCheck], Session, ActorRef, String)].asScala
+  val receivedMessages = new ConcurrentHashMap[String, (Long, Message)].asScala
+  val correlator = Executors.newScheduledThreadPool(16)
+
+  val correlationActivity = new Runnable {
+    override def run(): Unit = {
+      if (statsEngine != null) {
+        //go through the received messages and if any are found corresponding to the sent then
+        //pump them out for processing and remove them from both lists
+        if (messageReceiveFailed.get()) {
+          logger.debug("!!!!!!!!!!!!!!!!Message Receive Filure set and needs to be processed!!!!!!!!!!!!!!!! sent: " + sentMessages.size + " received: " + receivedMessages.size)
+          for ((key, value) <- sentMessages) {
+            logger.debug("=======>Processing a sent message: " + key)
+            receivedMessages.get(key) match {
+              case Some((receivedDate, message)) => {
+                logger.debug("=======>Recieved message found for sent message key: " + key)
+                sentMessages.get(key) match {
+                  case Some((startDate, checks, session, next, title)) => {
+                    logger.debug("=======>Sent message matches a received message: " + key)
+                    processMessage(session, startDate, receivedDate, checks, message, next, title)
+                    sentMessages.remove(key)
+                    receivedMessages.remove(key)
+                  }
+                  case None => {
+                    logger.debug("=======>No sent message matches the received messge: " + key)
+                    //should never get here
+                  }
+                }
+              }
+              case None => {
+                logger.debug("=======>No Recieved message found for sent message key: " + key)
+                //clean out the sent message as timed out
+                sentMessages.get(key) match {
+                  case Some((startDate, checks, session, next, title)) => {
+                    logger.debug("=======>... but we still have the sent message... must have been a timeout: " + key)
+                    processMessage(session, startDate, System.currentTimeMillis, checks, null, next, title)
+                    sentMessages.remove(key)
+                  }
+                  case None => {
+                    logger.debug("=======>... where did the sent message go: " + key)
+                    //should never get here
+                  }
+                }
+
+              }
+            }
+          }
+        } else {
+          logger.debug(":-)    All good     :-)")
+          for ((key, value) <- sentMessages) {
+
+            receivedMessages.get(key) match {
+              case Some((receivedDate, message)) => {
+                logger.debug("=======>Processing a received message: " + key)
+                sentMessages.get(key) match {
+                  case Some((startDate, checks, session, next, title)) => {
+                    logger.debug("=======>Received message matches sent message: " + key)
+                    processMessage(session, startDate, receivedDate, checks, message, next, title)
+                    sentMessages.remove(key)
+                    receivedMessages.remove(key)
+                  }
+                  case None => {
+                    logger.debug("=======>!!!Received Does not match sent message: " + key)
+                    //should never get here
+                  }
+                }
+              }
+              case None => {
+                logger.debug("No received message for this key: " + key)
+                //might receive the message later so do nothing for now
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  correlator.scheduleWithFixedDelay(correlationActivity, 5, 5, TimeUnit.SECONDS)
+
+  def processMessage(
+    session:      Session,
+    startDate:    Long,
+    receivedDate: Long,
+    checks:       List[JmsCheck],
+    message:      Message,
+    next:         ActorRef,
+    title:        String
+  ): Unit = {
+
+      def executeNext(updatedSession: Session, status: Status, message: Option[String] = None) = {
+        val timings = ResponseTimings(startDate, receivedDate)
+        statsEngine.logResponse(updatedSession, title, timings, status, None, message)
+        next ! updatedSession.logGroupRequest(timings.responseTime, status).increaseDrift(nowMillis - receivedDate)
+      }
+
+    // run all the checks, advise the Gatling API that it is complete and move to next
+    val (checkSaveUpdate, error) = Check.check(message, session, checks)
+    val newSession = checkSaveUpdate(session)
+    error match {
+      case None                   => executeNext(newSession, OK)
+      case Some(Failure(message)) => executeNext(newSession.markAsFailed, KO, Some(message))
+    }
+  }
+
+  def entryProcessor(key: String, value: String) = {
+
+  }
+
+}

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/RequestResponseCorrelator.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/RequestResponseCorrelator.scala
@@ -44,7 +44,7 @@ object RequestResponseCorrelator extends LazyLogging {
   val totalActorNotifications: AtomicInteger = new AtomicInteger(0)
   val sentMessages = new ConcurrentHashMap[String, (Long, List[JmsCheck], Session, ActorRef, String)].asScala
   val receivedMessages = new ConcurrentHashMap[String, (Long, Message)].asScala
-  val correlator = Executors.newScheduledThreadPool(16)
+  val correlator = Executors.newScheduledThreadPool(6)
 
   val correlationActivity = new Runnable {
     override def run(): Unit = {


### PR DESCRIPTION
The fix provided for issue #2913 in build 2.2.0-E20160217 worked fine agains the testcase provided in that ticket however when the number of concurrent users was increased the same unpredictable concurrency behaviour returned.
Looking at the fix it looks like the tracker was placed into the executing context which meant that a new one was created per context and thus per user. This pull request is a solution we coded which seems to be working fine for us under heavy user loads.