### PR TITLE
normal builder for GatlingPropertiesBuilder

### DIFF
--- a/gatling-charts/src/test/scala/io/gatling/charts/result/reader/LogFileReaderSpec.scala
+++ b/gatling-charts/src/test/scala/io/gatling/charts/result/reader/LogFileReaderSpec.scala
@@ -16,7 +16,6 @@
 package io.gatling.charts.result.reader
 
 import scala.collection.mutable
-
 import io.gatling.BaseSpec
 import io.gatling.charts.stats.LogFileReader
 import io.gatling.core.ConfigKeys._
@@ -24,10 +23,8 @@ import io.gatling.core.config.{ GatlingConfiguration, GatlingPropertiesBuilder }
 
 class LogFileReaderSpec extends BaseSpec {
 
-  val props = new GatlingPropertiesBuilder
-  props.resultsDirectory("src/test/resources")
-
-  implicit val configuration = GatlingConfiguration.loadForTest(props.build)
+  private implicit val configuration =
+    GatlingConfiguration.loadForTest(new GatlingPropertiesBuilder().resultsDirectory("src/test/resources").build)
 
   // FIXME re-enable with fresh and SIMPLE samples
   //	"When reading a single log file, LogFileReader" should {

--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingPropertiesBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingPropertiesBuilder.scala
@@ -23,35 +23,55 @@ class GatlingPropertiesBuilder {
 
   private val props = mutable.Map.empty[String, Any]
 
-  def noReports(): Unit =
+  def noReports(): GatlingPropertiesBuilder = {
     props += charting.NoReports -> true
+    this
+  }
 
-  def reportsOnly(v: String): Unit =
+  def reportsOnly(v: String): GatlingPropertiesBuilder = {
     props += core.directory.ReportsOnly -> v
+    this
+  }
 
-  def dataDirectory(v: String): Unit =
+  def dataDirectory(v: String): GatlingPropertiesBuilder = {
     props += core.directory.Data -> v
+    this
+  }
 
-  def resultsDirectory(v: String): Unit =
+  def resultsDirectory(v: String): GatlingPropertiesBuilder = {
     props += core.directory.Results -> v
+    this
+  }
 
-  def bodiesDirectory(v: String): Unit =
+  def bodiesDirectory(v: String): GatlingPropertiesBuilder = {
     props += core.directory.Bodies -> v
+    this
+  }
 
-  def sourcesDirectory(v: String): Unit =
+  def sourcesDirectory(v: String): GatlingPropertiesBuilder = {
     props += core.directory.Simulations -> v
+    this
+  }
 
-  def binariesDirectory(v: String): Unit =
+  def binariesDirectory(v: String): GatlingPropertiesBuilder = {
     props += core.directory.Binaries -> v
+    this
+  }
 
-  def simulationClass(v: String): Unit =
+  def simulationClass(v: String): GatlingPropertiesBuilder = {
     props += core.SimulationClass -> v
+    this
+  }
 
-  def outputDirectoryBaseName(v: String): Unit =
+  def outputDirectoryBaseName(v: String): GatlingPropertiesBuilder = {
     props += core.OutputDirectoryBaseName -> v
+    this
+  }
 
-  def runDescription(v: String): Unit =
+  def runDescription(v: String): GatlingPropertiesBuilder = {
     props += core.RunDescription -> v
+    this
+  }
 
   def build: mutable.Map[String, Any] = props
 }


### PR DESCRIPTION
After fromArgs became private the only way to run simulation programmatically is to use GatlingPropertiesBuilder. So it'd be better to make it real builder to provide fluent API