### PR TITLE
Use JAVA_HOME on Windows when running the recorder

### DIFF
--- a/gatling-bundle/src/universal/bin/recorder.bat
+++ b/gatling-bundle/src/universal/bin/recorder.bat
@@ -43,7 +43,17 @@ set JAVA_OPTS=-Xms512M -Xmx512M -Xmn100M %JAVA_OPTS%
 set CLASSPATH="%GATLING_HOME%"\lib\*;"%GATLING_HOME%"\conf;%JAVA_CLASSPATH%
 set COMMAND=-cp %CLASSPATH% io.gatling.recorder.GatlingRecorder
 
-java %JAVA_OPTS% %COMMAND% %1 %2 %3 %4 %5 %6 %7 %8 %9
+set JAVA=java
+if exist "%JAVA_HOME%\bin\java.exe" goto setJavaHome
+goto run
+
+:setJavaHome
+set JAVA="%JAVA_HOME%\bin\java.exe"
+
+:run
+echo JAVA = "%JAVA%"
+
+%JAVA% %JAVA_OPTS% %COMMAND% %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 goto exit
 


### PR DESCRIPTION
JAVA_HOME is hanadled the same way as in gatling.bat