### PR TITLE
Fix feeder shuffle description

### DIFF
--- a/src/sphinx/session/code/Feeders.scala
+++ b/src/sphinx/session/code/Feeders.scala
@@ -37,7 +37,7 @@ class Feeders {
       //#strategies
       .queue    // default behavior: use an Iterator on the underlying sequence
       .random   // randomly pick an entry in the sequence
-      .shuffle  // shuffle entries, then behave live queue
+      .shuffle  // shuffle entries, then behave like queue
       .circular // go back to the top of the sequence once the end is reached
       //#strategies
   }


### PR DESCRIPTION
# Problem 

Feeder shuffle description had a typo:

`shuffle entries, then behave live queue`

# Solution

Change `live` -> `like`