### PR TITLE
JMS: support custom JNDI properties

### DIFF
--- a/gatling-jms/src/main/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilder.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilder.scala
@@ -19,6 +19,8 @@ import java.util.{ Hashtable => JHashtable }
 import javax.jms.ConnectionFactory
 import javax.naming.{ Context, InitialContext }
 
+import scala.collection.JavaConverters._
+
 import io.gatling.commons.model.Credentials
 
 import com.typesafe.scalalogging.StrictLogging
@@ -37,20 +39,24 @@ case class JmsJndiConnectionFactoryBuilderUrlStep(connectionFactoryName: String)
 case class JmsJndiConnectionFactoryBuilderFactoryStep(
     connectionFactoryName: String,
     url:                   String,
-    credentials:           Option[Credentials] = None
+    credentials:           Option[Credentials] = None,
+    properties:            Map[String, String] = Map.empty
 ) {
 
   def credentials(user: String, password: String) = copy(credentials = Some(Credentials(user, password)))
 
+  def property(key: String, value: String) = copy (properties = properties.updated(key, value))
+
   def contextFactory(cf: String) =
-    JmsJndiConnectionFactoryBuilder(cf, connectionFactoryName, url, credentials)
+    JmsJndiConnectionFactoryBuilder(cf, connectionFactoryName, url, credentials, properties)
 }
 
 case class JmsJndiConnectionFactoryBuilder(
     contextFactory:        String,
     connectionFactoryName: String,
     url:                   String,
-    credentials:           Option[Credentials]
+    credentials:           Option[Credentials],
+    jndiProperties:        Map[String, String]
 ) extends StrictLogging {
 
   def build() = {
@@ -63,6 +69,7 @@ case class JmsJndiConnectionFactoryBuilder(
       properties.put(Context.SECURITY_PRINCIPAL, credentials.username)
       properties.put(Context.SECURITY_CREDENTIALS, credentials.password)
     }
+    properties.putAll(jndiProperties.asJava)
 
     val ctx = new InitialContext(properties)
     logger.info(s"Got InitialContext $ctx")

--- a/gatling-jms/src/test/scala/io/gatling/jms/JmsCompileTest.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/JmsCompileTest.scala
@@ -35,6 +35,7 @@ class JmsCompileTest extends Simulation {
     .connectionFactoryName("FFMQConstants.JNDI_CONNECTION_FACTORY_NAME")
     .url("tcp://localhost:10002")
     .credentials("user", "secret")
+    .property("FFMQConstants.JNDI_ENV_CLIENT_ID", "testclient")
     .contextFactory("FFMQConstants.JNDI_CONTEXT_FACTORY")
 
   // create JmsProtocol from JNDI based ConnectionFactory

--- a/gatling-jms/src/test/scala/io/gatling/jms/jndi/DummyContextFactory.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/jndi/DummyContextFactory.scala
@@ -1,0 +1,24 @@
+package io.gatling.jms.jndi
+
+import java.util
+import javax.jms.{Connection, ConnectionFactory}
+import javax.naming.Context
+import javax.naming.spi.InitialContextFactory
+
+import org.apache.activemq.jndi.ReadOnlyContext
+
+class DummyContextFactory extends InitialContextFactory {
+  override def getInitialContext(environment: util.Hashtable[_, _]): Context = {
+    val bindings = new util.HashMap[String, Object]()
+    bindings.put("DummyConnectionFactory", new DummyConnectionFactory(environment))
+    new ReadOnlyContext(environment, bindings)
+  }
+}
+
+class DummyConnectionFactory(env: util.Hashtable[_, _]) extends ConnectionFactory {
+  val environment: util.Hashtable[_, _] = env
+
+  override def createConnection(): Connection = null
+
+  override def createConnection(userName: String, password: String): Connection = null
+}

--- a/gatling-jms/src/test/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilderSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/jndi/JmsJndiConnectionFactoryBuilderSpec.scala
@@ -1,0 +1,33 @@
+package io.gatling.jms.jndi
+
+import javax.naming.Context
+
+import io.gatling.BaseSpec
+import io.gatling.jms.Predef.jmsJndiConnectionFactory
+
+import scala.collection.JavaConverters.dictionaryAsScalaMapConverter
+
+class JmsJndiConnectionFactoryBuilderSpec extends BaseSpec {
+
+  "jndi connection factory" should "pass all properties to InitialContext" in {
+
+    val jndiCf = jmsJndiConnectionFactory
+      .connectionFactoryName("DummyConnectionFactory")
+      .url("testUrl")
+      .credentials("user", "secret")
+      .property("testProperty", "testValue")
+      .property("extProperty", "extValue")
+      .contextFactory(classOf[DummyContextFactory].getName)
+
+    val factory = jndiCf.build()
+    val contextEnv = factory.asInstanceOf[DummyConnectionFactory].environment.asScala
+    contextEnv should contain allOf(
+      Context.INITIAL_CONTEXT_FACTORY -> classOf[DummyContextFactory].getName,
+      Context.PROVIDER_URL -> "testUrl",
+      Context.SECURITY_PRINCIPAL -> "user",
+      Context.SECURITY_CREDENTIALS -> "secret",
+      "testProperty" -> "testValue",
+      "extProperty" -> "extValue"
+    )
+  }
+}

--- a/src/sphinx/jms.rst
+++ b/src/sphinx/jms.rst
@@ -39,6 +39,7 @@ Use `jmsJndiConnectionFactory` object to obtain an instance of JMS `ConnectionFa
 * ``url``: mandatory
 * ``contextFactory``: mandatory
 * ``credentials``: optional, for performing JNDI lookup
+* ``property``: optional, custom JNDI property
 
 JMS Request API
 ===============


### PR DESCRIPTION
In some cases you could need to specific JNDI properties for JMS, at the moment you need can not do it using builder, you need to create connection factory by yourself.
This PR fix it