### PR TITLE
Remove typo and fix formatting in documentation

### DIFF
--- a/src/sphinx/advanced_tutorial.rst
+++ b/src/sphinx/advanced_tutorial.rst
@@ -94,12 +94,11 @@ Explanations:
      This user has two new session attributes named *searchCriterion*, *searchComputerName*.
   4. We use session data through Gatling's EL to parametrize the search.
   5. We use a CSS selector with an EL to capture a part of the HTML response, here a hyperlink, and save it in the user session with the name *computerURL*.
-     Note how Scala triple quotes are handy: you don't have to escape double quotes inside the regex with backslashes.
   6. We use the previously saved hyperlink to get a specific page.
 
 .. note::
     For more details regarding *Feeders*, please check out :ref:`Feeder reference page <feeder>`.
-    
+
     For more details regarding *HTTP Checks*, please check out :ref:`Checks reference page <http-check>`.
 
 Step 04: Looping

--- a/src/sphinx/general/scenario.rst
+++ b/src/sphinx/general/scenario.rst
@@ -42,7 +42,7 @@ This can be used for manually debugging or editing the :ref:`Session <expression
 .. includecode:: code/Scenario.scala#session-lambda
 
 .. note::
-  For those who wonder how the plumbing works and how you can return a ``Session`` instead of of ``Validation[Session]`` in the above examples,
+  For those who wonder how the plumbing works and how you can return a ``Session`` instead of ``Validation[Session]`` in the above examples,
   that's thanks to an implicit conversion.
 
 .. warning::

--- a/src/sphinx/general/scenario.rst
+++ b/src/sphinx/general/scenario.rst
@@ -46,8 +46,8 @@ This can be used for manually debugging or editing the :ref:`Session <expression
   that's thanks to an implicit conversion.
 
 .. warning::
-  Gatling DSL components are immutable ``ActionBuilder``s that have to be chained altogether and are only built once on startup.
-  The results is a workflow chain of ``Action``s.
+  Gatling DSL components are immutable ``ActionBuilder``\(s) that have to be chained altogether and are only built once on startup.
+  The results is a workflow chain of ``Action``\(s).
   These builders don't do anything by themselves, they don't trigger any side effect, they are just definitions.
   As a result, creating such DSL components at runtime in functions is completely meaningless.
   If you want conditional paths in your execution flow, use the proper DSL components (``doIf``, ``randomSwitch``, etc)


### PR DESCRIPTION
#### Overview
Remove duplicate "of of" and fix formatting issue on the [Scenario](http://gatling.io/docs/2.2.0/general/scenario.html) docs. Remove reference to missing code.

#### Screenshot
![screen shot 2016-05-18 at 3 25 22 pm](https://cloud.githubusercontent.com/assets/18267030/15375616/4bc71aac-1d0d-11e6-8e20-e8d237179757.png)