### PR TITLE
Fix typos in documentation

### DIFF
--- a/src/sphinx/http/polling.rst
+++ b/src/sphinx/http/polling.rst
@@ -42,7 +42,7 @@ When you don't need to poll a request anymore, you can stop the poller:
 
 For example:
 
-.. includecode:: code/Polling.scala#pollerStart
+.. includecode:: code/Polling.scala#pollerStop
 
 .. note::
   Stopping a poller works works in the same fashion as SSE or WebSockets ``reconciliate``:

--- a/src/sphinx/project/whats_new/2.2.rst
+++ b/src/sphinx/project/whats_new/2.2.rst
@@ -66,7 +66,7 @@ If you use DNS round-robin, this will balance your virtual users amongst the nod
 
 Alternatively, you can enable ``perUserNameResolution`` on the HTTP protocol and have each virtual user perform DNS resolution on its own.
 This, way, your virtual users would be properly balanced if your cluster grows elastically under load.
-See :ref:`HTTP protocol documentation <http-protocol-name-resolution>` for more details.
+See :ref:`HTTP protocol documentation <http-protocol-hostname-resolution>` for more details.
 
 We also support DNS fail-over, meaning that virtual users will try the next DNS record of they couldn't connect to the first address.
 


### PR DESCRIPTION
Hi,

I noticed some little typos in the documentation for 2.2, which this PR should fix (although I couldn't test it since I don't have sphinx(?) installed)

BTW, should'nt [the example for the polling](https://github.com/gatling/gatling/blob/master/src/sphinx/http/code/Polling.scala) assign the result of 
`polling.pollerName("myCustomName")`
to a val and reuse it after? Polling seems to be immutable and the other calls would not use the same pollerName. Am I missing something?

Anyway, good job on 2.2! :-) 
