### PR TITLE
Core: Fixed denominator of console summary percentage.

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/stats/writer/ConsoleSummary.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/stats/writer/ConsoleSummary.scala
@@ -78,11 +78,12 @@ object ConsoleSummary {
           requestsCounters.map { case (actionName, requestCounters) => writeRequestsCounter(actionName, requestCounters) }.mkFastring(Eol)
 
       def writeErrors: Fastring =
-        if (errorsCounters.nonEmpty)
+        if (errorsCounters.nonEmpty) {
+          val errorsTotal = errorsCounters.values.sum
           fast"""${writeSubTitle("Errors")}
-${errorsCounters.toVector.sortBy(-_._2).map { case (message, count) => ConsoleErrorsWriter.writeError(ErrorStats(message, count, globalRequestCounters.failedCount)) }.mkFastring(Eol)}
+${errorsCounters.toVector.sortBy(-_._2).map { case (message, count) => ConsoleErrorsWriter.writeError(ErrorStats(message, count, errorsTotal)) }.mkFastring(Eol)}
 """
-        else
+        } else
           EmptyFastring
 
     val text = fast"""


### PR DESCRIPTION
Hi, new pull request here :-)

Error percentage seems to be wrong in console summary.

In ``io.gatling.core.stats.write.ConsoleSummary#apply/writeErrors``, numerators are number of errors, but denominator is ``globalRequestCounters.failedCount``.

``failedCount`` counts only KO response, and does not count errors occurring before HTTP interaction.

I think writeErrors should use ``errorCounters.values.sum`` instead of ``globalRequestCounters.failedCount``.

Before-after example here:

Before:
```
================================================================================
2017-03-14 16:26:22                                          11s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=2      KO=8     )
> request_0                                                (OK=2      KO=8     )
---- Errors --------------------------------------------------------------------
> status.find.is(302), but actually found 304                         6 (75.00%)
> Failed to build request request_0: No attribute named 'nokey'       4 (50.00%)
is defined
> status.find.is(301), but actually found 304                         2 (25.00%)

---- RecordedSimulation --------------------------------------------------------
[##########################################################################]100%
          waiting: 0      / active: 0      / done:1
================================================================================
```

After:
```
================================================================================
2017-03-14 16:39:47                                          11s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=2      KO=8     )
> request_0                                                (OK=2      KO=8     )
---- Errors --------------------------------------------------------------------
> status.find.is(302), but actually found 304                         6 (50.00%)
> Failed to build request request_0: No attribute named 'nokey'       4 (33.33%)
is defined
> status.find.is(301), but actually found 304                         2 (16.67%)

---- RecordedSimulation --------------------------------------------------------
[##########################################################################]100%
          waiting: 0      / active: 0      / done:1
================================================================================
```
