### PR TITLE
fix GATLING_HOME detection when $0 is symlink

### DIFF
--- a/gatling-bundle/src/universal/bin/gatling.sh
+++ b/gatling-bundle/src/universal/bin/gatling.sh
@@ -15,7 +15,25 @@
 # limitations under the License.
 #
 
-DEFAULT_GATLING_HOME=$(cd "$(dirname "$(readlink -n "$0")")/.."; pwd)
+
+## resolve links - $0 may be a link to Maven's home
+PRG="$0"
+
+# need this for relative symlinks
+while [ -h "$PRG" ] ; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG="`dirname "$PRG"`/$link"
+  fi
+done
+
+DEFAULT_GATLING_HOME=`dirname "$PRG"`/..
+
+# make it fully qualified
+DEFAULT_GATLING_HOME=`cd "$DEFAULT_GATLING_HOME" && pwd`
 
 GATLING_HOME="${GATLING_HOME:=${DEFAULT_GATLING_HOME}}"
 GATLING_CONF="${GATLING_CONF:=$GATLING_HOME/conf}"

--- a/gatling-bundle/src/universal/bin/gatling.sh
+++ b/gatling-bundle/src/universal/bin/gatling.sh
@@ -15,9 +15,7 @@
 # limitations under the License.
 #
 
-OLDDIR=`pwd`
-BIN_DIR=`dirname $0`
-cd "${BIN_DIR}/.." && DEFAULT_GATLING_HOME=`pwd` && cd "${OLDDIR}"
+DEFAULT_GATLING_HOME=$(cd "$(dirname "$(readlink -n "$0")")/.."; pwd)
 
 GATLING_HOME="${GATLING_HOME:=${DEFAULT_GATLING_HOME}}"
 GATLING_CONF="${GATLING_CONF:=$GATLING_HOME/conf}"


### PR DESCRIPTION
When gatling is launched via a symlink, e.g. `/usr/local/bin/gatling -> /opt/gatling/bin/gatling.sh` 
It fails with the following error:
> GATLING_HOME is set to /usr/local
Error: Could not find or load main class io.gatling.app.Gatling

BTW, for better cross platform compatibility, `readlink` options  `-e` or `-f` are not used, as that's GNU specific, not available in `/usr/bin/readlink` on Mac. the effect is the resolved `GATLING_HOME` could be still a symlink, but feature wise it works fine.