### PR TITLE
Add accumulated checks support for Websockets

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncCheck.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncCheck.scala
@@ -32,6 +32,8 @@ case class AsyncCheck(
     blocking:    Boolean,
     timeout:     FiniteDuration,
     expectation: Expectation,
+    accumulate:  Boolean,
+    name:        Option[String] = None,
     timestamp:   Long           = nowMillis
 ) extends Check[String] {
   override def check(message: String, session: Session)(implicit cache: mutable.Map[Any, Any]) =

--- a/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncCheckBuilders.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncCheckBuilders.scala
@@ -22,8 +22,8 @@ import io.gatling.core.check.{ Extender, Preparer }
 
 object AsyncCheckBuilders {
 
-  def extender(await: Boolean, timeout: FiniteDuration, expectation: Expectation): Extender[AsyncCheck, String] =
-    wrapped => new AsyncCheck(wrapped, await, timeout, expectation)
+  def extender(await: Boolean, timeout: FiniteDuration, expectation: Expectation, accumulate: Boolean): Extender[AsyncCheck, String] =
+    wrapped => new AsyncCheck(wrapped, await, timeout, expectation, accumulate)
 
   val PassThroughMessagePreparer: Preparer[String, String] = _.success
 }

--- a/gatling-http/src/test/scala/io/gatling/http/WsCompileTest.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/WsCompileTest.scala
@@ -71,7 +71,10 @@ class WsCompileTest extends Simulation {
                 ws("Message4")
                   .sendText("""{"text": "Hello, I'm ${id} and this is message ${i}!"}""")
                   .check(wsAwait.within(30 seconds).until(1))
-              )
+                ).exec(
+                  //check without sendText
+                  ws("Message5").check(wsListen.within(30 seconds).accumulate.jsonPath("$.message").findAll.saveAs("message1"))
+                  )
     .exec(ws("Close WS").close)
     .exec(ws("Open Named", "foo").open("/bar"))
 


### PR DESCRIPTION
  Hello & Bonjour,

On my current project we need to benchmark some scenario with http and websockets, but the current possibilities in gatling were not enought.

Let's say our server is a "long running task executor". You can send some task via a http POST, and it returns OK with a UUID when it's safely stored in a queue.
When the task is done, we send a status on an already opened websocket (identified by by client) with the task-id.

So on my scenario one User needs to 
- open a websocket 
-  POST lots tasks via http 
- adds a Check for each task with the returned UUID and status OK
- close websocket
We want to have timing for the http requests AND Checks 

Currently we can add a check without sending the message on websocket, but the problem was that we can't create a second check before the 1st one is matched (or it fails it with "Check didn't succeed by the time a new one was set up").

It was already discussed here:
https://groups.google.com/forum/#!topic/gatling/1kGyMC_0DyQ
http://stackoverflow.com/questions/26624448/issues-with-websocket-check-didnt-succeed-by-the-time-a-new-one-was-set-up

In the solution I propose, I wanted to keep the exact same behavior for existing scenarios, so I updated the DSL to add a new "accumulate" (I'm opened to better suggestion) option.
It was possible to keep the "blocking" option, but didn't make any sense to block and accumulate, so I forbid it at the DSL level.
Finally, I forced the "UntilCount(1)", since it would have been more difficult to keep track of counts for each Check (could be done later?).

Technically, I keep all AsynCheck instances in a Set (any better suggestion for a constantly evolving array? mutable.ListBuffer?). There's few risk of erasure, as they have a timestamp of creation property.
On a received message, I just loop on all accumulated checks, and on timeout I remove it from the Set and fail.

Functionally, it seems to work :) 
Of course, the size of the Set will evolve with your response time and finely tuned timeouts...
