### PR TITLE
docs cheat-sheet: fix id of jmsType

### DIFF
--- a/src/sphinx/cheat-sheet.html
+++ b/src/sphinx/cheat-sheet.html
@@ -3010,7 +3010,7 @@
         </div>
 
         <div class="function">
-          <label class="function-syntax" for="property">jmsType</label>
+          <label class="function-syntax" for="jmsType">jmsType</label>
           <input type="checkbox" id="jmsType" name="jmsType">
 
           <div class="function-details">


### PR DESCRIPTION
Apologies for the typo. Could not run [docs](http://gatling.io/docs/2.2.1/developing_gatling/doc_guidelines.html#running-sphinx) locally. 