### PR TITLE
Save system COMPILATION_CLASSPATH variable for jar usage ability

### DIFF
--- a/gatling-bundle/src/universal/bin/gatling.bat
+++ b/gatling-bundle/src/universal/bin/gatling.bat
@@ -59,7 +59,6 @@ set JAVA="%JAVA_HOME%\bin\java.exe"
 :run
 echo JAVA = "%JAVA%"
 rem Run the compiler
-set COMPILATION_CLASSPATH=""
 for %%i in ("%GATLING_HOME%\lib\*.jar") do call :addToPath "%%i"
 %JAVA% %COMPILER_OPTS% -cp %COMPILER_CLASSPATH% io.gatling.compiler.ZincCompiler -ccp %COMPILATION_CLASSPATH% %USER_ARGS%  2>NUL
 rem Run Gatling

--- a/gatling-bundle/src/universal/bin/gatling.sh
+++ b/gatling-bundle/src/universal/bin/gatling.sh
@@ -40,7 +40,7 @@ COMPILER_CLASSPATH="$GATLING_HOME/lib/zinc/*:$COMMON_CLASSPATH"
 GATLING_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_HOME/user-files:$COMMON_CLASSPATH"
 
 # Build compilation classpath
-COMPILATION_CLASSPATH=`find "$GATLING_HOME/lib" -maxdepth 1 -name "*.jar" -type f -exec printf :{} ';'`
+COMPILATION_CLASSPATH=`find "$GATLING_HOME/lib" -maxdepth 1 -name "*.jar" -type f -exec printf :{} ';'`":${COMPILATION_CLASSPATH}"
 
 # Run the compiler
 java $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler -ccp "$COMPILATION_CLASSPATH" "$@"  2> /dev/null


### PR DESCRIPTION
I'm writing automation wrapper around Gatling and need to use external java class in Gatling scala script. 
I can tell java where this class is located, but I can't tell it zinc compiler due to $COMPILATION_CLASSPATH takes files only from $GATLING_HOME/lib. 
It would be great if I could add my *jar to zinc libraries. For this it's enough to use same environment variable.