### PR TITLE
Unify the bracket usage

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
@@ -54,7 +54,7 @@ object Gatling extends StrictLogging {
         logger.error("Could not terminate ActorSystem", e)
     }
 
-  private[app] def start(overrides: ConfigOverrides, selectedSimulationClass: SelectedSimulationClass) = {
+  private[app] def start(overrides: ConfigOverrides, selectedSimulationClass: SelectedSimulationClass) =
     try {
       logger.trace("Starting")
       val configuration = GatlingConfiguration.load(overrides)
@@ -74,5 +74,4 @@ object Gatling extends StrictLogging {
     } finally {
       LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext].stop()
     }
-  }
 }


### PR DESCRIPTION
Hi all,

I know I'm a bit of a formatting purist, but I would like to strip the brackets to get to a single unified way of formatting. The brackets at the `start` function are redundant.

Cheers, Fokko