### PR TITLE
Replaced manual escaping with Jackson

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
@@ -21,6 +21,8 @@ import scala.collection.JavaConverters._
 
 import com.dongxiguo.fastring.Fastring.Implicits._
 
+import com.fasterxml.jackson.databind.ObjectMapper
+
 object Json {
 
   def stringify(value: Any, isRootObject: Boolean = true): String =
@@ -45,8 +47,9 @@ object Json {
   }
 
   private def writeString(s: String, rootLevel: Boolean) = {
-    val escapedLineFeeds = s.replace("\n", "\\n").replace("\"", "\\\"")
-    if (rootLevel) fast"$escapedLineFeeds" else fast""""$escapedLineFeeds""""
+    val objectMapper = new ObjectMapper
+    val escapedLineFeeds = objectMapper.writeValueAsString(s).replaceAll("^\"|\"$", "")
+    if (rootLevel) fast"$escapedLineFeeds" else fast""""$escapedLineFeeds""""   
   }
 
   private def writeValue(value: Any) = fast"${value.toString}"

--- a/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
@@ -50,7 +50,7 @@ object Json {
 
   private def writeString(s: String, rootLevel: Boolean) = {
     val escapedLineFeeds = objectMapper.writeValueAsString(s).replaceAll("^\"|\"$", "")
-    if (rootLevel) fast"$escapedLineFeeds" else fast""""$escapedLineFeeds""""   
+    if (rootLevel) fast"$escapedLineFeeds" else fast""""$escapedLineFeeds""""
   }
 
   private def writeValue(value: Any) = fast"${value.toString}"

--- a/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
@@ -45,7 +45,7 @@ object Json {
   }
 
   private def writeString(s: String, rootLevel: Boolean) = {
-    val escapedLineFeeds = s.replace("\n", "\\n")
+    val escapedLineFeeds = s.replace("\n", "\\n").replace("\"", "\\\"")
     if (rootLevel) fast"$escapedLineFeeds" else fast""""$escapedLineFeeds""""
   }
 

--- a/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
@@ -27,6 +27,8 @@ object Json {
 
   def stringify(value: Any, isRootObject: Boolean = true): String =
     fastringify(value, isRootObject).toString()
+  
+  private val objectMapper = new ObjectMapper
 
   private def fastringify(value: Any, rootLevel: Boolean): Fastring = value match {
     case b: Byte                   => writeValue(b)
@@ -47,7 +49,6 @@ object Json {
   }
 
   private def writeString(s: String, rootLevel: Boolean) = {
-    val objectMapper = new ObjectMapper
     val escapedLineFeeds = objectMapper.writeValueAsString(s).replaceAll("^\"|\"$", "")
     if (rootLevel) fast"$escapedLineFeeds" else fast""""$escapedLineFeeds""""   
   }

--- a/gatling-core/src/test/scala/io/gatling/core/json/JsonSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/json/JsonSpec.scala
@@ -28,7 +28,7 @@ class JsonSpec extends BaseSpec {
     stringify("Foo") shouldBe "Foo"
   }
   
-  should "be able to stringify double-quoted strings" in {
+  it should "be able to stringify double-quoted strings" in {
     stringify("""Double quoted "Foo"""") shouldBe """Double quoted \"Foo\""""
   }
 

--- a/gatling-core/src/test/scala/io/gatling/core/json/JsonSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/json/JsonSpec.scala
@@ -27,6 +27,10 @@ class JsonSpec extends BaseSpec {
   "JSON.stringify" should "be able to stringify strings" in {
     stringify("Foo") shouldBe "Foo"
   }
+  
+  should "be able to stringify double-quoted strings" in {
+    stringify("""Double quoted "Foo"""") shouldBe """Double quoted \"Foo\""""
+  }
 
   it should "be able to stringify numbers" in {
     stringify(3.toByte) shouldBe "3"
@@ -71,6 +75,10 @@ class JsonSpec extends BaseSpec {
 
   it should "be able to stringify Scala maps" in {
     stringify(Map(1 -> "foo", "bar" -> 4.5, "toto" -> Seq(1, 2))) shouldBe """{"1":"foo","bar":4.5,"toto":[1,2]}"""
+  }
+
+  it should "be able to stringify Scala maps with double quoted string values" in {
+    stringify(Map(1 -> """Double quoted "Foo"""", "bar" -> 4.5, "toto" -> Seq(1, 2))) shouldBe """{"1":"Double quoted \"Foo\"","bar":4.5,"toto":[1,2]}"""
   }
 
   it should "be able to stringify Java maps" in {


### PR DESCRIPTION
1. I have removed the manual escaping of new line
2. Escaping is now done by Jackson (only used for String)
3. ObjectMapper is now created when first used. According to this [article](http://stackoverflow.com/questions/3907929/should-i-declare-jacksons-objectmapper-as-a-static-field) it is thread-safe
4. Jackson adds double quotes to start and end of the stringified String object. These are removed using regex to fit the existing code.