### PR TITLE
Core: TryMax should support an Expression[Int]

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/action/builder/TryMaxBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/action/builder/TryMaxBuilder.scala
@@ -16,9 +16,10 @@
 package io.gatling.core.action.builder
 
 import io.gatling.core.action.{ Action, TryMax }
+import io.gatling.core.session.Expression
 import io.gatling.core.structure.{ ChainBuilder, ScenarioContext }
 
-class TryMaxBuilder(times: Int, counterName: String, loopNext: ChainBuilder) extends ActionBuilder {
+class TryMaxBuilder(times: Expression[Int], counterName: String, loopNext: ChainBuilder) extends ActionBuilder {
 
   override def build(ctx: ScenarioContext, next: Action): Action = {
     import ctx._

--- a/gatling-core/src/main/scala/io/gatling/core/structure/Errors.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/structure/Errors.scala
@@ -18,13 +18,12 @@ package io.gatling.core.structure
 import java.util.UUID
 
 import io.gatling.core.action.builder.{ ExitHereIfFailedBuilder, TryMaxBuilder }
+import io.gatling.core.session._
 
 trait Errors[B] extends Execs[B] {
 
-  def exitBlockOnFail(chain: ChainBuilder): B = tryMax(1)(chain)
-  def tryMax(times: Int, counter: String = UUID.randomUUID.toString)(chain: ChainBuilder): B = {
-
-    require(times >= 1, "Can't set up a max try <= 1")
+  def exitBlockOnFail(chain: ChainBuilder): B = tryMax(1.expressionSuccess)(chain)
+  def tryMax(times: Expression[Int], counter: String = UUID.randomUUID.toString)(chain: ChainBuilder): B = {
 
     exec(new TryMaxBuilder(times, counter, chain))
   }

--- a/gatling-http/src/test/scala/io/gatling/http/HttpCompileTest.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/HttpCompileTest.scala
@@ -257,6 +257,12 @@ class HttpCompileTest extends Simulation {
             override val body = new StringResponseBody(response.body.string.replace(")]}',", ""), response.charset)
           }
       })
+    .exec(session => session.set("tryMax", 3))
+    .tryMax("${tryMax}") {
+      exec(http("tryMaxWithExpression")
+        .get("/"))
+    }
+
 
   val inject1 = nothingFor(10 milliseconds)
   val inject2 = rampUsers(10).over(10 minutes)


### PR DESCRIPTION
Hi,
unless there is a reason not to allow it, this should make it possible to use Expression[Int] for tryMax. :-)
With a test simulation : https://github.com/GabrielPlassard/gatlingTest/blob/master/src/test/scala/gatlingtest/TryMaxSimulation.scala