### PR TITLE
Add a parameter to choose group timings displayed in report. Close #2924.

### DIFF
--- a/gatling-core/src/main/resources/gatling-defaults.conf
+++ b/gatling-core/src/main/resources/gatling-defaults.conf
@@ -43,6 +43,7 @@ gatling {
   charting {
     noReports = false       # When set to true, don't generate HTML reports
     maxPlotPerSeries = 1000 # Number of points per graph in Gatling reports
+    useGroupDurationInsteadOfCumulatedResponseTime = false  # Switch group timings from cumulated response time to group duration.
     indicators {
       lowerBound = 800      # Lower bound for the requests' response time to track in the reports and the console summary
       higherBound = 1200    # Higher bound for the requests' response time to track in the reports and the console summary

--- a/gatling-core/src/main/scala/io/gatling/core/ConfigKeys.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/ConfigKeys.scala
@@ -55,7 +55,8 @@ object ConfigKeys {
   object charting {
     val NoReports = "gatling.charting.noReports"
     val MaxPlotPerSeries = "gatling.charting.maxPlotPerSeries"
-
+    val UseGroupDurationInsteadOfCumulatedResponseTime = "gatling.charting.useGroupDurationInsteadOfCumulatedResponseTime"
+    
     object indicators {
       val LowerBound = "gatling.charting.indicators.lowerBound"
       val HigherBound = "gatling.charting.indicators.higherBound"

--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
@@ -137,6 +137,7 @@ object GatlingConfiguration extends StrictLogging {
       charting = ChartingConfiguration(
         noReports = config.getBoolean(charting.NoReports),
         maxPlotsPerSeries = config.getInt(charting.MaxPlotPerSeries),
+        useGroupDurationInsteadOfCumulatedResponseTime = config.getBoolean(charting.UseGroupDurationInsteadOfCumulatedResponseTime),
         indicators = IndicatorsConfiguration(
           lowerBound = config.getInt(charting.indicators.LowerBound),
           higherBound = config.getInt(charting.indicators.HigherBound),
@@ -292,6 +293,7 @@ case class DirectoryConfiguration(
 case class ChartingConfiguration(
   noReports:         Boolean,
   maxPlotsPerSeries: Int,
+  useGroupDurationInsteadOfCumulatedResponseTime: Boolean,
   indicators:        IndicatorsConfiguration
 )
 


### PR DESCRIPTION
By default, keep previous behaviour: group timings displayed are
cumulated response times. This can be replaced in config to display
group duration instead.
Close #2924.