### PR TITLE
App: call LoggerContext.stop() at the end of simulation, close #3255

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
@@ -23,7 +23,9 @@ import io.gatling.app.cli.ArgsParser
 import io.gatling.core.config.GatlingConfiguration
 
 import akka.actor.ActorSystem
+import ch.qos.logback.classic.LoggerContext
 import com.typesafe.scalalogging.StrictLogging
+import org.slf4j.LoggerFactory
 
 /**
  * Object containing entry point of application
@@ -53,20 +55,25 @@ object Gatling extends StrictLogging {
     }
 
   private[app] def start(overrides: ConfigOverrides, selectedSimulationClass: SelectedSimulationClass) = {
-    logger.trace("Starting")
-    val configuration = GatlingConfiguration.load(overrides)
-    logger.trace("Configuration loaded")
-    // start actor system before creating simulation instance, some components might need it (e.g. shutdown hook)
-    val system = ActorSystem("GatlingSystem", GatlingConfiguration.loadActorSystemConfiguration())
-    logger.trace("ActorSystem instantiated")
-    val runResult =
-      try {
-        val runner = Runner(system, configuration)
-        logger.trace("Runner instantiated")
-        runner.run(selectedSimulationClass)
-      } finally {
-        terminateActorSystem(system, 5 seconds)
-      }
-    RunResultProcessor(configuration).processRunResult(runResult).code
+    try {
+      logger.trace("Starting")
+      val configuration = GatlingConfiguration.load(overrides)
+      logger.trace("Configuration loaded")
+      // start actor system before creating simulation instance, some components might need it (e.g. shutdown hook)
+      val system = ActorSystem("GatlingSystem", GatlingConfiguration.loadActorSystemConfiguration())
+      logger.trace("ActorSystem instantiated")
+      val runResult =
+        try {
+          val runner = Runner(system, configuration)
+          logger.trace("Runner instantiated")
+          runner.run(selectedSimulationClass)
+        } finally {
+          terminateActorSystem(system, 5 seconds)
+        }
+      RunResultProcessor(configuration).processRunResult(runResult).code
+    } finally {
+      val loggerContext: LoggerContext = LoggerFactory.getILoggerFactory.asInstanceOf
+      loggerContext.stop()
+    }
   }
 }


### PR DESCRIPTION
Fixed to call ``LoggerContext.stop()`` at the end of run.
Statements in ``start(...)`` method are surrounded by try-finally, and log buffer will be flushed even if simulation is stopped with Ctrl-C.
This will work both run in SBT and zipped bundle.