### PR TITLE
Prefix http names with method name in reports

### DIFF
--- a/gatling-core/src/main/resources/gatling-defaults.conf
+++ b/gatling-core/src/main/resources/gatling-defaults.conf
@@ -60,6 +60,7 @@ gatling {
     perUserCacheMaxCapacity = 200             # Per virtual user cache size, set to 0 to disable
     warmUpUrl = "http://gatling.io"           # The URL to use to warm-up the HTTP stack (blank means disabled)
     enableGA = true                           # Very light Google Analytics, please support
+    prefixHttpNamesWithMethod = false         # Http request will be formated as : [METHOD_NAME] request name
     ssl {
       keyStore {
         type = ""      # Type of SSLContext's KeyManagers store

--- a/gatling-core/src/main/scala/io/gatling/core/ConfigKeys.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/ConfigKeys.scala
@@ -74,6 +74,7 @@ object ConfigKeys {
     val PerUserCacheMaxCapacity = "gatling.http.perUserCacheMaxCapacity"
     val WarmUpUrl = "gatling.http.warmUpUrl"
     val EnableGA = "gatling.http.enableGA"
+    val PrefixHttpNamesWithMethod = "gatling.http.prefixHttpNamesWithMethod"
 
     object ssl {
       object keyStore {

--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
@@ -155,6 +155,7 @@ object GatlingConfiguration extends StrictLogging {
         perUserCacheMaxCapacity = config.getInt(http.PerUserCacheMaxCapacity),
         warmUpUrl = config.getString(http.WarmUpUrl).trimToOption,
         enableGA = config.getBoolean(http.EnableGA),
+        prefixHttpNamesWithMethod = config.getBoolean(http.PrefixHttpNamesWithMethod),
         ssl = {
             def storeConfig(typeKey: String, fileKey: String, passwordKey: String, algorithmKey: String) = {
 
@@ -319,14 +320,15 @@ case class IndicatorsConfiguration(
 )
 
 case class HttpConfiguration(
-  fetchedCssCacheMaxCapacity:  Long,
-  fetchedHtmlCacheMaxCapacity: Long,
-  perUserCacheMaxCapacity:     Int,
-  warmUpUrl:                   Option[String],
-  enableGA:                    Boolean,
-  ssl:                         SslConfiguration,
-  ahc:                         AhcConfiguration,
-  dns:                         DnsConfiguration
+                              fetchedCssCacheMaxCapacity:  Long,
+                              fetchedHtmlCacheMaxCapacity: Long,
+                              perUserCacheMaxCapacity:     Int,
+                              warmUpUrl:                   Option[String],
+                              enableGA:                    Boolean,
+                              prefixHttpNamesWithMethod:   Boolean,
+                              ssl:                         SslConfiguration,
+                              ahc:                         AhcConfiguration,
+                              dns:                         DnsConfiguration
 )
 
 case class JmsConfiguration(

--- a/gatling-http/src/main/scala/io/gatling/http/request/HttpRequest.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/HttpRequest.scala
@@ -44,8 +44,15 @@ case class HttpRequestDef(
     config:      HttpRequestConfig
 ) {
 
-  def build(requestName: String, session: Session): Validation[HttpRequest] =
-    ahcRequest(session).map(HttpRequest(requestName, _, config))
+  def build(requestName: String, session: Session): Validation[HttpRequest] = {
+    val prefixingEnabled = config.coreComponents.configuration.http.prefixHttpNamesWithMethod
+
+    ahcRequest(session).map(request => {
+      val reqName = if (prefixingEnabled) s"[${request.getMethod.toUpperCase()}] $requestName" else requestName
+      HttpRequest(reqName, request, config)
+    })
+  }
+
 }
 
 case class HttpRequest(requestName: String, ahcRequest: Request, config: HttpRequestConfig)

--- a/gatling-http/src/test/scala/io/gatling/http/action/async/polling/PollerActorSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/action/async/polling/PollerActorSpec.scala
@@ -64,6 +64,7 @@ class PollerActorSpec extends AkkaSpec {
     poller.stateData.asInstanceOf[PollingData] shouldBe PollingData(session, Session.Identity)
   }
 
+  // @ToDo it's not failing when I'll hardcode val prefixingEnabled in HttpRequest:48
   it should "do nothing if the request name could not be resolved and fail the session" in {
     val dataWriterProbe = TestProbe()
     val mockHttpEngine = mock[HttpEngine]
@@ -80,6 +81,7 @@ class PollerActorSpec extends AkkaSpec {
     pollingData.session.isFailed shouldBe true
   }
 
+  // @ToDo it's not failing when I'll hardcode val prefixingEnabled in HttpRequest:48
   it should "do nothing if the request could not be resolved, fail the session and report to the DataWriters" in {
     val dataWriterProbe = TestProbe()
     val mockHttpEngine = mock[HttpEngine]


### PR DESCRIPTION
This automatically adds methods type prefix to http request name. 

`http("list of sth").get() `

will be reported as : [GET] list of sth