### PR TITLE
Provide a lazy, batched CSV reader

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/feeder/FeederBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/feeder/FeederBuilder.scala
@@ -15,6 +15,8 @@
  */
 package io.gatling.core.feeder
 
+import java.util.concurrent.locks.ReentrantLock
+
 import io.gatling.core.structure.ScenarioContext
 
 trait FeederBuilder[T] {
@@ -23,6 +25,44 @@ trait FeederBuilder[T] {
 
 case class FeederWrapper[T](feeder: Feeder[T]) extends FeederBuilder[T] {
   def build(ctx: ScenarioContext) = feeder
+}
+
+case class BatchedFeederBuilder[T](
+    records:   Iterator[Record[T]],
+    batchSize: Long,
+    strategy:  FeederStrategy      = Queue
+) extends FeederBuilder[T] {
+
+  override def build(ctx: ScenarioContext): Feeder[T] = {
+      def fetchNextBatch(): Feeder[T] = {
+        val batchRecords = (1L to batchSize).toIterator.zip(records).map {
+          case (_, record) => record
+        }.toIndexedSeq
+        strategy.feeder(batchRecords, ctx)
+      }
+
+    var currentBatch: Feeder[T] = fetchNextBatch()
+
+    var invocations = 1
+    val lock = new ReentrantLock()
+
+    new Feeder[T] {
+      def hasNext: Boolean = {
+        lock.lock()
+        try {
+          if (invocations % batchSize == 0) {
+            currentBatch = fetchNextBatch()
+          }
+          invocations += 1
+        } finally {
+          lock.unlock()
+        }
+
+        currentBatch.hasNext
+      }
+      def next: Record[T] = currentBatch.next()
+    }
+  }
 }
 
 case class RecordSeqFeederBuilder[T](

--- a/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
@@ -30,6 +30,18 @@ trait FeederSupport {
   implicit def array2FeederBuilder[T](data: Array[Map[String, T]]): RecordSeqFeederBuilder[T] = RecordSeqFeederBuilder(data)
   implicit def feeder2FeederBuilder[T](feeder: Feeder[T]): FeederBuilder[T] = FeederWrapper(feeder)
 
+  def csvBatched(fileName: String, batchSize: Long, quoteChar: Char = '"', escapeChar: Char = 0)(implicit configuration: GatlingConfiguration): BatchedFeederBuilder[String] = {
+    val validation = Resource.feeder(fileName)
+    validation match {
+      case Success(res) =>
+        BatchedFeederBuilder(
+          SeparatedValuesParser.stream(res.inputStream, CommaSeparator, quoteChar, escapeChar),
+          batchSize
+        )
+      case Failure(message) => throw new IllegalArgumentException(s"Could not locate feeder file: $message")
+    }
+  }
+
   def csv(fileName: String, quoteChar: Char = '"', escapeChar: Char = 0)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =
     separatedValues(fileName, CommaSeparator, quoteChar, escapeChar)
   def ssv(fileName: String, quoteChar: Char = '"', escapeChar: Char = 0)(implicit configuration: GatlingConfiguration): RecordSeqFeederBuilder[String] =

--- a/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/feeder/FeederSupport.scala
@@ -30,13 +30,14 @@ trait FeederSupport {
   implicit def array2FeederBuilder[T](data: Array[Map[String, T]]): RecordSeqFeederBuilder[T] = RecordSeqFeederBuilder(data)
   implicit def feeder2FeederBuilder[T](feeder: Feeder[T]): FeederBuilder[T] = FeederWrapper(feeder)
 
-  def csvBatched(fileName: String, batchSize: Long, quoteChar: Char = '"', escapeChar: Char = 0)(implicit configuration: GatlingConfiguration): BatchedFeederBuilder[String] = {
+  def csvBatched(fileName: String, batchSize: Long, minUsedItemsPerBatch: Long, quoteChar: Char = '"', escapeChar: Char = 0)(implicit configuration: GatlingConfiguration): BatchedFeederBuilder[String] = {
     val validation = Resource.feeder(fileName)
     validation match {
       case Success(res) =>
         BatchedFeederBuilder(
           SeparatedValuesParser.stream(res.inputStream, CommaSeparator, quoteChar, escapeChar),
-          batchSize
+          batchSize,
+          minUsedItemsPerBatch
         )
       case Failure(message) => throw new IllegalArgumentException(s"Could not locate feeder file: $message")
     }

--- a/gatling-core/src/test/scala/io/gatling/core/feeder/BatchedFeederBuilderSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/feeder/BatchedFeederBuilderSpec.scala
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2011-2017 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.core.feeder
+
+import io.gatling.BaseSpec
+import io.gatling.core.feeder._
+import io.gatling.core.structure.ScenarioContext
+import io.gatling.core.feeder._
+
+class BatchedFeederBuilderSpec extends BaseSpec {
+  "BatchedFeederBuilder" should "support Random strategy" in {
+    val records = (0 to 20).map { i =>
+      Map("id" -> i)
+    }.toIterator
+
+    val ctx = mock[ScenarioContext]
+    val builder = BatchedFeederBuilder(records, 2L, 3L, Random)
+    val feeder = builder.build(ctx)
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(0) or equal(1))
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(0) or equal(1))
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(0) or equal(1))
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(2) or equal(3))
+  }
+
+  "BatchedFeederBuilder" should "support Queue strategy" in {
+    val records = (0 to 20).map { i =>
+      Map("id" -> i)
+    }.toIterator
+
+    val ctx = mock[ScenarioContext]
+    val builder = BatchedFeederBuilder(records, 2L, 3L, Queue)
+    val feeder = builder.build(ctx)
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 0
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 1
+
+    feeder.hasNext shouldBe false
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 2
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 3
+
+    feeder.hasNext shouldBe false
+  }
+
+  "BatchedFeederBuilder" should "support Shuffle strategy" in {
+    val records = (0 to 20).map { i =>
+      Map("id" -> i)
+    }.toIterator
+
+    val ctx = mock[ScenarioContext]
+    val builder = BatchedFeederBuilder(records, 2L, 3L, Shuffle)
+    val feeder = builder.build(ctx)
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(0) or equal(1))
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(0) or equal(1))
+
+    feeder.hasNext shouldBe false
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(2) or equal(3))
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") should (equal(2) or equal(3))
+
+    feeder.hasNext shouldBe false
+  }
+
+  "BatchedFeederBuilder" should "support Circular strategy" in {
+    val records = (0 to 20).map { i =>
+      Map("id" -> i)
+    }.toIterator
+
+    val ctx = mock[ScenarioContext]
+    val builder = BatchedFeederBuilder(records, 2L, 3L, Circular)
+    val feeder = builder.build(ctx)
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 0
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 1
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 0
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 2
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 3
+
+    feeder.hasNext shouldBe true
+    feeder.next()("id") shouldBe 2
+  }
+}


### PR DESCRIPTION
see https://github.com/gatling/gatling/issues/2602

Currently csv files are loaded eagerly which is a problem when the files are very big. This `Feeder` processes portions of the csv file on demand in batches. When creating, you can specify batch size and how often you want to move to the next batch.