### PR TITLE
Add explicit jmsType support, close #2967

### DIFF
--- a/gatling-jms/src/main/scala/io/gatling/jms/client/JmsClient.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/client/JmsClient.scala
@@ -51,7 +51,7 @@ trait JmsClient {
   /**
    * Wrapper to send a BytesMessage, returns the message ID of the sent message
    */
-  def sendBytesMessage(bytes: Array[Byte], props: Map[String, Any]): Message
+  def sendBytesMessage(bytes: Array[Byte], props: Map[String, Any], jmsType: Option[String]): Message
 
   /**
    * Wrapper to send a MapMessage, returns the message ID of the sent message
@@ -60,17 +60,17 @@ trait JmsClient {
    * for the objectified primitive object types (Integer, Double, Long ...), String objects,
    * and byte arrays."
    */
-  def sendMapMessage(map: Map[String, Any], props: Map[String, Any]): Message
+  def sendMapMessage(map: Map[String, Any], props: Map[String, Any], jmsType: Option[String]): Message
 
   /**
    * Wrapper to send an ObjectMessage, returns the message ID of the sent message
    */
-  def sendObjectMessage(o: java.io.Serializable, props: Map[String, Any]): Message
+  def sendObjectMessage(o: java.io.Serializable, props: Map[String, Any], jmsType: Option[String]): Message
 
   /**
    * Wrapper to send a TextMessage, returns the message ID of the sent message
    */
-  def sendTextMessage(messageText: String, props: Map[String, Any]): Message
+  def sendTextMessage(messageText: String, props: Map[String, Any], jmsType: Option[String]): Message
 
   def close(): Unit
 }

