### PR TITLE
Support whitespace in gatling.sh options, fixes #2979

### DIFF
--- a/gatling-bundle/src/universal/bin/gatling.sh
+++ b/gatling-bundle/src/universal/bin/gatling.sh
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-USER_ARGS="$@"
-
 OLDDIR=`pwd`
 BIN_DIR=`dirname $0`
 cd "${BIN_DIR}/.." && DEFAULT_GATLING_HOME=`pwd` && cd "${OLDDIR}"
@@ -45,6 +43,6 @@ GATLING_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_HOME/user-files:$COMMON_CLASSPAT
 COMPILATION_CLASSPATH=`find "$GATLING_HOME/lib" -maxdepth 1 -name "*.jar" -type f -exec printf :{} ';'`
 
 # Run the compiler
-java $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler -ccp "$COMPILATION_CLASSPATH" $USER_ARGS  2> /dev/null
+java $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler -ccp "$COMPILATION_CLASSPATH" "$@"  2> /dev/null
 # Run Gatling
-java $JAVA_OPTS -cp "$GATLING_CLASSPATH" io.gatling.app.Gatling $USER_ARGS
+java $JAVA_OPTS -cp "$GATLING_CLASSPATH" io.gatling.app.Gatling "$@"


### PR DESCRIPTION
This allows to use spaces in the --run-description