### PR TITLE
Recorder: Redirections shoud not be generated as resources

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
@@ -49,7 +49,8 @@ private[recorder] object ScenarioDefinition extends StrictLogging {
 
   private def filterInferredResources(requests: Seq[TimedScenarioElement[RequestElement]]): Seq[TimedScenarioElement[RequestElement]] = {
     val groupChainedRequests = requests.groupByNeighborCondition { (a, b) =>
-      b.sendTime - a.arrivalTime < ConsecutiveResourcesMaxIntervalInMillis
+      b.sendTime - a.arrivalTime < ConsecutiveResourcesMaxIntervalInMillis &&
+      !isRedirection(a)
     }
 
     groupChainedRequests.map {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioDefinition.scala
@@ -48,22 +48,8 @@ private[recorder] object ScenarioDefinition extends StrictLogging {
   }
 
   private def filterInferredResources(requests: Seq[TimedScenarioElement[RequestElement]]): Seq[TimedScenarioElement[RequestElement]] = {
-
-    val groupChainedRequests: List[List[TimedScenarioElement[RequestElement]]] = {
-      var globalAcc = List.empty[List[TimedScenarioElement[RequestElement]]]
-      var currentAcc = List.empty[TimedScenarioElement[RequestElement]]
-      var previousArrivalTime = requests.head.arrivalTime
-      for (request <- requests) {
-        if (request.sendTime - previousArrivalTime < ConsecutiveResourcesMaxIntervalInMillis) {
-          currentAcc = currentAcc ::: List(request)
-        } else {
-          if (currentAcc.nonEmpty)
-            globalAcc = globalAcc ::: List(currentAcc)
-          currentAcc = List(request)
-        }
-        previousArrivalTime = request.arrivalTime
-      }
-      globalAcc ::: List(currentAcc)
+    val groupChainedRequests = requests.groupByNeighborCondition { (a, b) =>
+      b.sendTime - a.arrivalTime < ConsecutiveResourcesMaxIntervalInMillis
     }
 
     groupChainedRequests.map {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/util/collection.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/util/collection.scala
@@ -33,5 +33,13 @@ private[recorder] object collection {
         case (Nil, x)          => List(x) :: Nil
         case (l @ (h :: t), x) => if (p(x)) List(x) :: l else (x :: h) :: t
       }).map(_.reverse).reverse
+
+    def groupByNeighborCondition(p: (T, T) => Boolean): List[List[T]] =
+      elts.foldLeft(List[List[T]]()) {
+        case (Nil, x) => List(x) :: Nil
+        case (l @ (h :: t), x) =>
+          if (h.exists(p(_, x))) (x :: h) :: t
+          else List(x) :: l
+      }.map(_.reverse).reverse
   }
 }


### PR DESCRIPTION
Redirections should not be generated as resources.
(But, It may be necessary to examine other influences.)

HTTP Referer header problem occurs in recorder, both by proxy and from HAR.

Recording in following condition:
* No follow redirects
* Automatic Referers

Redicections are generated as resources:
```scala
	val scn = scenario("RecordedSimulationNoFollowRedirects")
		.exec(http("request_0")
			.get("/top.html"))
		.pause(1)
		.exec(http("request_1")
			.get("/SampleWeb")
			.resources(http("request_2")
			.get("/SampleWeb/"))
			.check(status.is(302)))
		.pause(1)
		.exec(http("request_3")
			.get("/SampleWeb/next.html"))
```

This simulation (auto-referer) produces wrong Referer value:
```
> GET /top.html HTTP/1.1
< HTTP/1.1 200 OK
< <a href="/SampleWeb">SampleWeb</a>
> GET /SampleWeb HTTP/1.1
> Referer: http://hogehoge/top.html
< HTTP/1.1 302 Found
< Location: http://hogehoge/SampleWeb/
> GET /SampleWeb/ HTTP/1.1
> Referer: http://hogehoge/top.html
< HTTP/1.1 200 OK
< <a href="/SampleWeb/next.html">Last</a>
> GET /SampleWeb/next.html HTTP/1.1
> Referer: http://hogehoge/top.html   <<----- WHY???? (should be http://hogehoge/SampleWeb/)
< HTTP/1.1 200 OK
```

This is because redirections and resources do not change Referer session variable.

This change sets are fixes that excludes redirection from resource grouping.
Using this patch, redirections are generated as following:
```scala
	val scn = scenario("RecordedSimulationNoFollowRedirects")
		.exec(http("request_0")
			.get("/top.html"))
		.pause(1)
		.exec(http("request_1")
			.get("/SampleWeb")
			.check(status.is(302)))
		.exec(http("request_2")
			.get("/SampleWeb/"))
		.pause(1)
		.exec(http("request_3")
			.get("/SampleWeb/next.html"))
```

And Referer of ``/SampleWeb/next.html`` is produced correctly.