### PR TITLE
Fixed java.lang.ArrayIndexOutOfBoundsException with negative index during creation of report

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/stats/StatsHelper.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/stats/StatsHelper.scala
@@ -28,5 +28,5 @@ private[stats] object StatsHelper {
   }
 
   def timeToBucketNumber(start: Long, step: Double, maxPlots: Int): Long => Int =
-    time => math.min(((time - start) / step).round.toInt, maxPlots - 1)
+    time => math.max(math.min(((time - start) / step).round.toInt, maxPlots - 1), 0)
 }


### PR DESCRIPTION
Error message:

```
17:37:03.363 [INFO ] i.g.c.s.LogFileReader - Second pass
17:37:04.091 [INFO ] i.g.c.s.LogFileReader - Second pass, read 100000 lines
17:37:04.678 [INFO ] i.g.c.s.LogFileReader - Second pass, read 200000 lines
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: -1473946494
    at io.gatling.charts.stats.buffers.CountsBuffer.update(CountBuffer.scala:35)
    at io.gatling.charts.stats.buffers.ResponsesPerSecBuffers$class.updateResponsesPerSecBuffers(ResponsesPerSecBuffers.scala:32)
    at io.gatling.charts.stats.ResultsHolder.updateResponsesPerSecBuffers(ResultsHolder.scala:21)
    at io.gatling.charts.stats.ResultsHolder.addRequestRecord(ResultsHolder.scala:48)
    at io.gatling.charts.stats.LogFileReader.io$gatling$charts$stats$LogFileReader$$$anonfun$10(LogFileReader.scala:150)
    at io.gatling.charts.stats.LogFileReader$lambda$$secondPass$1.apply(LogFileReader.scala:145)
    at io.gatling.charts.stats.LogFileReader$lambda$$secondPass$1.apply(LogFileReader.scala:145)
    at scala.collection.Iterator$class.foreach(Iterator.scala:893)
    at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
    at io.gatling.charts.stats.LogFileReader.secondPass(LogFileReader.scala:145)
    at io.gatling.charts.stats.LogFileReader.io$gatling$charts$stats$LogFileReader$$$anonfun$11(LogFileReader.scala:165)
    at io.gatling.charts.stats.LogFileReader$lambda$3.apply(LogFileReader.scala:165)
    at io.gatling.charts.stats.LogFileReader$lambda$3.apply(LogFileReader.scala:165)
    at io.gatling.charts.stats.LogFileReader.parseInputFiles(LogFileReader.scala:63)
    at io.gatling.charts.stats.LogFileReader.<init>(LogFileReader.scala:165)
    at io.gatling.app.LogFileProcessor.initLogFileReader(RunResultProcessor.scala:55)
    at io.gatling.app.LogFileProcessor.processRunResult(RunResultProcessor.scala:37)
    at io.gatling.app.Gatling.start(Gatling.scala:66)
    at io.gatling.app.Gatling$.start(Gatling.scala:57)
    at io.gatling.app.Gatling$.fromArgs(Gatling.scala:49)
    at io.gatling.app.Gatling$.main(Gatling.scala:43)
    at io.gatling.app.Gatling.main(Gatling.scala)
```

I fixed it by placing negative values into bucket 0.

The simulation.log file which causes this issue can be downloaded at https://dl.dropboxusercontent.com/u/1326340/simulation.log (200 MB)
