### PR TITLE
Doc: fixed typo in cheat sheet.

### DIFF
--- a/src/sphinx/cheat-sheet.html
+++ b/src/sphinx/cheat-sheet.html
@@ -2489,7 +2489,7 @@
 
     <div class="row-fluid">
       <h2>
-        SSE (Server Side Events)
+        SSE (Server Sent Events)
         <small>Define the SSE requests sent in your scenario</small>
       </h2>
 


### PR DESCRIPTION
SSE = Server-Sent Events, not "Server Side Events"!
Just one word exchanged. Decided to adopt the notation used in the docs/http/sse ("Server Sent Events") instead of the more widely used notation with dash ("Server-Sent Events") because of consistency reasons.