### PR TITLE
Fix cheatsheet for conditionals

### DIFF
--- a/src/sphinx/cheat-sheet.html
+++ b/src/sphinx/cheat-sheet.html
@@ -43,10 +43,11 @@
           <div class="function-details">
             Executes a chain when a condition is satisfied
             <dl>
-              <dt>(actual, expected){chain}</dt>
-              <dd>If the <i>actual</i> value is equal to <i>expected</i>, then, <i>chain</i> is executed.</dd>
+              <dt>(condition){chain}</dt>
+              <dd>If the result of the condition is true, then <i>chain</i> is executed.</dd>
               <dt>(Session => Boolean){chain}</dt>
-              <dd>If the result of the function <i>Session => Boolean</i> is true, then <i>chain</i> is executed.</dd>
+              <dd>If the result of the function <i>Session => Boolean</i> is true, 
+                then <i>chain</i> is executed.</dd>
             </dl>
           </div>
         </div>
@@ -62,6 +63,22 @@
               <dd>If the result of the condition is true, then <i>chain</i> is executed, else
                 <i>otherChain</i> is executed.
               </dd>
+              <dt>(Session => Boolean){chain}{otherChain}</dt>
+              <dd>If the result of the function <i>Session => Boolean</i> is true, 
+                then <i>chain</i> is executed, else <i>otherChain</i> is executed.</dd>
+            </dl>
+          </div>
+        </div>
+        
+        <div class="function">
+          <label class="function-syntax" for="doIfEquals">doIfEquals</label>
+          <input type="checkbox" id="doIfEquals" name="doIfEquals">
+
+          <div class="function-details">
+            Executes a chain when two values are equal
+            <dl>
+              <dt>(expected, actual){chain}</dt>
+              <dd>If expected equals actual, then <i>chain</i> is executed</dd>
             </dl>
           </div>
         </div>
@@ -71,7 +88,7 @@
           <input type="checkbox" id="doIfEqualsOrElse" name="doIfEqualsOrElse">
 
           <div class="function-details">
-            Executes a chain when two values are equals, another if not
+            Executes a chain when two values are equal, another if not
             <dl>
               <dt>(expected, actual){chain}{otherChain}</dt>
               <dd>If expected equals actual, then <i>chain</i> is executed, else


### PR DESCRIPTION
I was writing a scenario with some conditionals, and noticed that the [cheatsheet](http://gatling.io/#/cheat-sheet/2.2.3) docs for conditionals weren't quite right:

* No entry for `doIfEquals`
* The parameters for `doIf` in the cheatsheet are `(actual, expected)`, but it should be a single expression parameter (or something which can be implicitly converted to one)

I've fixed those in this pull request. I've tried to stick with the conventions in the existing cheatsheet entries, which give a quick summary of the usage without going into all the possibilities provided by implicit conversion.