### PR TITLE
removed unnecessary Content-Type default. #3256

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ProtocolDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ProtocolDefinition.scala
@@ -26,7 +26,6 @@ private[scenario] object ProtocolDefinition {
     HeaderNames.AcceptLanguage -> "acceptLanguageHeader",
     HeaderNames.Authorization -> "authorizationHeader",
     HeaderNames.Connection -> "connectionHeader",
-    HeaderNames.ContentType -> "contentTypeHeader",
     HeaderNames.DNT -> "doNotTrackHeader",
     HeaderNames.UserAgent -> "userAgentHeader",
     HeaderNames.UpgradeInsecureRequests -> "upgradeInsecureRequestsHeader"

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
@@ -118,7 +118,8 @@ private[recorder] object ScenarioExporter extends StrictLogging {
                   val isFiltered = filteredHeaders contains headerName
                   val isAlreadyInBaseHeaders = baseHeaders.get(headerName).contains(headerValue)
                   val isPostWithFormParams = element.method == "POST" && headerValue == HeaderValues.ApplicationFormUrlEncoded
-                  isFiltered || isAlreadyInBaseHeaders || isPostWithFormParams
+                  val isGetWithContentType = element.method == "GET" && headerName == HeaderNames.ContentType
+                  isFiltered || isAlreadyInBaseHeaders || isPostWithFormParams || isGetWithContentType
               }
               .sortBy(_._1)
 


### PR DESCRIPTION
removed unecessary ``.contentTypeHeader("")`` and generates header method for each interaction properly.