### PR TITLE
JMS: Support passing a ConnectionFactory factory, close #3103

### DIFF
--- a/gatling-jms/src/main/scala/io/gatling/jms/JmsDsl.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/JmsDsl.scala
@@ -15,14 +15,19 @@
  */
 package io.gatling.jms
 
+import javax.jms.ConnectionFactory
+
 import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.jms.check.JmsCheckSupport
+import io.gatling.jms.jndi.{ JmsJndiConnectionFactoryBuilder, JmsJndiConnectionFactoryBuilderBase }
 import io.gatling.jms.protocol.{ JmsProtocol, JmsProtocolBuilder, JmsProtocolBuilderBase }
 import io.gatling.jms.request.{ JmsQueue, JmsReplyRequestBuilder, JmsRequestBuilderBase, JmsSendRequestBuilder, JmsTopic }
 
 trait JmsDsl extends JmsCheckSupport {
 
   val jms = JmsProtocolBuilderBase
+
+  val jmsJndiConnectionFactory = JmsJndiConnectionFactoryBuilderBase
 
   /**
    * DSL text to start the jms builder
@@ -42,6 +47,8 @@ trait JmsDsl extends JmsCheckSupport {
   implicit def jmsRequestBuilder2ActionBuilder(builder: JmsSendRequestBuilder): ActionBuilder = builder.build()
 
   implicit def jmsRequestBuilder2ActionBuilder(builder: JmsReplyRequestBuilder): ActionBuilder = builder.build()
+
+  implicit def jmsJndiConnectionFactory2ActionBuilder(builder: JmsJndiConnectionFactoryBuilder): ConnectionFactory = builder.build()
 
   def topic(name: String) = JmsTopic(name)
   def queue(name: String) = JmsQueue(name)

--- a/gatling-jms/src/main/scala/io/gatling/jms/client/JmsReqReplyClient.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/client/JmsReqReplyClient.scala
@@ -30,12 +30,9 @@ class JmsReqReplyClient(
   replyDestination: JmsDestination
 )
     extends JmsClient(
-      protocol.connectionFactoryName,
+      protocol.connectionFactory,
       destination,
-      protocol.url,
       protocol.credentials,
-      protocol.anonymousConnect,
-      protocol.contextFactory,
       protocol.deliveryMode
     ) {
 

--- a/gatling-jms/src/main/scala/io/gatling/jms/client/JmsSendClient.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/client/JmsSendClient.scala
@@ -27,12 +27,9 @@ class JmsSendClient(
   protocol:    JmsProtocol,
   destination: JmsDestination
 ) extends JmsClient(
-  protocol.connectionFactoryName,
+  protocol.connectionFactory,
   destination,
-  protocol.url,
   protocol.credentials,
-  protocol.anonymousConnect,
-  protocol.contextFactory,
   protocol.deliveryMode
 ) {
 

--- a/gatling-jms/src/main/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilder.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilder.scala
@@ -19,8 +19,9 @@ import java.util.{ Hashtable => JHashtable }
 import javax.jms.ConnectionFactory
 import javax.naming.{ Context, InitialContext }
 
-import com.typesafe.scalalogging.StrictLogging
 import io.gatling.core.config.Credentials
+
+import com.typesafe.scalalogging.StrictLogging
 
 case object JmsJndiConnectionFactoryBuilderBase {
 

--- a/gatling-jms/src/main/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilder.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilder.scala
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2011-2017 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.jms.jndi
+
+import java.util.{ Hashtable => JHashtable }
+import javax.jms.ConnectionFactory
+import javax.naming.{ Context, InitialContext }
+
+import com.typesafe.scalalogging.StrictLogging
+import io.gatling.core.config.Credentials
+
+case object JmsJndiConnectionFactoryBuilderBase {
+
+  def connectionFactoryName(cfn: String) = JmsJndiConnectionFactoryBuilderUrlStep(cfn)
+}
+
+case class JmsJndiConnectionFactoryBuilderUrlStep(connectionFactoryName: String) {
+
+  def url(theUrl: String) =
+    JmsJndiConnectionFactoryBuilderFactoryStep(connectionFactoryName, theUrl)
+}
+
+case class JmsJndiConnectionFactoryBuilderFactoryStep(
+    connectionFactoryName: String,
+    url:                   String,
+    credentials:           Option[Credentials] = None
+) {
+
+  def credentials(user: String, password: String) = copy(credentials = Some(Credentials(user, password)))
+
+  def contextFactory(cf: String) =
+    JmsJndiConnectionFactoryBuilder(cf, connectionFactoryName, url, credentials)
+}
+
+case class JmsJndiConnectionFactoryBuilder(
+    contextFactory:        String,
+    connectionFactoryName: String,
+    url:                   String,
+    credentials:           Option[Credentials]
+) extends StrictLogging {
+
+  def build() = {
+    // create InitialContext
+    val properties = new JHashtable[String, String]
+    properties.put(Context.INITIAL_CONTEXT_FACTORY, contextFactory)
+    properties.put(Context.PROVIDER_URL, url)
+
+    credentials.foreach { credentials =>
+      properties.put(Context.SECURITY_PRINCIPAL, credentials.username)
+      properties.put(Context.SECURITY_CREDENTIALS, credentials.password)
+    }
+
+    val ctx = new InitialContext(properties)
+    logger.info(s"Got InitialContext $ctx")
+
+    // create QueueConnectionFactory
+    val qcf = ctx.lookup(connectionFactoryName).asInstanceOf[ConnectionFactory]
+    logger.info(s"Got ConnectionFactory $qcf")
+    qcf
+  }
+
+}

--- a/gatling-jms/src/main/scala/io/gatling/jms/protocol/JmsProtocol.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/protocol/JmsProtocol.scala
@@ -15,11 +15,12 @@
  */
 package io.gatling.jms.protocol
 
-import io.gatling.core.CoreComponents
-import io.gatling.core.config.{ GatlingConfiguration, Credentials }
-import io.gatling.core.protocol.{ ProtocolKey, Protocol }
-import io.gatling.jms.action.JmsRequestTrackerActor
+import javax.jms.ConnectionFactory
 
+import io.gatling.core.CoreComponents
+import io.gatling.core.config.{ Credentials, GatlingConfiguration }
+import io.gatling.core.protocol.{ Protocol, ProtocolKey }
+import io.gatling.jms.action.JmsRequestTrackerActor
 import akka.actor.ActorSystem
 
 object JmsProtocol {
@@ -41,15 +42,12 @@ object JmsProtocol {
 }
 
 case class JmsProtocol(
-    contextFactory:        String,
-    connectionFactoryName: String,
-    url:                   String,
-    credentials:           Option[Credentials],
-    anonymousConnect:      Boolean,
-    listenerCount:         Int,
-    deliveryMode:          Int,
-    receiveTimeout:        Option[Long],
-    messageMatcher:        JmsMessageMatcher
+    connectionFactory: ConnectionFactory,
+    credentials:       Option[Credentials],
+    listenerCount:     Int,
+    deliveryMode:      Int,
+    receiveTimeout:    Option[Long],
+    messageMatcher:    JmsMessageMatcher
 ) extends Protocol {
 
   type Components = JmsComponents

--- a/gatling-jms/src/test/scala/io/gatling/jms/JmsCompileTest.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/JmsCompileTest.scala
@@ -18,7 +18,6 @@ package io.gatling.jms
 import javax.jms._
 
 import scala.concurrent.duration.DurationInt
-
 import io.gatling.core.Predef._
 import io.gatling.jms.Predef._
 import io.gatling.jms.protocol.JmsMessageMatcher
@@ -31,11 +30,14 @@ object IdentificationMatcher extends JmsMessageMatcher {
 
 class JmsCompileTest extends Simulation {
 
-  val jmsConfig = jms
+  val cf = jmsJndiConnectionFactory
     .connectionFactoryName("FFMQConstants.JNDI_CONNECTION_FACTORY_NAME")
     .url("tcp://localhost:10002")
     .credentials("user", "secret")
     .contextFactory("FFMQConstants.JNDI_CONTEXT_FACTORY")
+
+  val jmsConfig = jms
+    .connectionFactory(cf)
     .listenerCount(1)
     .usePersistentDeliveryMode
     .receiveTimeout(1000)

--- a/gatling-jms/src/test/scala/io/gatling/jms/client/BrokerBasedSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/client/BrokerBasedSpec.scala
@@ -17,14 +17,13 @@ package io.gatling.jms.client
 
 import io.gatling.jms.protocol.MessageIDMessageMatcher
 import io.gatling.jms.request.JmsDestination
-
 import org.apache.activemq.broker.{ BrokerFactory, BrokerService }
 import org.apache.activemq.jndi.ActiveMQInitialContextFactory
-
 import io.gatling.AkkaSpec
 import io.gatling.jms.protocol.JmsProtocol
-
 import javax.jms.DeliveryMode
+
+import io.gatling.jms.jndi.JmsJndiConnectionFactoryBuilder
 
 trait BrokerBasedSpec extends AkkaSpec {
 
@@ -61,12 +60,15 @@ trait BrokerBasedSpec extends AkkaSpec {
   }
 
   def createClient(destination: JmsDestination) = {
-    val protocol = new JmsProtocol(
+    val jmsJndiConnectionFactoryBuilder = new JmsJndiConnectionFactoryBuilder(
       classOf[ActiveMQInitialContextFactory].getName,
       "ConnectionFactory",
       "vm://gatling?broker.persistent=false&broker.useJmx=false",
+      None
+    )
+    val protocol = new JmsProtocol(
+      jmsJndiConnectionFactoryBuilder.build(),
       None,
-      false,
       1,
       DeliveryMode.PERSISTENT,
       None,

--- a/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsMockingSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsMockingSpec.scala
@@ -56,10 +56,13 @@ class JmsMockCustomer(client: JmsReqReplyClient, mockResponse: PartialFunction[M
 
 trait JmsMockingSpec extends BrokerBasedSpec with JmsDsl {
 
-  def jmsProtocol = jms
+  def cf = jmsJndiConnectionFactory
     .connectionFactoryName("ConnectionFactory")
     .url("vm://gatling?broker.persistent=false&broker.useJmx=false")
     .contextFactory(classOf[ActiveMQInitialContextFactory].getName)
+
+  def jmsProtocol = jms
+    .connectionFactory(cf)
     .listenerCount(1)
 
   def runScenario(sb: ScenarioBuilder, timeout: FiniteDuration = 10.seconds, protocols: Protocols = Protocols(jmsProtocol))(implicit configuration: GatlingConfiguration) = {

--- a/gatling-jms/src/test/scala/io/gatling/jms/protocol/JmsProtocolSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/protocol/JmsProtocolSpec.scala
@@ -15,18 +15,20 @@
  */
 package io.gatling.jms.protocol
 
-import io.gatling.{ ValidationValues, BaseSpec }
+import javax.jms.ConnectionFactory
+
+import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.jms.MockMessage
 import io.gatling.jms.Predef._
 
 class JmsProtocolSpec extends BaseSpec with ValidationValues with MockMessage {
 
+  val cf = mock[ConnectionFactory]
+
   "jms protocol" should "pass defined parameters" in {
 
-    val protocol = jms.connectionFactoryName("cfName").url("url").contextFactory("cf").listenerCount(3).build
-    protocol.connectionFactoryName shouldBe "cfName"
-    protocol.url shouldBe "url"
-    protocol.contextFactory shouldBe "cf"
+    val protocol = jms.connectionFactory(cf).listenerCount(3).build
+    protocol.connectionFactory shouldBe cf
     protocol.listenerCount shouldBe 3
 
   }
@@ -34,9 +36,7 @@ class JmsProtocolSpec extends BaseSpec with ValidationValues with MockMessage {
   it should "pass receiveTimeout" in {
     val protocol =
       jms
-        .connectionFactoryName("cfName")
-        .url("url")
-        .contextFactory("cf")
+        .connectionFactory(cf)
         .listenerCount(3)
         .receiveTimeout(1500)
         .build

--- a/src/sphinx/code/Jms.scala
+++ b/src/sphinx/code/Jms.scala
@@ -27,14 +27,14 @@ import scala.concurrent.duration._
 
 class TestJmsDsl extends Simulation {
 
-  val cf = jmsJndiConnectionFactory
+  val connectionFactory = jmsJndiConnectionFactory
     .connectionFactoryName(FFMQConstants.JNDI_CONNECTION_FACTORY_NAME)
     .url("tcp://localhost:10002")
     .credentials("user", "secret")
     .contextFactory(FFMQConstants.JNDI_CONTEXT_FACTORY)
 
   val jmsConfig = jms
-    .connectionFactory(cf)
+    .connectionFactory(connectionFactory)
     .listenerCount(1)
     .usePersistentDeliveryMode
 

--- a/src/sphinx/code/Jms.scala
+++ b/src/sphinx/code/Jms.scala
@@ -27,11 +27,14 @@ import scala.concurrent.duration._
 
 class TestJmsDsl extends Simulation {
 
-  val jmsConfig = jms
+  val cf = jmsJndiConnectionFactory
     .connectionFactoryName(FFMQConstants.JNDI_CONNECTION_FACTORY_NAME)
     .url("tcp://localhost:10002")
     .credentials("user", "secret")
     .contextFactory(FFMQConstants.JNDI_CONTEXT_FACTORY)
+
+  val jmsConfig = jms
+    .connectionFactory(cf)
     .listenerCount(1)
     .usePersistentDeliveryMode
 

--- a/src/sphinx/jms.rst
+++ b/src/sphinx/jms.rst
@@ -22,11 +22,8 @@ JMS Protocol
 
 Use the ``jms`` object in order to create a JMS protocol.
 
-* ``connectionFactoryName``: mandatory
-* ``url``: mandatory
-* ``contextFactory``: mandatory
-* ``credentials``: optional, for performing JNDI lookup
-* ``disableAnonymousConnect``: optional, by default, connection won't use the above credentials
+* ``connectionFactory``: mandatory, an instance of `ConnectionFactory`. Use `jmsJndiConnectionFactory`_ to obtain one via JNDI lookup or create it by yourself.
+* ``credentials``: optional, to create a JMS connection
 * ``listenerCount``: the number of ReplyConsumers. mandatory (> 0)
 * ``useNonPersistentDeliveryMode`` / ``usePersistentDeliveryMode``: optional, default to non persistent
 * ``matchByMessageID`` / ``matchByCorrelationID`` / ``messageMatcher``: specify how request and response messages should be matched, default to matchByMessageID. Use matchByCorrelationID for ActiveMQ.
@@ -91,6 +88,18 @@ There is ``simpleCheck`` that accepts just ``javax.jms.Message => Boolean`` func
 There is also ``xpath`` check for ``javax.jms.TextMessage`` that carries XML content.
 
 Additionally you can define your custom check that implements ``Check[javax.jms.Message]``
+
+JMS JNDI Connection Factory
+============
+
+Use `jmsJndiConnectionFactory` object to obtain an instance of JMS `ConnectionFactory` via JNDI lookup.
+
+.. _jmsJndiConnectionFactory:
+
+* ``connectionFactoryName``: mandatory
+* ``url``: mandatory
+* ``contextFactory``: mandatory
+* ``credentials``: optional, for performing JNDI lookup
 
 Example
 =======


### PR DESCRIPTION
Scope of the changes

* `jms` now accepts `ConnectionFactory` only
* Existing JNDI functionality has been moved into `jmsJndiConnectionFactory` DSL