--- a/gatling-jms/src/main/scala/io/gatling/jms/client/SimpleJmsClient.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/client/SimpleJmsClient.scala
@@ -103,10 +103,11 @@ class SimpleJmsClient(
   /**
    * Wrapper to send a BytesMessage, returns the message ID of the sent message
    */
-  def sendBytesMessage(bytes: Array[Byte], props: Map[String, Any]): Message = {
+  def sendBytesMessage(bytes: Array[Byte], props: Map[String, Any], jmsType: Option[String]): Message = {
     val message = session.createBytesMessage
     message.writeBytes(bytes)
     writePropsToMessage(props, message)
+    jmsType.foreach(message.setJMSType)
     sendMessage(message)
   }
 
@@ -117,28 +118,31 @@ class SimpleJmsClient(
    * for the objectified primitive object types (Integer, Double, Long ...), String objects,
    * and byte arrays."
    */
-  def sendMapMessage(map: Map[String, Any], props: Map[String, Any]): Message = {
+  def sendMapMessage(map: Map[String, Any], props: Map[String, Any], jmsType: Option[String]): Message = {
     val message = session.createMapMessage
     map.foreach { case (key, value) => message.setObject(key, value) }
     writePropsToMessage(props, message)
+    jmsType.foreach(message.setJMSType)
     sendMessage(message)
   }
 
   /**
    * Wrapper to send an ObjectMessage, returns the message ID of the sent message
    */
-  def sendObjectMessage(o: java.io.Serializable, props: Map[String, Any]): Message = {
+  def sendObjectMessage(o: java.io.Serializable, props: Map[String, Any], jmsType: Option[String]): Message = {
     val message = session.createObjectMessage(o)
     writePropsToMessage(props, message)
+    jmsType.foreach(message.setJMSType)
     sendMessage(message)
   }
 
   /**
    * Wrapper to send a TextMessage, returns the message ID of the sent message
    */
-  def sendTextMessage(messageText: String, props: Map[String, Any]): Message = {
+  def sendTextMessage(messageText: String, props: Map[String, Any], jmsType: Option[String]): Message = {
     val message = session.createTextMessage(messageText)
     writePropsToMessage(props, message)
+    jmsType.foreach(message.setJMSType)
     sendMessage(message)
   }
 

--- a/gatling-jms/src/main/scala/io/gatling/jms/request/JmsAttributes.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/request/JmsAttributes.scala
@@ -34,5 +34,6 @@ case class JmsAttributes(
   selector:          Option[String],
   message:           JmsMessage,
   messageProperties: Map[Expression[String], Expression[Any]] = Map.empty,
+  jmsType:           Option[Expression[String]]               = None,
   checks:            List[JmsCheck]                           = Nil
 )

--- a/gatling-jms/src/main/scala/io/gatling/jms/request/JmsRequestBuilder.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/request/JmsRequestBuilder.scala
@@ -75,6 +75,8 @@ case class JmsRequestBuilder(attributes: JmsAttributes, factory: JmsAttributes =
    */
   def property(key: Expression[String], value: Expression[Any]) = this.modify(_.attributes.messageProperties).using(_ + (key -> value))
 
+  def jmsType(jmsType: Expression[String]) = this.modify(_.attributes.jmsType).setTo(Some(jmsType))
+
   /**
    * Add a check that will be perfomed on each received JMS response message before giving Gatling on OK/KO response
    */

--- a/gatling-jms/src/test/scala/io/gatling/jms/client/SimpleJmsClientSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/client/SimpleJmsClientSpec.scala
@@ -24,11 +24,11 @@ import io.gatling.jms.MockMessage
 
 class SimpleJmsClientSpec extends BrokerBasedSpec with MockMessage {
 
-  def withJmsClient(name: String)(testCode: (SimpleJmsClient, MessageConsumer, String) => Any): Unit = {
+  def withJmsClient(name: String, jmsType: Option[String])(testCode: (SimpleJmsClient, MessageConsumer, String, Option[String]) => Any): Unit = {
     val client = createClient(JmsQueue(name))
     val consumer = client.createReplyConsumer()
     try {
-      testCode(client, consumer, name)
+      testCode(client, consumer, name, jmsType)
     } finally {
       client.close()
     }
@@ -36,49 +36,53 @@ class SimpleJmsClientSpec extends BrokerBasedSpec with MockMessage {
 
   val propKey = "key"
 
-  "simple client" should "send  and pick up text message" in withJmsClient("text") { (client, consumer, name) =>
+  "simple client" should "send and pick up text message" in withJmsClient("text", Some("textType")) { (client, consumer, name, jmsType) =>
     val payload = "hello message"
     val properties = Map(propKey -> name)
-    val sentMsg = client.sendTextMessage(payload, properties).asInstanceOf[TextMessage]
+    val sentMsg = client.sendTextMessage(payload, properties, jmsType).asInstanceOf[TextMessage]
     val receivedMsg = consumer.receive().asInstanceOf[TextMessage]
 
     receivedMsg shouldBe sentMsg
     receivedMsg.getText shouldBe payload
     receivedMsg.getStringProperty(propKey) shouldBe name
+    Option(receivedMsg.getJMSType) shouldBe jmsType
   }
 
-  it should "send and pick up map message" in withJmsClient("map") { (client, consumer, name) =>
+  it should "send and pick up map message" in withJmsClient("map", Some("mapType")) { (client, consumer, name, jmsType) =>
     val payload = Map("msg" -> "hello message")
     val properties = Map(propKey -> name)
-    val sentMsg = client.sendMapMessage(payload, properties).asInstanceOf[MapMessage]
+    val sentMsg = client.sendMapMessage(payload, properties, jmsType).asInstanceOf[MapMessage]
     val receivedMsg = consumer.receive().asInstanceOf[MapMessage]
 
     receivedMsg shouldBe sentMsg
     receivedMsg.getObject("msg") shouldBe payload("msg")
     receivedMsg.getStringProperty(propKey) shouldBe name
+    Option(receivedMsg.getJMSType) shouldBe jmsType
   }
 
-  it should "send and pick up bytes message" in withJmsClient("bytes") { (client, consumer, name) =>
+  it should "send and pick up bytes message" in withJmsClient("bytes", Some("bytesType")) { (client, consumer, name, jmsType) =>
     val payload = Array[Byte](1, 2, 3)
     val properties = Map(propKey -> name)
-    val sentMsg = client.sendBytesMessage(payload, properties).asInstanceOf[BytesMessage]
+    val sentMsg = client.sendBytesMessage(payload, properties, jmsType).asInstanceOf[BytesMessage]
     val receivedMsg = consumer.receive().asInstanceOf[BytesMessage]
 
     receivedMsg shouldBe sentMsg
     receivedMsg.getBodyLength shouldBe 3
     receivedMsg.getStringProperty(propKey) shouldBe name
+    Option(receivedMsg.getJMSType) shouldBe jmsType
   }
 
-  it should "send and pick up object message" in withJmsClient("object") { (client, consumer, name) =>
+  it should "send and pick up object message" in withJmsClient("object", Some("objectType")) { (client, consumer, name, jmsType) =>
 
     val payload = Payload(name)
     val properties = Map(propKey -> name)
-    val sentMsg = client.sendObjectMessage(payload, properties).asInstanceOf[ObjectMessage]
+    val sentMsg = client.sendObjectMessage(payload, properties, jmsType).asInstanceOf[ObjectMessage]
     val receivedMsg = consumer.receive().asInstanceOf[ObjectMessage]
 
     receivedMsg shouldBe sentMsg
     receivedMsg.getObject shouldBe payload
     receivedMsg.getStringProperty(propKey) shouldBe name
+    Option(receivedMsg.getJMSType) shouldBe jmsType
   }
 }
 

--- a/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsIntegrationSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsIntegrationSpec.scala
@@ -31,21 +31,33 @@ class JmsIntegrationSpec extends JmsMockingSpec with CoreDsl with JmsDsl {
     val requestQueue = JmsQueue("request")
 
     jmsMock(requestQueue, {
-      case tm: TextMessage => tm.getText.toUpperCase
+      case tm: TextMessage =>
+        s"""<response>
+           |<hello>${tm.getText.toUpperCase()}</hello>
+           |<property><key>${tm.getStringProperty("key")}</key></property>
+           |<jmsType>${tm.getJMSType}</jmsType>
+           |</response>""".stripMargin
     })
 
     val session = runScenario(
       scenario("Jms upperCase")
+        .exec(_.set("sessionMarker", "test"))
         .exec(
           jms("toUpperCase")
             .reqreply
             .destination(requestQueue)
-            .textMessage("<hello>hi</hello>")
-            .check(xpath("/HELLO").find.saveAs("content"))
+            .textMessage("hi ${sessionMarker}")
+            .property("key", "${sessionMarker} value")
+            .jmsType("${sessionMarker} jmsType")
+            .check(xpath("/response/hello").find.saveAs("content"))
+            .check(xpath("/response/property/key").find.saveAs("propertyValue"))
+            .check(xpath("/response/jmsType").find.saveAs("jmsType"))
         )
     )
 
     session.isFailed shouldBe false
-    session("content").as[String] shouldBe "HI"
+    session("content").as[String] shouldBe "HI TEST"
+    session("propertyValue").as[String] shouldBe "test value"
+    session("jmsType").as[String] shouldBe "test jmsType"
   }
 }

--- a/src/sphinx/cheat-sheet.html
+++ b/src/sphinx/cheat-sheet.html
@@ -3003,8 +3003,21 @@
           <div class="function-details">
             Sends additional properties
             <dl>
-              <dt>(property)</dt>
-              <dd>Where <i>name</i> is the name of the queue</dd>
+              <dt>(key, value)</dt>
+              <dd>Sets <i>value</i> as an object property <i>key</i></dd>
+            </dl>
+          </div>
+        </div>
+
+        <div class="function">
+          <label class="function-syntax" for="property">jmsType</label>
+          <input type="checkbox" id="jmsType" name="jmsType">
+
+          <div class="function-details">
+            Sends additional properties
+            <dl>
+              <dt>(value)</dt>
+              <dd>Sets <i>value</i> as a <a href="https://docs.oracle.com/javaee/6/api/javax/jms/Message.html#setJMSType(java.lang.String)">JMSType</a></dd>
             </dl>
           </div>
         </div>

--- a/src/sphinx/code/Jms.scala
+++ b/src/sphinx/code/Jms.scala
@@ -40,6 +40,7 @@ class TestJmsDsl extends Simulation {
       .queue("jmstestq")
       .textMessage("hello from gatling jms dsl")
       .property("test_header", "test_value")
+      .jmsType("test_jms_type")
       .check(simpleCheck(checkBodyTextCorrect))
     )
   }

--- a/src/sphinx/jms.rst
+++ b/src/sphinx/jms.rst
@@ -74,6 +74,11 @@ Properties
 
 One can send additional properties with ``property(Expression[String], Expression[Any])``.
 
+JMS Type
+----------
+
+Jms type can be specified with ``jmsType(Expression[String])``.
+
 JMS Check API
 =============
 


### PR DESCRIPTION
Simplistic implementation. fixes #2967 

The `JmsClient` interface and its `SimpleJmsClient` implementation become bit clumsy due to repeating properties/jmsType. Would grow even worse if more settings needed. 

Could refactor this further upon request. the responsibility of setting the properties and jmsType could be moved to `io.gatling.jms.action.JmsReqReplyActor#executeOrFail` either via callback or splitting the `JmsClient.sendXXXMessage` into `JmsClient.createXXXMessage` and generic `JmsClient.send`