### PR TITLE
Reports: Add a parameter to choose group timings displayed in report. Close #2924.

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/report/StatsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/StatsReportGenerator.scala
@@ -24,8 +24,9 @@ import io.gatling.charts.template.{ ConsoleTemplate, StatsJsTemplate, GlobalStat
 import io.gatling.commons.stats._
 import io.gatling.commons.util.NumberHelper._
 import io.gatling.core.config.GatlingConfiguration
+import com.typesafe.scalalogging.StrictLogging
 
-private[charts] class StatsReportGenerator(reportsGenerationInputs: ReportsGenerationInputs, componentLibrary: ComponentLibrary)(implicit configuration: GatlingConfiguration) {
+private[charts] class StatsReportGenerator(reportsGenerationInputs: ReportsGenerationInputs, componentLibrary: ComponentLibrary)(implicit configuration: GatlingConfiguration) extends StrictLogging {
 
   import reportsGenerationInputs._
 
@@ -69,10 +70,19 @@ private[charts] class StatsReportGenerator(reportsGenerationInputs: ReportsGener
 
       def computeGroupStats(name: String, group: Group): RequestStatistics = {
 
-        val total = logFileReader.groupCumulatedResponseTimeGeneralStats(group, None)
-        val ok = logFileReader.groupCumulatedResponseTimeGeneralStats(group, Some(OK))
-        val ko = logFileReader.groupCumulatedResponseTimeGeneralStats(group, Some(KO))
-
+        def groupStatsFunction: (Group, Option[Status]) => GeneralStats = 
+          if (configuration.charting.useGroupDurationMetric) {
+            logger.debug("Use group duration stats.")
+            logFileReader.groupDurationGeneralStats _
+          } else {
+            logger.debug("Use group cumulated response time stats.")
+            logFileReader.groupCumulatedResponseTimeGeneralStats _
+          }
+        
+        val total = groupStatsFunction(group, None)
+        val ok = groupStatsFunction(group, Some(OK))
+        val ko = groupStatsFunction(group, Some(KO))
+        
         val numberOfRequestsStatistics = Statistics("numberOfRequests", total.count, ok.count, ko.count)
         val minResponseTimeStatistics = Statistics("minResponseTime", total.min, ok.min, ko.min)
         val maxResponseTimeStatistics = Statistics("maxResponseTime", total.max, ok.max, ko.max)

--- a/gatling-core/src/main/resources/gatling-defaults.conf
+++ b/gatling-core/src/main/resources/gatling-defaults.conf
@@ -43,6 +43,7 @@ gatling {
   charting {
     noReports = false       # When set to true, don't generate HTML reports
     maxPlotPerSeries = 1000 # Number of points per graph in Gatling reports
+    useGroupDurationMetric = false  # Switch group timings from cumulated response time to group duration.
     indicators {
       lowerBound = 800      # Lower bound for the requests' response time to track in the reports and the console summary
       higherBound = 1200    # Higher bound for the requests' response time to track in the reports and the console summary

--- a/gatling-core/src/main/scala/io/gatling/core/ConfigKeys.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/ConfigKeys.scala
@@ -55,7 +55,8 @@ object ConfigKeys {
   object charting {
     val NoReports = "gatling.charting.noReports"
     val MaxPlotPerSeries = "gatling.charting.maxPlotPerSeries"
-
+    val UseGroupDurationMetric = "gatling.charting.useGroupDurationMetric"
+    
     object indicators {
       val LowerBound = "gatling.charting.indicators.lowerBound"
       val HigherBound = "gatling.charting.indicators.higherBound"

--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
@@ -137,6 +137,7 @@ object GatlingConfiguration extends StrictLogging {
       charting = ChartingConfiguration(
         noReports = config.getBoolean(charting.NoReports),
         maxPlotsPerSeries = config.getInt(charting.MaxPlotPerSeries),
+        useGroupDurationMetric = config.getBoolean(charting.UseGroupDurationMetric),
         indicators = IndicatorsConfiguration(
           lowerBound = config.getInt(charting.indicators.LowerBound),
           higherBound = config.getInt(charting.indicators.HigherBound),
@@ -292,6 +293,7 @@ case class DirectoryConfiguration(
 case class ChartingConfiguration(
   noReports:         Boolean,
   maxPlotsPerSeries: Int,
+  useGroupDurationMetric: Boolean,
   indicators:        IndicatorsConfiguration
 )
 

--- a/src/sphinx/general/reports.rst
+++ b/src/sphinx/general/reports.rst
@@ -39,6 +39,8 @@ The top panel shows some standard statistics such as min, max, average, standard
 
 .. note:: these percentiles can be configured in the ``gatling.conf`` file.
 
+.. note:: If your scenario contains groups, this panel becomes a tree : each group is a non leaf node, and each request is a descendant leaf of a group. Group timings are by default the cumulated response times of all elements inside the group. Group duration can be displayed instead of group cumulated response time by editing the ``gatling.conf`` file.
+
 The bottom panel shows some details on the failed requests.
 
 Active users over time


### PR DESCRIPTION
By default, keep previous behaviour: group timings displayed are
cumulated response times. This can be replaced in config to display
group duration instead.
Close #2924.