### PR TITLE
Added the clause to hide HTTP engine warm up exceptions from log level higher than debug, close gatling/gatling#3331

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/Selection.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Selection.scala
@@ -62,21 +62,21 @@ object Selection {
 
     private def singleSimulationFromConfig(simulationClasses: SimulationClasses, userDefinedSimulationClass: Option[String]): SelectedSimulationClass = {
 
-        def findUserDefinedSimulationAmongstCompiledOnes(className: String): SelectedSimulationClass =
-          simulationClasses.find(_.getCanonicalName == className)
+      def findUserDefinedSimulationAmongstCompiledOnes(className: String): SelectedSimulationClass =
+        simulationClasses.find(_.getCanonicalName == className)
 
-        def findUserDefinedSimulationInClassloader(className: String): SelectedSimulationClass =
-          Try(Class.forName(className)) match {
-            case Success(clazz) =>
-              if (classOf[Simulation].isAssignableFrom(clazz)) {
-                Some(clazz.asInstanceOf[Class[Simulation]])
-              } else {
-                throw new IllegalArgumentException(s"User defined Simulation class $className does not extend of Simulation")
-              }
+      def findUserDefinedSimulationInClassloader(className: String): SelectedSimulationClass =
+        Try(Class.forName(className)) match {
+          case Success(clazz) =>
+            if (classOf[Simulation].isAssignableFrom(clazz)) {
+              Some(clazz.asInstanceOf[Class[Simulation]])
+            } else {
+              throw new IllegalArgumentException(s"User defined Simulation class $className does not extend of Simulation")
+            }
 
-            case Failure(t) =>
-              throw new IllegalArgumentException(s"User defined Simulation class $className could not be loaded", t)
-          }
+          case Failure(t) =>
+            throw new IllegalArgumentException(s"User defined Simulation class $className could not be loaded", t)
+        }
 
       userDefinedSimulationClass.flatMap { userDefinedSimulationClassName =>
         findUserDefinedSimulationAmongstCompiledOnes(userDefinedSimulationClassName)
@@ -95,30 +95,30 @@ object Selection {
     private def interactiveSelect(simulationClasses: SimulationClasses): Class[Simulation] = {
       val validRange = simulationClasses.indices
 
-        @tailrec
-        def readSimulationNumber(attempts: Int = 0): Int = {
-          if (attempts > MaxReadSimulationNumberAttempts) {
-            println(s"Max attempts of reading simulation number ($MaxReadSimulationNumberAttempts) reached. Aborting.")
-            sys.exit()
-          } else {
-            println("Choose a simulation number:")
-            for ((simulation, index) <- simulationClasses.zipWithIndex) {
-              println(s"     [$index] ${simulation.getName}")
-            }
+      @tailrec
+      def readSimulationNumber(attempts: Int = 0): Int = {
+        if (attempts > MaxReadSimulationNumberAttempts) {
+          println(s"Max attempts of reading simulation number ($MaxReadSimulationNumberAttempts) reached. Aborting.")
+          sys.exit()
+        } else {
+          println("Choose a simulation number:")
+          for ((simulation, index) <- simulationClasses.zipWithIndex) {
+            println(s"     [$index] ${simulation.getName}")
+          }
 
-            Try(StdIn.readInt()) match {
-              case Success(number) =>
-                if (validRange contains number) number
-                else {
-                  println(s"Invalid selection, must be in $validRange")
-                  readSimulationNumber(attempts + 1)
-                }
-              case _ =>
-                println("Invalid characters, please provide a correct simulation number:")
+          Try(StdIn.readInt()) match {
+            case Success(number) =>
+              if (validRange contains number) number
+              else {
+                println(s"Invalid selection, must be in $validRange")
                 readSimulationNumber(attempts + 1)
-            }
+              }
+            case _ =>
+              println("Invalid characters, please provide a correct simulation number:")
+              readSimulationNumber(attempts + 1)
           }
         }
+      }
 
       if (simulationClasses.isEmpty) {
         println("There is no simulation script. Please check that your scripts are in user-files/simulations")

--- a/gatling-app/src/main/scala/io/gatling/app/classloader/FileSystemBackedClassLoader.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/classloader/FileSystemBackedClassLoader.scala
@@ -26,7 +26,7 @@ import io.gatling.commons.util.Io._
 import io.gatling.commons.util.PathHelper._
 
 private[classloader] class FileSystemBackedClassLoader(root: Path, parent: ClassLoader)
-    extends ClassLoader(parent) {
+  extends ClassLoader(parent) {
 
   def classNameToPath(name: String): Path =
     if (name endsWith ".class") name

--- a/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTableComponent.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTableComponent.scala
@@ -31,7 +31,7 @@ private[charts] class StatisticsTableComponent(implicit configuration: GatlingCo
 
   val html = {
 
-      def pctTitle(pct: Double) = pct.toRank + " pct"
+    def pctTitle(pct: Double) = pct.toRank + " pct"
 
     val pct1 = pctTitle(configuration.charting.indicators.percentile1)
     val pct2 = pctTitle(configuration.charting.indicators.percentile2)

--- a/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTextComponent.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTextComponent.scala
@@ -40,19 +40,19 @@ private[charts] case class GroupedCount(name: String, count: Long, total: Long) 
 }
 
 private[charts] case class RequestStatistics(
-  name:                                    String,
-  path:                                    String,
-  numberOfRequestsStatistics:              Statistics[Long],
-  minResponseTimeStatistics:               Statistics[Int],
-  maxResponseTimeStatistics:               Statistics[Int],
-  meanStatistics:                          Statistics[Int],
-  stdDeviationStatistics:                  Statistics[Int],
-  percentiles1:                            Statistics[Int],
-  percentiles2:                            Statistics[Int],
-  percentiles3:                            Statistics[Int],
-  percentiles4:                            Statistics[Int],
-  groupedCounts:                           Seq[GroupedCount],
-  meanNumberOfRequestsPerSecondStatistics: Statistics[Double]
+    name:                                    String,
+    path:                                    String,
+    numberOfRequestsStatistics:              Statistics[Long],
+    minResponseTimeStatistics:               Statistics[Int],
+    maxResponseTimeStatistics:               Statistics[Int],
+    meanStatistics:                          Statistics[Int],
+    stdDeviationStatistics:                  Statistics[Int],
+    percentiles1:                            Statistics[Int],
+    percentiles2:                            Statistics[Int],
+    percentiles3:                            Statistics[Int],
+    percentiles4:                            Statistics[Int],
+    groupedCounts:                           Seq[GroupedCount],
+    meanNumberOfRequestsPerSecondStatistics: Statistics[Double]
 )
 
 private[charts] class StatisticsTextComponent(implicit configuration: GatlingConfiguration) extends Component {

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/AllSessionsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/AllSessionsReportGenerator.scala
@@ -22,7 +22,7 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.stats.{ IntVsTimePlot, Series }
 
 private[charts] class AllSessionsReportGenerator(reportsGenerationInputs: ReportsGenerationInputs, componentLibrary: ComponentLibrary)(implicit configuration: GatlingConfiguration)
-    extends ReportGenerator {
+  extends ReportGenerator {
 
   def generate(): Unit = {
     import reportsGenerationInputs._

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/Container.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/Container.scala
@@ -43,11 +43,11 @@ private[charts] case class GroupContainer(
 
   private def findGroup(path: List[String]) = {
 
-      @tailrec
-      def getGroupRec(g: GroupContainer, path: List[String]): GroupContainer = path match {
-        case head :: tail => getGroupRec(g.groups(head), tail)
-        case _            => g
-      }
+    @tailrec
+    def getGroupRec(g: GroupContainer, path: List[String]): GroupContainer = path match {
+      case head :: tail => getGroupRec(g.groups(head), tail)
+      case _            => g
+    }
 
     getGroupRec(this, path)
   }

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/GroupDetailsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/GroupDetailsReportGenerator.scala
@@ -25,59 +25,59 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.stats.{ PercentilesVsTimePlot, Series }
 
 private[charts] class GroupDetailsReportGenerator(reportsGenerationInputs: ReportsGenerationInputs, componentLibrary: ComponentLibrary)(implicit configuration: GatlingConfiguration)
-    extends ReportGenerator {
+  extends ReportGenerator {
 
   def generate(): Unit = {
     import reportsGenerationInputs._
 
-      def generateDetailPage(path: String, group: Group): Unit = {
-          def cumulatedResponseTimeChartComponent: Component = {
-            val dataSuccess = logFileReader.groupCumulatedResponseTimePercentilesOverTime(OK, group)
-            val seriesSuccess = new Series[PercentilesVsTimePlot]("Group Cumulated Response Time Percentiles over Time (success)", dataSuccess, ReportGenerator.PercentilesColors)
+    def generateDetailPage(path: String, group: Group): Unit = {
+      def cumulatedResponseTimeChartComponent: Component = {
+        val dataSuccess = logFileReader.groupCumulatedResponseTimePercentilesOverTime(OK, group)
+        val seriesSuccess = new Series[PercentilesVsTimePlot]("Group Cumulated Response Time Percentiles over Time (success)", dataSuccess, ReportGenerator.PercentilesColors)
 
-            componentLibrary.getGroupDetailsDurationChartComponent("cumulatedResponseTimeChartContainer", "Cumulated Response Time (ms)", logFileReader.runStart, seriesSuccess)
-          }
-
-          def cumulatedResponseTimeDistributionChartComponent: Component = {
-            val (distributionSuccess, distributionFailure) = logFileReader.groupCumulatedResponseTimeDistribution(100, group)
-            val distributionSeriesSuccess = new Series("Group cumulated response time (success)", distributionSuccess, List(Blue))
-            val distributionSeriesFailure = new Series("Group cumulated response time (failure)", distributionFailure, List(Red))
-
-            componentLibrary.getGroupDetailsDurationDistributionChartComponent("Group Cumulated Response Time Distribution", "cumulatedResponseTimeDistributionContainer", distributionSeriesSuccess, distributionSeriesFailure)
-          }
-
-          def durationChartComponent: Component = {
-            val dataSuccess = logFileReader.groupDurationPercentilesOverTime(OK, group)
-            val seriesSuccess = new Series[PercentilesVsTimePlot]("Group Duration Percentiles over Time (success)", dataSuccess, ReportGenerator.PercentilesColors)
-
-            componentLibrary.getGroupDetailsDurationChartComponent("durationContainer", "Duration (ms)", logFileReader.runStart, seriesSuccess)
-          }
-
-          def durationDistributionChartComponent: Component = {
-            val (distributionSuccess, distributionFailure) = logFileReader.groupDurationDistribution(100, group)
-            val distributionSeriesSuccess = new Series("Group duration (success)", distributionSuccess, List(Blue))
-            val distributionSeriesFailure = new Series("Group duration (failure)", distributionFailure, List(Red))
-
-            componentLibrary.getGroupDetailsDurationDistributionChartComponent("Group Duration Distribution", "durationDistributionContainer", distributionSeriesSuccess, distributionSeriesFailure)
-          }
-
-          def statisticsComponent: Component = new StatisticsTextComponent
-
-          def indicatorChartComponent: Component = componentLibrary.getRequestDetailsIndicatorChartComponent
-
-        val template = new GroupDetailsPageTemplate(
-          group,
-          statisticsComponent,
-          indicatorChartComponent,
-          new ErrorsTableComponent(logFileReader.errors(None, Some(group))),
-          cumulatedResponseTimeChartComponent,
-          cumulatedResponseTimeDistributionChartComponent,
-          durationChartComponent,
-          durationDistributionChartComponent
-        )
-
-        new TemplateWriter(groupFile(reportFolderName, path)).writeToFile(template.getOutput(configuration.core.charset))
+        componentLibrary.getGroupDetailsDurationChartComponent("cumulatedResponseTimeChartContainer", "Cumulated Response Time (ms)", logFileReader.runStart, seriesSuccess)
       }
+
+      def cumulatedResponseTimeDistributionChartComponent: Component = {
+        val (distributionSuccess, distributionFailure) = logFileReader.groupCumulatedResponseTimeDistribution(100, group)
+        val distributionSeriesSuccess = new Series("Group cumulated response time (success)", distributionSuccess, List(Blue))
+        val distributionSeriesFailure = new Series("Group cumulated response time (failure)", distributionFailure, List(Red))
+
+        componentLibrary.getGroupDetailsDurationDistributionChartComponent("Group Cumulated Response Time Distribution", "cumulatedResponseTimeDistributionContainer", distributionSeriesSuccess, distributionSeriesFailure)
+      }
+
+      def durationChartComponent: Component = {
+        val dataSuccess = logFileReader.groupDurationPercentilesOverTime(OK, group)
+        val seriesSuccess = new Series[PercentilesVsTimePlot]("Group Duration Percentiles over Time (success)", dataSuccess, ReportGenerator.PercentilesColors)
+
+        componentLibrary.getGroupDetailsDurationChartComponent("durationContainer", "Duration (ms)", logFileReader.runStart, seriesSuccess)
+      }
+
+      def durationDistributionChartComponent: Component = {
+        val (distributionSuccess, distributionFailure) = logFileReader.groupDurationDistribution(100, group)
+        val distributionSeriesSuccess = new Series("Group duration (success)", distributionSuccess, List(Blue))
+        val distributionSeriesFailure = new Series("Group duration (failure)", distributionFailure, List(Red))
+
+        componentLibrary.getGroupDetailsDurationDistributionChartComponent("Group Duration Distribution", "durationDistributionContainer", distributionSeriesSuccess, distributionSeriesFailure)
+      }
+
+      def statisticsComponent: Component = new StatisticsTextComponent
+
+      def indicatorChartComponent: Component = componentLibrary.getRequestDetailsIndicatorChartComponent
+
+      val template = new GroupDetailsPageTemplate(
+        group,
+        statisticsComponent,
+        indicatorChartComponent,
+        new ErrorsTableComponent(logFileReader.errors(None, Some(group))),
+        cumulatedResponseTimeChartComponent,
+        cumulatedResponseTimeDistributionChartComponent,
+        durationChartComponent,
+        durationDistributionChartComponent
+      )
+
+      new TemplateWriter(groupFile(reportFolderName, path)).writeToFile(template.getOutput(configuration.core.charset))
+    }
 
     logFileReader.statsPaths.foreach {
       case GroupStatsPath(group) => generateDetailPage(RequestPath.path(group), group)

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/ReportsGenerationInputs.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/ReportsGenerationInputs.scala
@@ -19,7 +19,7 @@ import io.gatling.charts.stats.LogFileReader
 import io.gatling.commons.stats.assertion.AssertionResult
 
 private[gatling] case class ReportsGenerationInputs(
-  reportFolderName: String,
-  logFileReader:    LogFileReader,
-  assertionResults: List[AssertionResult]
+    reportFolderName: String,
+    logFileReader:    LogFileReader,
+    assertionResults: List[AssertionResult]
 )

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/ReportsGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/ReportsGenerator.scala
@@ -30,19 +30,19 @@ private[gatling] class ReportsGenerator(implicit configuration: GatlingConfigura
   def generateFor(reportsGenerationInputs: ReportsGenerationInputs): Path = {
     import reportsGenerationInputs._
 
-      def hasAtLeastOneRequestReported: Boolean =
-        logFileReader.statsPaths.exists(_.isInstanceOf[RequestStatsPath])
+    def hasAtLeastOneRequestReported: Boolean =
+      logFileReader.statsPaths.exists(_.isInstanceOf[RequestStatsPath])
 
-      def generateMenu(): Unit = new TemplateWriter(menuFile(reportFolderName)).writeToFile(new MenuTemplate().getOutput)
+    def generateMenu(): Unit = new TemplateWriter(menuFile(reportFolderName)).writeToFile(new MenuTemplate().getOutput)
 
-      def generateStats(): Unit = new StatsReportGenerator(reportsGenerationInputs, ComponentLibrary.Instance).generate()
+    def generateStats(): Unit = new StatsReportGenerator(reportsGenerationInputs, ComponentLibrary.Instance).generate()
 
-      def generateAssertions(): Unit = new AssertionsReportGenerator(reportsGenerationInputs, ComponentLibrary.Instance).generate()
+    def generateAssertions(): Unit = new AssertionsReportGenerator(reportsGenerationInputs, ComponentLibrary.Instance).generate()
 
-      def copyAssets(): Unit = {
-        deepCopyPackageContent(GatlingAssetsStylePackage, styleDirectory(reportFolderName))
-        deepCopyPackageContent(GatlingAssetsJsPackage, jsDirectory(reportFolderName))
-      }
+    def copyAssets(): Unit = {
+      deepCopyPackageContent(GatlingAssetsStylePackage, styleDirectory(reportFolderName))
+      deepCopyPackageContent(GatlingAssetsJsPackage, jsDirectory(reportFolderName))
+    }
 
     if (!hasAtLeastOneRequestReported)
       throw new UnsupportedOperationException("There were no requests sent during the simulation, reports won't be generated")

--- a/gatling-charts/src/main/scala/io/gatling/charts/report/RequestDetailsReportGenerator.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/report/RequestDetailsReportGenerator.scala
@@ -25,85 +25,85 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.stats._
 
 private[charts] class RequestDetailsReportGenerator(reportsGenerationInputs: ReportsGenerationInputs, componentLibrary: ComponentLibrary)(implicit configuration: GatlingConfiguration)
-    extends ReportGenerator {
+  extends ReportGenerator {
 
   def generate(): Unit = {
     import reportsGenerationInputs._
 
-      def generateDetailPage(path: String, requestName: String, group: Option[Group]): Unit = {
+    def generateDetailPage(path: String, requestName: String, group: Option[Group]): Unit = {
 
-          def responseTimeDistributionChartComponent: Component = {
-            val (okDistribution, koDistribution) = logFileReader.responseTimeDistribution(100, Some(requestName), group)
-            val okDistributionSeries = new Series(Series.OK, okDistribution, List(Blue))
-            val koDistributionSeries = new Series(Series.KO, koDistribution, List(Red))
+      def responseTimeDistributionChartComponent: Component = {
+        val (okDistribution, koDistribution) = logFileReader.responseTimeDistribution(100, Some(requestName), group)
+        val okDistributionSeries = new Series(Series.OK, okDistribution, List(Blue))
+        val koDistributionSeries = new Series(Series.KO, koDistribution, List(Red))
 
-            componentLibrary.getRequestDetailsResponseTimeDistributionChartComponent(okDistributionSeries, koDistributionSeries)
-          }
-
-          def responseTimeChartComponent: Component =
-            percentilesChartComponent(logFileReader.responseTimePercentilesOverTime, componentLibrary.getRequestDetailsResponseTimeChartComponent, "Response Time Percentiles over Time")
-
-          def percentilesChartComponent(
-            dataSource:       (Status, Option[String], Option[Group]) => Iterable[PercentilesVsTimePlot],
-            componentFactory: (Long, Series[PercentilesVsTimePlot]) => Component,
-            title:            String
-          ): Component = {
-            val successData = dataSource(OK, Some(requestName), group)
-            val successSeries = new Series[PercentilesVsTimePlot](s"$title (${Series.OK})", successData, ReportGenerator.PercentilesColors)
-
-            componentFactory(logFileReader.runStart, successSeries)
-          }
-
-          def requestsChartComponent: Component =
-            countsChartComponent(logFileReader.numberOfRequestsPerSecond, componentLibrary.getRequestsChartComponent)
-
-          def responsesChartComponent: Component =
-            countsChartComponent(logFileReader.numberOfResponsesPerSecond, componentLibrary.getResponsesChartComponent)
-
-          def countsChartComponent(
-            dataSource:       (Option[String], Option[Group]) => Seq[CountsVsTimePlot],
-            componentFactory: (Long, Series[CountsVsTimePlot], Series[PieSlice]) => Component
-          ): Component = {
-
-            val counts = dataSource(Some(requestName), group).sortBy(_.time)
-
-            val countsSeries = new Series[CountsVsTimePlot]("", counts, List(Blue, Red, Green))
-            val okPieSlice = PieSlice(Series.OK, count(counts, OK))
-            val koPieSlice = PieSlice(Series.KO, count(counts, KO))
-            val pieRequestsSeries = new Series[PieSlice](Series.Distribution, Seq(okPieSlice, koPieSlice), List(Green, Red))
-
-            componentFactory(logFileReader.runStart, countsSeries, pieRequestsSeries)
-          }
-
-          def responseTimeScatterChartComponent: Component =
-            scatterChartComponent(logFileReader.responseTimeAgainstGlobalNumberOfRequestsPerSec, componentLibrary.getRequestDetailsResponseTimeScatterChartComponent)
-
-          def scatterChartComponent(
-            dataSource:       (Status, String, Option[Group]) => Seq[IntVsTimePlot],
-            componentFactory: (Series[IntVsTimePlot], Series[IntVsTimePlot]) => Component
-          ): Component = {
-
-            val scatterPlotSuccessData = dataSource(OK, requestName, group)
-            val scatterPlotFailuresData = dataSource(KO, requestName, group)
-            val scatterPlotSuccessSeries = new Series[IntVsTimePlot](Series.OK, scatterPlotSuccessData, List(TranslucidBlue))
-            val scatterPlotFailuresSeries = new Series[IntVsTimePlot](Series.KO, scatterPlotFailuresData, List(TranslucidRed))
-
-            componentFactory(scatterPlotSuccessSeries, scatterPlotFailuresSeries)
-          }
-
-        val template =
-          new RequestDetailsPageTemplate(path, requestName, group,
-            new StatisticsTextComponent,
-            componentLibrary.getRequestDetailsIndicatorChartComponent,
-            new ErrorsTableComponent(logFileReader.errors(Some(requestName), group)),
-            responseTimeDistributionChartComponent,
-            responseTimeChartComponent,
-            requestsChartComponent,
-            responsesChartComponent,
-            responseTimeScatterChartComponent)
-
-        new TemplateWriter(requestFile(reportFolderName, path)).writeToFile(template.getOutput(configuration.core.charset))
+        componentLibrary.getRequestDetailsResponseTimeDistributionChartComponent(okDistributionSeries, koDistributionSeries)
       }
+
+      def responseTimeChartComponent: Component =
+        percentilesChartComponent(logFileReader.responseTimePercentilesOverTime, componentLibrary.getRequestDetailsResponseTimeChartComponent, "Response Time Percentiles over Time")
+
+      def percentilesChartComponent(
+        dataSource:       (Status, Option[String], Option[Group]) => Iterable[PercentilesVsTimePlot],
+        componentFactory: (Long, Series[PercentilesVsTimePlot]) => Component,
+        title:            String
+      ): Component = {
+        val successData = dataSource(OK, Some(requestName), group)
+        val successSeries = new Series[PercentilesVsTimePlot](s"$title (${Series.OK})", successData, ReportGenerator.PercentilesColors)
+
+        componentFactory(logFileReader.runStart, successSeries)
+      }
+
+      def requestsChartComponent: Component =
+        countsChartComponent(logFileReader.numberOfRequestsPerSecond, componentLibrary.getRequestsChartComponent)
+
+      def responsesChartComponent: Component =
+        countsChartComponent(logFileReader.numberOfResponsesPerSecond, componentLibrary.getResponsesChartComponent)
+
+      def countsChartComponent(
+        dataSource:       (Option[String], Option[Group]) => Seq[CountsVsTimePlot],
+        componentFactory: (Long, Series[CountsVsTimePlot], Series[PieSlice]) => Component
+      ): Component = {
+
+        val counts = dataSource(Some(requestName), group).sortBy(_.time)
+
+        val countsSeries = new Series[CountsVsTimePlot]("", counts, List(Blue, Red, Green))
+        val okPieSlice = PieSlice(Series.OK, count(counts, OK))
+        val koPieSlice = PieSlice(Series.KO, count(counts, KO))
+        val pieRequestsSeries = new Series[PieSlice](Series.Distribution, Seq(okPieSlice, koPieSlice), List(Green, Red))
+
+        componentFactory(logFileReader.runStart, countsSeries, pieRequestsSeries)
+      }
+
+      def responseTimeScatterChartComponent: Component =
+        scatterChartComponent(logFileReader.responseTimeAgainstGlobalNumberOfRequestsPerSec, componentLibrary.getRequestDetailsResponseTimeScatterChartComponent)
+
+      def scatterChartComponent(
+        dataSource:       (Status, String, Option[Group]) => Seq[IntVsTimePlot],
+        componentFactory: (Series[IntVsTimePlot], Series[IntVsTimePlot]) => Component
+      ): Component = {
+
+        val scatterPlotSuccessData = dataSource(OK, requestName, group)
+        val scatterPlotFailuresData = dataSource(KO, requestName, group)
+        val scatterPlotSuccessSeries = new Series[IntVsTimePlot](Series.OK, scatterPlotSuccessData, List(TranslucidBlue))
+        val scatterPlotFailuresSeries = new Series[IntVsTimePlot](Series.KO, scatterPlotFailuresData, List(TranslucidRed))
+
+        componentFactory(scatterPlotSuccessSeries, scatterPlotFailuresSeries)
+      }
+
+      val template =
+        new RequestDetailsPageTemplate(path, requestName, group,
+          new StatisticsTextComponent,
+          componentLibrary.getRequestDetailsIndicatorChartComponent,
+          new ErrorsTableComponent(logFileReader.errors(Some(requestName), group)),
+          responseTimeDistributionChartComponent,
+          responseTimeChartComponent,
+          requestsChartComponent,
+          responsesChartComponent,
+          responseTimeScatterChartComponent)
+
+      new TemplateWriter(requestFile(reportFolderName, path)).writeToFile(template.getOutput(configuration.core.charset))
+    }
 
     logFileReader.statsPaths.foreach {
       case RequestStatsPath(request, group) => generateDetailPage(RequestPath.path(request, group), request, group)

--- a/gatling-charts/src/main/scala/io/gatling/charts/stats/LogFileReader.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/stats/LogFileReader.scala
@@ -55,8 +55,8 @@ class LogFileReader(runUuid: String)(implicit configuration: GatlingConfiguratio
 
   private def parseInputFiles[T](f: Iterator[String] => T): T = {
 
-      def multipleFileIterator(streams: Seq[InputStream]): Iterator[String] =
-        streams.map(Source.fromInputStream(_)(configuration.core.codec).getLines()).reduce((first, second) => first ++ second)
+    def multipleFileIterator(streams: Seq[InputStream]): Iterator[String] =
+      streams.map(Source.fromInputStream(_)(configuration.core.codec).getLines()).reduce((first, second) => first ++ second)
 
     val streams = inputFiles.map(_.inputStream)
     try f(multipleFileIterator(streams))
@@ -74,10 +74,10 @@ class LogFileReader(runUuid: String)(implicit configuration: GatlingConfiguratio
     var runStart = Long.MaxValue
     var runEnd = Long.MinValue
 
-      def updateRunLimits(eventStart: Long, eventEnd: Long): Unit = {
-        runStart = math.min(runStart, eventStart)
-        runEnd = math.max(runEnd, eventEnd)
-      }
+    def updateRunLimits(eventStart: Long, eventEnd: Long): Unit = {
+      runStart = math.min(runStart, eventStart)
+      runEnd = math.max(runEnd, eventEnd)
+    }
 
     val runMessages = mutable.ListBuffer.empty[RunMessage]
     val assertions = mutable.LinkedHashSet.empty[Assertion]
@@ -207,11 +207,11 @@ class LogFileReader(runUuid: String)(implicit configuration: GatlingConfiguratio
     val min = allBuffer.stats.min
     val max = allBuffer.stats.max
 
-      def percent(s: Int) = s * 100.0 / size
+    def percent(s: Int) = s * 100.0 / size
 
     if (max - min <= maxPlots) {
-        // use exact values
-        def plotsToPercents(plots: Iterable[IntVsTimePlot]) = plots.map(plot => PercentVsTimePlot(plot.time, percent(plot.value))).toSeq.sortBy(_.time)
+      // use exact values
+      def plotsToPercents(plots: Iterable[IntVsTimePlot]) = plots.map(plot => PercentVsTimePlot(plot.time, percent(plot.value))).toSeq.sortBy(_.time)
       (plotsToPercents(ok), plotsToPercents(ko))
 
     } else {
@@ -225,25 +225,25 @@ class LogFileReader(runUuid: String)(implicit configuration: GatlingConfiguratio
         (value - (value - min) % step + halfStep).round.toInt
       }
 
-        def process(buffer: Iterable[IntVsTimePlot]): Seq[PercentVsTimePlot] = {
+      def process(buffer: Iterable[IntVsTimePlot]): Seq[PercentVsTimePlot] = {
 
-          val bucketsWithValues: Map[Int, Double] = buffer
-            .map(record => (bucketFunction(record.time), record))
-            .groupBy(_._1)
-            .map {
-              case (responseTimeBucket, recordList) =>
+        val bucketsWithValues: Map[Int, Double] = buffer
+          .map(record => (bucketFunction(record.time), record))
+          .groupBy(_._1)
+          .map {
+            case (responseTimeBucket, recordList) =>
 
-                val bucketSize = recordList.foldLeft(0) {
-                  (partialSize, record) => partialSize + record._2.value
-                }
+              val bucketSize = recordList.foldLeft(0) {
+                (partialSize, record) => partialSize + record._2.value
+              }
 
-                (responseTimeBucket, percent(bucketSize))
-            }(breakOut)
+              (responseTimeBucket, percent(bucketSize))
+          }(breakOut)
 
-          buckets.map {
-            bucket => PercentVsTimePlot(bucket, bucketsWithValues.getOrElse(bucket, 0.0))
-          }
+        buckets.map {
+          bucket => PercentVsTimePlot(bucket, bucketsWithValues.getOrElse(bucket, 0.0))
         }
+      }
 
       (process(ok), process(ko))
     }

--- a/gatling-charts/src/main/scala/io/gatling/charts/stats/ResultsHolder.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/stats/ResultsHolder.scala
@@ -19,17 +19,17 @@ import io.gatling.charts.stats.buffers._
 import io.gatling.core.config.GatlingConfiguration
 
 private[stats] class ResultsHolder(val minTimestamp: Long, val maxTimestamp: Long, val buckets: Array[Int])(implicit configuration: GatlingConfiguration)
-    extends GeneralStatsBuffers(math.ceil((maxTimestamp - minTimestamp) / 1000.0).toInt)
-    with Buckets
-    with RunTimes
-    with NamesBuffers
-    with RequestsPerSecBuffers
-    with ResponseTimeRangeBuffers
-    with SessionDeltaPerSecBuffers
-    with ResponsesPerSecBuffers
-    with ErrorsBuffers
-    with RequestPercentilesBuffers
-    with GroupPercentilesBuffers {
+  extends GeneralStatsBuffers(math.ceil((maxTimestamp - minTimestamp) / 1000.0).toInt)
+  with Buckets
+  with RunTimes
+  with NamesBuffers
+  with RequestsPerSecBuffers
+  with ResponseTimeRangeBuffers
+  with SessionDeltaPerSecBuffers
+  with ResponsesPerSecBuffers
+  with ErrorsBuffers
+  with RequestPercentilesBuffers
+  with GroupPercentilesBuffers {
 
   def addUserRecord(record: UserRecord): Unit = {
     addSessionBuffers(record)

--- a/gatling-charts/src/main/scala/io/gatling/charts/stats/buffers/ErrorsBuffers.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/stats/buffers/ErrorsBuffers.scala
@@ -34,17 +34,17 @@ private[stats] trait ErrorsBuffers {
 
   def updateErrorBuffers(record: RequestRecord): Unit = {
 
-      def updateGroupError(errorMessage: String): Unit = {
-        record.group.foreach { group =>
-          val buffer = getErrorsBuffers(None, Some(group))
-          buffer += errorMessage -> (buffer.getOrElseUpdate(errorMessage, 0) + 1)
-        }
-      }
-
-      def updateRequestError(errorMessage: String): Unit = {
-        val buffer = getErrorsBuffers(Some(record.name), record.group)
+    def updateGroupError(errorMessage: String): Unit = {
+      record.group.foreach { group =>
+        val buffer = getErrorsBuffers(None, Some(group))
         buffer += errorMessage -> (buffer.getOrElseUpdate(errorMessage, 0) + 1)
       }
+    }
+
+    def updateRequestError(errorMessage: String): Unit = {
+      val buffer = getErrorsBuffers(Some(record.name), record.group)
+      buffer += errorMessage -> (buffer.getOrElseUpdate(errorMessage, 0) + 1)
+    }
 
     record.errorMessage.foreach { errorMessage =>
       updateGlobalError(errorMessage)

--- a/gatling-charts/src/main/scala/io/gatling/charts/template/GlobalStatsJsonTemplate.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/template/GlobalStatsJsonTemplate.scala
@@ -26,13 +26,13 @@ private[charts] class GlobalStatsJsonTemplate(stats: RequestStatistics, raw: Boo
 
   def getOutput: Fastring = {
 
-      def style[T: Numeric](value: T) =
-        if (raw) {
-          // raw mode is used for JSON extract, non-raw for displaying in the reports
-          if (value == GeneralStats.NoPlotMagicValue) "0"
-          else value.toString
-        } else
-          s""""${printable(value)}""""
+    def style[T: Numeric](value: T) =
+      if (raw) {
+        // raw mode is used for JSON extract, non-raw for displaying in the reports
+        if (value == GeneralStats.NoPlotMagicValue) "0"
+        else value.toString
+      } else
+        s""""${printable(value)}""""
 
     fast"""{
     "name": "${stats.name.escapeJsIllegalChars}",

--- a/gatling-charts/src/main/scala/io/gatling/charts/template/StatsJsTemplate.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/template/StatsJsTemplate.scala
@@ -33,32 +33,32 @@ private[charts] class StatsJsTemplate(stats: GroupContainer, outputJson: Boolean
 
   def getOutput(charset: Charset): Fastring = {
 
-      def renderStats(request: RequestStatistics, path: String): Fastring = {
-        val jsonStats = new GlobalStatsJsonTemplate(request, outputJson).getOutput
+    def renderStats(request: RequestStatistics, path: String): Fastring = {
+      val jsonStats = new GlobalStatsJsonTemplate(request, outputJson).getOutput
 
-        fast"""${fieldName("name")}: "${request.name.escapeJsIllegalChars}",
+      fast"""${fieldName("name")}: "${request.name.escapeJsIllegalChars}",
 ${fieldName("path")}: "${request.path.escapeJsIllegalChars}",
 ${fieldName("pathFormatted")}: "$path",
 ${fieldName("stats")}: $jsonStats"""
-      }
+    }
 
-      def renderSubGroups(group: GroupContainer): Iterable[Fastring] =
-        group.groups.values.map { subGroup =>
-          fast""""${subGroup.name.toGroupFileName(charset)}": {
+    def renderSubGroups(group: GroupContainer): Iterable[Fastring] =
+      group.groups.values.map { subGroup =>
+        fast""""${subGroup.name.toGroupFileName(charset)}": {
           ${renderGroup(subGroup)}
      }"""
-        }
+      }
 
-      def renderSubRequests(group: GroupContainer): Iterable[Fastring] =
-        group.requests.values.map { request =>
-          fast""""${request.name.toRequestFileName(charset)}": {
+    def renderSubRequests(group: GroupContainer): Iterable[Fastring] =
+      group.requests.values.map { request =>
+        fast""""${request.name.toRequestFileName(charset)}": {
         ${fieldName("type")}: "$Request",
         ${renderStats(request.stats, request.stats.path.toRequestFileName(charset))}
     }"""
-        }
+      }
 
-      def renderGroup(group: GroupContainer): Fastring =
-        fast"""${fieldName("type")}: "$Group",
+    def renderGroup(group: GroupContainer): Fastring =
+      fast"""${fieldName("type")}: "$Group",
 ${renderStats(group.stats, group.stats.path.toGroupFileName(charset))},
 ${fieldName("contents")}: {
 ${(renderSubGroups(group) ++ renderSubRequests(group)).mkFastring(",")}

--- a/gatling-commons/src/main/scala/io/gatling/commons/stats/assertion/AssertionValidator.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/stats/assertion/AssertionValidator.scala
@@ -141,8 +141,8 @@ object AssertionValidator {
 
     val printableCondition = assertion.condition.printable
 
-      def assertionResult(result: Boolean, expectedValueMessage: Any) =
-        AssertionResult(assertion, result, s"$path: $printableTarget $printableCondition $expectedValueMessage", Some(actualValue))
+    def assertionResult(result: Boolean, expectedValueMessage: Any) =
+      AssertionResult(assertion, result, s"$path: $printableTarget $printableCondition $expectedValueMessage", Some(actualValue))
 
     assertion.condition match {
       case Lt(upper)                    => assertionResult(actualValue < upper, upper)

--- a/gatling-commons/src/main/scala/io/gatling/commons/util/GzipHelper.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/util/GzipHelper.scala
@@ -73,7 +73,7 @@ object ReusableGzipOutputStream {
 }
 
 class ReusableGzipOutputStream(val os: SettableOutputStream)
-    extends DeflaterOutputStream(os, new Deflater(Deflater.DEFAULT_COMPRESSION, true)) {
+  extends DeflaterOutputStream(os, new Deflater(Deflater.DEFAULT_COMPRESSION, true)) {
 
   import ReusableGzipOutputStream._
 

--- a/gatling-commons/src/main/scala/io/gatling/commons/util/HtmlHelper.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/util/HtmlHelper.scala
@@ -30,7 +30,7 @@ object HtmlHelper {
   implicit class HtmlRichString(val string: String) extends AnyVal {
 
     def htmlEscape: String = {
-        def charToHtmlEntity(char: Char): String = charToHtmlEntities.getOrElse(char, char.toString)
+      def charToHtmlEntity(char: Char): String = charToHtmlEntities.getOrElse(char, char.toString)
 
       string.map(charToHtmlEntity).mkString
     }

--- a/gatling-commons/src/main/scala/io/gatling/commons/util/Io.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/util/Io.scala
@@ -54,13 +54,13 @@ object Io {
   implicit class RichInputStream(val is: InputStream) extends AnyVal {
 
     def toString(charset: Charset, bufferSize: Int = DefaultBufferSize): String = {
-          val writer = new FastStringWriter(bufferSize)
-          val reader = new InputStreamReader(is, charset)
+      val writer = new FastStringWriter(bufferSize)
+      val reader = new InputStreamReader(is, charset)
 
-          reader.copyTo(writer, bufferSize)
+      reader.copyTo(writer, bufferSize)
 
-          writer.toString
-      }
+      writer.toString
+    }
 
     def toByteArray(): Array[Byte] = {
       val os = FastByteArrayOutputStream.pooled()
@@ -70,23 +70,23 @@ object Io {
 
     def copyTo(os: OutputStream, bufferSize: Int = DefaultBufferSize): Int = {
 
-        def copyLarge(buffer: Array[Byte]): Long = {
+      def copyLarge(buffer: Array[Byte]): Long = {
 
-          var lastReadCount: Int = 0
-            def read(): Int = {
-              lastReadCount = is.read(buffer)
-              lastReadCount
-            }
-
-          var count: Long = 0
-
-          while (read() != -1) {
-            os.write(buffer, 0, lastReadCount)
-            count += lastReadCount
-          }
-
-          count
+        var lastReadCount: Int = 0
+        def read(): Int = {
+          lastReadCount = is.read(buffer)
+          lastReadCount
         }
+
+        var count: Long = 0
+
+        while (read() != -1) {
+          os.write(buffer, 0, lastReadCount)
+          count += lastReadCount
+        }
+
+        count
+      }
 
       copyLarge(new Array[Byte](bufferSize)) match {
         case l if l > Integer.MAX_VALUE => -1
@@ -99,23 +99,23 @@ object Io {
 
     def copyTo(writer: Writer, bufferSize: Int = DefaultBufferSize): Int = {
 
-        def copyLarge(buffer: Array[Char]) = {
+      def copyLarge(buffer: Array[Char]) = {
 
-          var lastReadCount: Int = 0
-            def read(): Int = {
-              lastReadCount = reader.read(buffer)
-              lastReadCount
-            }
-
-          var count: Long = 0
-
-          while (read() != -1) {
-            writer.write(buffer, 0, lastReadCount)
-            count += lastReadCount
-          }
-
-          count
+        var lastReadCount: Int = 0
+        def read(): Int = {
+          lastReadCount = reader.read(buffer)
+          lastReadCount
         }
+
+        var count: Long = 0
+
+        while (read() != -1) {
+          writer.write(buffer, 0, lastReadCount)
+          count += lastReadCount
+        }
+
+        count
+      }
 
       copyLarge(new Array[Char](bufferSize)) match {
         case l if l > Integer.MAX_VALUE => -1
@@ -152,11 +152,11 @@ object Io {
     }
 
   /**
-    * Delete a possibly non empty directory
-    *
-    * @param directory the directory to delete
-    * @return if directory could be deleted
-    */
+   * Delete a possibly non empty directory
+   *
+   * @param directory the directory to delete
+   * @return if directory could be deleted
+   */
   def deleteDirectory(directory: Path): Boolean = try {
     Files.walkFileTree(directory, new SimpleFileVisitor[Path]() {
       @throws[IOException]
@@ -178,22 +178,22 @@ object Io {
   }
 
   /**
-    * Make a possibly non empty directory to be deleted on exit
-    *
-    * @param directory the directory to delete
-    */
+   * Make a possibly non empty directory to be deleted on exit
+   *
+   * @param directory the directory to delete
+   */
   def deleteDirectoryOnExit(directory: Path): Unit =
-  Files.walkFileTree(directory, new SimpleFileVisitor[Path]() {
-    @throws[IOException]
-    override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-      file.toFile.deleteOnExit()
-      FileVisitResult.CONTINUE
-    }
+    Files.walkFileTree(directory, new SimpleFileVisitor[Path]() {
+      @throws[IOException]
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        file.toFile.deleteOnExit()
+        FileVisitResult.CONTINUE
+      }
 
-    @throws[IOException]
-    override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
-      dir.toFile.deleteOnExit()
-      FileVisitResult.CONTINUE
-    }
-  })
+      @throws[IOException]
+      override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+        dir.toFile.deleteOnExit()
+        FileVisitResult.CONTINUE
+      }
+    })
 }

--- a/gatling-commons/src/main/scala/io/gatling/commons/util/PathHelper.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/util/PathHelper.scala
@@ -61,12 +61,12 @@ object PathHelper {
     def segments: List[Path] = path.iterator.asScala.toList
 
     def ancestor(n: Int): Path = {
-        @tailrec
-        def loop(path: Path, n: Int): Path =
-          n match {
-            case 0 => path
-            case _ => loop(path.getParent, n - 1)
-          }
+      @tailrec
+      def loop(path: Path, n: Int): Path =
+        n match {
+          case 0 => path
+          case _ => loop(path.getParent, n - 1)
+        }
 
       require(n >= 0, s"ancestor rank must be positive but asked for $n")
       val length = path.segments.length

--- a/gatling-commons/src/main/scala/io/gatling/commons/util/ScanHelper.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/util/ScanHelper.scala
@@ -71,10 +71,10 @@ object ScanHelper {
 
   def getPackageResources(pkg: Path, deep: Boolean): Iterator[Resource] = {
 
-      def isResourceInRootDir(resource: Path, rootDir: Path): Boolean =
-        if (resource.extension.isEmpty) false
-        else if (deep) resource.startsWith(rootDir)
-        else resource.getParent == rootDir
+    def isResourceInRootDir(resource: Path, rootDir: Path): Boolean =
+      if (resource.extension.isEmpty) false
+      else if (deep) resource.startsWith(rootDir)
+      else resource.getParent == rootDir
 
     getClass.getClassLoader.getResources(pkg.toString.replace("\\", "/")).asScala.flatMap { pkgURL =>
       pkgURL.getProtocol match {
@@ -99,11 +99,11 @@ object ScanHelper {
 
   def deepCopyPackageContent(pkg: Path, targetDirectoryPath: Path): Unit = {
 
-      def getPathStringAfterPackage(path: Path, pkg: Path): Path = {
-        val pathString = path.segments.mkString(Separator)
-        val pkgString = pkg.segments.mkString(Separator)
-        segments2path(pathString.split(pkgString).last.split(Separator))
-      }
+    def getPathStringAfterPackage(path: Path, pkg: Path): Path = {
+      val pathString = path.segments.mkString(Separator)
+      val pkgString = pkg.segments.mkString(Separator)
+      segments2path(pathString.split(pkgString).last.split(Separator))
+    }
 
     getPackageResources(pkg, deep = true).foreach { resource =>
       val target = targetDirectoryPath / getPathStringAfterPackage(resource.path, pkg)

--- a/gatling-commons/src/main/scala/io/gatling/commons/util/ThreadLocalRandoms.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/util/ThreadLocalRandoms.scala
@@ -23,10 +23,11 @@ import scala.language.higherKinds
 
 object ThreadLocalRandoms {
 
-  /** Returns a new collection of the same type in a randomly chosen order.
-    *
-    *  @return         the shuffled collection
-    */
+  /**
+   * Returns a new collection of the same type in a randomly chosen order.
+   *
+   *  @return         the shuffled collection
+   */
   def shuffle[T, CC[X] <: TraversableOnce[X]](xs: CC[T])(implicit bf: CanBuildFrom[CC[T], T, CC[T]]): CC[T] = {
 
     val random = ThreadLocalRandom.current

--- a/gatling-commons/src/test/scala/io/gatling/commons/validation/SafelySpec.scala
+++ b/gatling-commons/src/test/scala/io/gatling/commons/validation/SafelySpec.scala
@@ -26,12 +26,12 @@ class SafelySpec extends BaseSpec {
   }
 
   it should "return a failure if the provided Validation threw exceptions" in {
-      def exceptionThrower = {
-          def thrower = throw new Exception("Woops") with NoStackTrace
+    def exceptionThrower = {
+      def thrower = throw new Exception("Woops") with NoStackTrace
 
-        thrower
-        Success(1)
-      }
+      thrower
+      Success(1)
+    }
 
     safely()(exceptionThrower) shouldBe "j.l.Exception: Woops".failure
     safely(_ + "y")(exceptionThrower) shouldBe "j.l.Exception: Woopsy".failure

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/CompilerConfiguration.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/CompilerConfiguration.scala
@@ -25,9 +25,9 @@ import io.gatling.compiler.config.cli.{ ArgsParser, CommandLineOverrides }
 import com.typesafe.config.ConfigFactory
 
 private[compiler] case class CompilerConfiguration(
-  encoding:             String,
-  simulationsDirectory: Path,
-  binariesDirectory:    Path
+    encoding:             String,
+    simulationsDirectory: Path,
+    binariesDirectory:    Path
 )
 
 private[compiler] object CompilerConfiguration {
@@ -37,19 +37,19 @@ private[compiler] object CompilerConfiguration {
   private val binariesDirectoryKey = "gatling.core.directory.binaries"
 
   def configuration(args: Array[String]) = {
-      def buildConfigurationMap(overrides: CommandLineOverrides): Map[String, _ <: Any] = {
-        val mapForSimulationFolder =
-          string2option(overrides.simulationsDirectory)
-            .map(v => Map(simulationsDirectoryKey -> v))
-            .getOrElse(Map.empty)
+    def buildConfigurationMap(overrides: CommandLineOverrides): Map[String, _ <: Any] = {
+      val mapForSimulationFolder =
+        string2option(overrides.simulationsDirectory)
+          .map(v => Map(simulationsDirectoryKey -> v))
+          .getOrElse(Map.empty)
 
-        val mapForBinariesFolder =
-          string2option(overrides.binariesFolder)
-            .map(v => Map(binariesDirectoryKey -> v))
-            .getOrElse(Map.empty)
+      val mapForBinariesFolder =
+        string2option(overrides.binariesFolder)
+          .map(v => Map(binariesDirectoryKey -> v))
+          .getOrElse(Map.empty)
 
-        mapForSimulationFolder ++ mapForBinariesFolder
-      }
+      mapForSimulationFolder ++ mapForBinariesFolder
+    }
 
     val argsParser = new ArgsParser(args)
     val commandLineOverrides = argsParser.parseArguments
@@ -62,7 +62,7 @@ private[compiler] object CompilerConfiguration {
     val encoding = config.getString(encodingKey)
     val simulationsDirectory = resolvePath(Paths.get(config.getString(simulationsDirectoryKey)))
     val binariesDirectory = string2option(config.getString(binariesDirectoryKey))
-        .fold(GatlingHome / "target" / "test-classes")(resolvePath(_))
+      .fold(GatlingHome / "target" / "test-classes")(resolvePath(_))
 
     CompilerConfiguration(encoding, simulationsDirectory, binariesDirectory)
   }

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/ArgsParser.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/ArgsParser.scala
@@ -20,8 +20,8 @@ import scopt.{ OptionDef, OptionParser, Read }
 import io.gatling.compiler.config.cli.CommandLineConstants._
 
 private[config] case class CommandLineOverrides(
-  simulationsDirectory: String = "",
-  binariesFolder:       String = ""
+    simulationsDirectory: String = "",
+    binariesFolder:       String = ""
 )
 
 private[config] class ArgsParser(args: Array[String]) {

--- a/gatling-core/src/main/scala/io/gatling/core/CoreComponents.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/CoreComponents.scala
@@ -23,9 +23,9 @@ import io.gatling.core.stats.StatsEngine
 import _root_.akka.actor.ActorRef
 
 case class CoreComponents(
-  controller:    ActorRef,
-  throttler:     Throttler,
-  statsEngine:   StatsEngine,
-  exit:          Action,
-  configuration: GatlingConfiguration
+    controller:    ActorRef,
+    throttler:     Throttler,
+    statsEngine:   StatsEngine,
+    exit:          Action,
+    configuration: GatlingConfiguration
 )

--- a/gatling-core/src/main/scala/io/gatling/core/CoreDsl.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/CoreDsl.scala
@@ -29,14 +29,14 @@ import io.gatling.core.session.{ Expression, Session }
 import io.gatling.core.structure.{ ScenarioBuilder, StructureSupport }
 
 trait CoreDsl extends StructureSupport
-    with PauseSupport
-    with CheckSupport
-    with FeederSupport
-    with InjectionSupport
-    with ThrottlingSupport
-    with AssertionSupport
-    with CoreDefaultImplicits
-    with ValidationImplicits {
+  with PauseSupport
+  with CheckSupport
+  with FeederSupport
+  with InjectionSupport
+  with ThrottlingSupport
+  with AssertionSupport
+  with CoreDefaultImplicits
+  with ValidationImplicits {
 
   def gzipBody(implicit configuration: GatlingConfiguration) = BodyProcessors.gzip
   def streamBody(implicit configuration: GatlingConfiguration) = BodyProcessors.stream
@@ -66,9 +66,9 @@ trait CoreDsl extends StructureSupport
 
   def InputStreamBody = io.gatling.core.body.InputStreamBody
 
-  /***********************************/
+/***********************************/
   /** Duration implicit conversions **/
-  /***********************************/
+/***********************************/
 
   implicit def integerToFiniteDuration(i: Integer): FiniteDuration = intToFiniteDuration(i.toInt)
 

--- a/gatling-core/src/main/scala/io/gatling/core/action/BlockExit.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/action/BlockExit.scala
@@ -71,20 +71,20 @@ object BlockExit {
    */
   private def exitAsapLoop(session: Session): Option[BlockExit] = {
 
-      @tailrec
-      def exitAsapLoopRec(leftToRightBlocks: List[Block]): Option[BlockExit] = leftToRightBlocks match {
-        case Nil => None
+    @tailrec
+    def exitAsapLoopRec(leftToRightBlocks: List[Block]): Option[BlockExit] = leftToRightBlocks match {
+      case Nil => None
 
-        case head :: tail => head match {
+      case head :: tail => head match {
 
-          case ExitAsapLoopBlock(_, condition, exitAction) if !LoopBlock.continue(condition, session) =>
-            val exit = blockExit(session.blockStack, head, exitAction, session, Nil)
-            // block stack head is now the loop itself, we must exit it
-            Some(exit.copy(session = exit.session.exitLoop))
+        case ExitAsapLoopBlock(_, condition, exitAction) if !LoopBlock.continue(condition, session) =>
+          val exit = blockExit(session.blockStack, head, exitAction, session, Nil)
+          // block stack head is now the loop itself, we must exit it
+          Some(exit.copy(session = exit.session.exitLoop))
 
-          case _ => exitAsapLoopRec(tail)
-        }
+        case _ => exitAsapLoopRec(tail)
       }
+    }
 
     exitAsapLoopRec(session.blockStack.reverse)
   }
@@ -98,20 +98,20 @@ object BlockExit {
    */
   private def exitTryMax(session: Session): Option[BlockExit] = {
 
-      @tailrec
-      def exitTryMaxRec(stack: List[Block]): Option[BlockExit] = stack match {
-        case Nil => None
+    @tailrec
+    def exitTryMaxRec(stack: List[Block]): Option[BlockExit] = stack match {
+      case Nil => None
 
-        case head :: tail => head match {
+      case head :: tail => head match {
 
-          case TryMaxBlock(_, tryMaxActor, KO) =>
-            // block stack head is now the tryMax itself, leave as is
-            val exit = blockExit(session.blockStack, head, tryMaxActor, session, Nil)
-            Some(exit)
+        case TryMaxBlock(_, tryMaxActor, KO) =>
+          // block stack head is now the tryMax itself, leave as is
+          val exit = blockExit(session.blockStack, head, tryMaxActor, session, Nil)
+          Some(exit)
 
-          case _ => exitTryMaxRec(tail)
-        }
+        case _ => exitTryMaxRec(tail)
       }
+    }
 
     exitTryMaxRec(session.blockStack)
   }

--- a/gatling-core/src/main/scala/io/gatling/core/action/Pace.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/action/Pace.scala
@@ -55,7 +55,7 @@ class Pace(intervalExpr: Expression[Duration], counter: String, system: ActorSys
       val nextStartTime = startTime + interval.toMillis
       val waitTime = startTime - nowMillis
 
-        def doNext() = next ! session.set(counter, nextStartTime)
+      def doNext() = next ! session.set(counter, nextStartTime)
 
       if (waitTime > 0) {
         scheduler.scheduleOnce(waitTime milliseconds)(doNext())

--- a/gatling-core/src/main/scala/io/gatling/core/action/Pause.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/action/Pause.scala
@@ -43,32 +43,32 @@ class Pause(pauseDuration: Expression[Long], system: ActorSystem, val statsEngin
    */
   override def execute(session: Session): Unit = recover(session) {
 
-      def schedule(durationInMillis: Long) = {
-        val drift = session.drift
+    def schedule(durationInMillis: Long) = {
+      val drift = session.drift
 
-        if (durationInMillis > drift) {
-          // can make pause
-          val durationMinusDrift = durationInMillis - drift
-          logger.debug(s"Pausing for ${durationInMillis}ms (real=${durationMinusDrift}ms)")
+      if (durationInMillis > drift) {
+        // can make pause
+        val durationMinusDrift = durationInMillis - drift
+        logger.debug(s"Pausing for ${durationInMillis}ms (real=${durationMinusDrift}ms)")
 
-          val pauseStart = nowMillis
+        val pauseStart = nowMillis
 
-          try {
-            scheduler.scheduleOnce(durationMinusDrift milliseconds) {
-              val newDrift = nowMillis - pauseStart - durationMinusDrift
-              next ! session.setDrift(newDrift)
-            }
-          } catch {
-            case ise: IllegalStateException => // engine was shutdown
+        try {
+          scheduler.scheduleOnce(durationMinusDrift milliseconds) {
+            val newDrift = nowMillis - pauseStart - durationMinusDrift
+            next ! session.setDrift(newDrift)
           }
-
-        } else {
-          // drift is too big
-          val remainingDrift = drift - durationInMillis
-          logger.debug(s"Can't pause (remaining drift=${remainingDrift}ms)")
-          system.dispatcher.execute(() => next ! session.setDrift(remainingDrift))
+        } catch {
+          case ise: IllegalStateException => // engine was shutdown
         }
+
+      } else {
+        // drift is too big
+        val remainingDrift = drift - durationInMillis
+        logger.debug(s"Can't pause (remaining drift=${remainingDrift}ms)")
+        system.dispatcher.execute(() => next ! session.setDrift(remainingDrift))
       }
+    }
 
     pauseDuration(session).map(schedule)
   }

--- a/gatling-core/src/main/scala/io/gatling/core/action/builder/RandomSwitchBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/action/builder/RandomSwitchBuilder.scala
@@ -65,15 +65,15 @@ class RandomSwitchBuilder(possibilities: List[(Int, ChainBuilder)], elseNext: Op
 
     val nextAction: Expression[Action] = _ => {
 
-        @tailrec
-        def determineNextAction(index: Int, possibilities: List[(Int, Action)]): Action = possibilities match {
-          case Nil => elseNextAction
-          case (percentage, possibleAction) :: others =>
-            if (percentage >= index)
-              possibleAction
-            else
-              determineNextAction(index - percentage, others)
-        }
+      @tailrec
+      def determineNextAction(index: Int, possibilities: List[(Int, Action)]): Action = possibilities match {
+        case Nil => elseNextAction
+        case (percentage, possibleAction) :: others =>
+          if (percentage >= index)
+            possibleAction
+          else
+            determineNextAction(index - percentage, others)
+      }
 
       determineNextAction(randomWithinAccuracy, possibleActions).success
     }

--- a/gatling-core/src/main/scala/io/gatling/core/check/CheckBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/CheckBuilder.scala
@@ -28,7 +28,7 @@ trait FindCheckBuilder[A, P, X] {
 }
 
 class DefaultFindCheckBuilder[A, P, X](extractor: Expression[Extractor[P, X]])
-    extends FindCheckBuilder[A, P, X] {
+  extends FindCheckBuilder[A, P, X] {
 
   def find: ValidatorCheckBuilder[A, P, X] = ValidatorCheckBuilder(extractor)
 }
@@ -47,7 +47,7 @@ trait MultipleFindCheckBuilder[A, P, X] extends FindCheckBuilder[A, P, X] {
 }
 
 abstract class DefaultMultipleFindCheckBuilder[A, P, X]
-    extends MultipleFindCheckBuilder[A, P, X] {
+  extends MultipleFindCheckBuilder[A, P, X] {
 
   def findExtractor(occurrence: Int): Expression[Extractor[P, X]]
 
@@ -73,28 +73,28 @@ abstract class DefaultMultipleFindCheckBuilder[A, P, X]
 
       override def apply(prepared: P): Validation[Option[Seq[X]]] =
         fae(prepared)
-            .flatMap {
-              case Some(seq) =>
-                if (failIfLess && seq.size < num) {
-                  s"Failed to collect $num matches".failure
+          .flatMap {
+            case Some(seq) =>
+              if (failIfLess && seq.size < num) {
+                s"Failed to collect $num matches".failure
 
-                } else if (seq.isEmpty) {
-                  NoneSuccess
+              } else if (seq.isEmpty) {
+                NoneSuccess
 
-                } else {
-                  val randomSeq =
-                    if (num >= seq.size) {
-                      seq
-                    } else {
-                      val sortedRandomIndexes = ThreadLocalRandoms.shuffle(seq.indices.toVector).take(num).sorted
-                      sortedRandomIndexes.map(seq)
-                    }
+              } else {
+                val randomSeq =
+                  if (num >= seq.size) {
+                    seq
+                  } else {
+                    val sortedRandomIndexes = ThreadLocalRandoms.shuffle(seq.indices.toVector).take(num).sorted
+                    sortedRandomIndexes.map(seq)
+                  }
 
-                  Some(randomSeq).success
-                }
+                Some(randomSeq).success
+              }
 
-              case None => NoneSuccess
-            }
+            case None => NoneSuccess
+          }
     }
   }
 
@@ -183,7 +183,8 @@ case class ValidatorCheckBuilder[A, P, X](extractor: Expression[Extractor[P, X]]
 case class CheckBuilder[A, P, X](
     validatorCheckBuilder: ValidatorCheckBuilder[A, P, X],
     validator:             Expression[Validator[X]],
-    saveAs:                Option[String] = None) {
+    saveAs:                Option[String]                 = None
+) {
 
   def build[C <: Check[R], R](protocolProvider: CheckProtocolProvider[A, C, R, P]): C = {
     import protocolProvider._

--- a/gatling-core/src/main/scala/io/gatling/core/check/OldCheckBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/OldCheckBuilder.scala
@@ -27,10 +27,10 @@ trait OldFindCheckBuilder[C <: Check[R], R, P, X] {
 
 @deprecated("Only used in old Async checks, will be replaced with new impl, will be removed in 3.0.0", "3.0.0-M1")
 class OldDefaultFindCheckBuilder[C <: Check[R], R, P, X](
-                                                          specializer:  Specializer[C, R],
-                                                          preparer:  Preparer[R, P],
-                                                          extractor: Expression[Extractor[P, X]]
-                                                     )
+    specializer: Specializer[C, R],
+    preparer:    Preparer[R, P],
+    extractor:   Expression[Extractor[P, X]]
+)
   extends OldFindCheckBuilder[C, R, P, X] {
 
   def find: OldValidatorCheckBuilder[C, R, P, X] = OldValidatorCheckBuilder(specializer, preparer, extractor)
@@ -48,9 +48,9 @@ trait OldMultipleFindCheckBuilder[C <: Check[R], R, P, X] extends OldFindCheckBu
 
 @deprecated("Only used in old Async checks, will be replaced with new impl, will be removed in 3.0.0", "3.0.0-M1")
 abstract class OldDefaultMultipleFindCheckBuilder[C <: Check[R], R, P, X](
-                                                                           specializer: Specializer[C, R],
-                                                                           preparer: Preparer[R, P]
-                                                                      )
+    specializer: Specializer[C, R],
+    preparer:    Preparer[R, P]
+)
   extends OldMultipleFindCheckBuilder[C, R, P, X] {
 
   def findExtractor(occurrence: Int): Expression[Extractor[P, X]]
@@ -76,10 +76,10 @@ object OldValidatorCheckBuilder {
 
 @deprecated("Only used in old Async checks, will be replaced with new impl, will be removed in 3.0.0", "3.0.0-M1")
 case class OldValidatorCheckBuilder[C <: Check[R], R, P, X](
-                                                             specializer:  Specializer[C, R],
-                                                             preparer:  Preparer[R, P],
-                                                             extractor: Expression[Extractor[P, X]]
-                                                        ) {
+    specializer: Specializer[C, R],
+    preparer:    Preparer[R, P],
+    extractor:   Expression[Extractor[P, X]]
+) {
 
   import OldValidatorCheckBuilder._
 
@@ -141,10 +141,10 @@ case class OldValidatorCheckBuilder[C <: Check[R], R, P, X](
 
 @deprecated("Only used in old Async checks, will be replaced with new impl, will be removed in 3.0.0", "3.0.0-M1")
 case class OldCheckBuilder[C <: Check[R], R, P, X](
-                                                 validatorCheckBuilder: OldValidatorCheckBuilder[C, R, P, X],
-                                                 validator:             Expression[Validator[X]],
-                                                 saveAs:                Option[String]                    = None
-                                               ) {
+    validatorCheckBuilder: OldValidatorCheckBuilder[C, R, P, X],
+    validator:             Expression[Validator[X]],
+    saveAs:                Option[String]                       = None
+) {
 
   def build: C = {
     val base = CheckBase(validatorCheckBuilder.preparer, validatorCheckBuilder.extractor, validator, saveAs)

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/css/CssCheckBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/css/CssCheckBuilder.scala
@@ -34,11 +34,11 @@ object CssCheckBuilder {
 }
 
 class CssCheckBuilder[X: NodeConverter](
-  private[css] val expression:    Expression[String],
-  private[css] val nodeAttribute: Option[String],
-  private[css] val selectors:     CssSelectors
+    private[css] val expression:    Expression[String],
+    private[css] val nodeAttribute: Option[String],
+    private[css] val selectors:     CssSelectors
 )
-    extends DefaultMultipleFindCheckBuilder[CssCheckType, NodeSelector, X] {
+  extends DefaultMultipleFindCheckBuilder[CssCheckType, NodeSelector, X] {
 
   import CssExtractorFactory._
 

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/css/FormExtractor.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/css/FormExtractor.scala
@@ -54,19 +54,19 @@ private[css] object FormExtractor {
 
   private def extractSelect(node: Node): Option[SelectInput] = {
 
-      def extractOptions(currentNode: Node, values: List[SelectOption]): List[SelectOption] =
-        (for {
-          i <- 0 until currentNode.getChildNodesCount
-          child = currentNode.getChild(i)
-        } yield child.getNodeName match {
-          case "option" =>
-            Option(child.getAttribute("value")) match {
-              case Some(value) if value.nonEmpty => SelectOption(value, child.hasAttribute("selected")) :: values
-              case _                             => values
-            }
-          case _ =>
-            extractOptions(child, values)
-        }).toList.flatten
+    def extractOptions(currentNode: Node, values: List[SelectOption]): List[SelectOption] =
+      (for {
+        i <- 0 until currentNode.getChildNodesCount
+        child = currentNode.getChild(i)
+      } yield child.getNodeName match {
+        case "option" =>
+          Option(child.getAttribute("value")) match {
+            case Some(value) if value.nonEmpty => SelectOption(value, child.hasAttribute("selected")) :: values
+            case _                             => values
+          }
+        case _ =>
+          extractOptions(child, values)
+      }).toList.flatten
 
     for {
       name <- Option(node.getAttribute("name"))
@@ -96,25 +96,25 @@ private[css] object FormExtractor {
 
   private def processForm(formNode: Node): Seq[Input] = {
 
-      def processFormRec(currentNode: Node, inputs: Seq[Input]): Seq[Input] = {
-        val childInputs =
-          for {
-            i <- 0 until currentNode.getChildNodesCount
-          } yield {
-            val childNode = currentNode.getChild(i)
-            childNode.getNodeName match {
-              case "input" => extractInput(childNode).map(Seq(_)).getOrElse(Nil)
-              case "select" => extractSelect(childNode) match {
-                case Some(input) => Seq(input)
-                case None        => Nil
-              }
-              case "textarea" => extractTextArea(childNode).map(Seq(_)).getOrElse(Nil)
-              case _          => processFormRec(childNode, inputs)
+    def processFormRec(currentNode: Node, inputs: Seq[Input]): Seq[Input] = {
+      val childInputs =
+        for {
+          i <- 0 until currentNode.getChildNodesCount
+        } yield {
+          val childNode = currentNode.getChild(i)
+          childNode.getNodeName match {
+            case "input" => extractInput(childNode).map(Seq(_)).getOrElse(Nil)
+            case "select" => extractSelect(childNode) match {
+              case Some(input) => Seq(input)
+              case None        => Nil
             }
+            case "textarea" => extractTextArea(childNode).map(Seq(_)).getOrElse(Nil)
+            case _          => processFormRec(childNode, inputs)
           }
+        }
 
-        inputs ++ childInputs.flatten
-      }
+      inputs ++ childInputs.flatten
+    }
 
     processFormRec(formNode, Nil)
   }

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/jsonpath/JsonPathCheckBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/jsonpath/JsonPathCheckBuilder.scala
@@ -32,10 +32,10 @@ object JsonPathCheckBuilder {
 }
 
 class JsonPathCheckBuilder[X: JsonFilter](
-  private[jsonpath] val path:      Expression[String],
-  private[jsonpath] val jsonPaths: JsonPaths
+    private[jsonpath] val path:      Expression[String],
+    private[jsonpath] val jsonPaths: JsonPaths
 )
-    extends DefaultMultipleFindCheckBuilder[JsonPathCheckType, Any, X] {
+  extends DefaultMultipleFindCheckBuilder[JsonPathCheckType, Any, X] {
 
   import JsonPathExtractorFactory._
 

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/jsonpath/JsonPaths.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/jsonpath/JsonPaths.scala
@@ -23,10 +23,10 @@ import io.gatling.jsonpath.JsonPath
 class JsonPaths(implicit configuration: GatlingConfiguration) {
 
   private val jsonPathCache = {
-      def compile(expression: String): Validation[JsonPath] = JsonPath.compile(expression) match {
-        case Left(error) => error.reason.failure
-        case Right(path) => path.success
-      }
+    def compile(expression: String): Validation[JsonPath] = JsonPath.compile(expression) match {
+      case Left(error) => error.reason.failure
+      case Right(path) => path.success
+    }
 
     Cache.newConcurrentLoadingCache(configuration.core.extract.jsonPath.cacheMaxCapacity, compile)
   }

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/jsonpath/JsonpJsonPathCheckBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/jsonpath/JsonpJsonPathCheckBuilder.scala
@@ -34,10 +34,10 @@ object JsonpJsonPathCheckBuilder {
 }
 
 class JsonpJsonPathCheckBuilder[X: JsonFilter](
-  private[jsonpath] val path:      Expression[String],
-  private[jsonpath] val jsonPaths: JsonPaths
+    private[jsonpath] val path:      Expression[String],
+    private[jsonpath] val jsonPaths: JsonPaths
 )
-    extends DefaultMultipleFindCheckBuilder[JsonpJsonPathCheckType, Any, X] {
+  extends DefaultMultipleFindCheckBuilder[JsonpJsonPathCheckType, Any, X] {
 
   import JsonpJsonPathExtractorFactory._
 

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/regex/GroupExtractor.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/regex/GroupExtractor.scala
@@ -27,17 +27,17 @@ trait LowPriorityGroupExtractorImplicits extends StrictLogging {
 
     def extract(matcher: Matcher): String = {
 
-        @tailrec
-        def extractFirstNonNullGroupRec(i: Int, max: Int): String = {
-          matcher.group(i) match {
-            case null =>
-              if (i < max)
-                extractFirstNonNullGroupRec(i + 1, max)
-              else
-                "" // shouldn't happen, as the regex matched, we should have at least one non null group
-            case value => value
-          }
+      @tailrec
+      def extractFirstNonNullGroupRec(i: Int, max: Int): String = {
+        matcher.group(i) match {
+          case null =>
+            if (i < max)
+              extractFirstNonNullGroupRec(i + 1, max)
+            else
+              "" // shouldn't happen, as the regex matched, we should have at least one non null group
+          case value => value
         }
+      }
 
       matcher.groupCount match {
         case 0     => safeGetGroupValue(matcher, 0)

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/regex/RegexCheckBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/regex/RegexCheckBuilder.scala
@@ -33,10 +33,10 @@ object RegexCheckBuilder {
 }
 
 class RegexCheckBuilder[X: GroupExtractor](
-  private[regex] val pattern:  Expression[String],
-  private[regex] val patterns: Patterns
+    private[regex] val pattern:  Expression[String],
+    private[regex] val patterns: Patterns
 )
-    extends DefaultMultipleFindCheckBuilder[RegexCheckType, CharSequence, X] {
+  extends DefaultMultipleFindCheckBuilder[RegexCheckType, CharSequence, X] {
 
   import RegexExtractorFactory._
 

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/regex/package.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/regex/package.scala
@@ -32,8 +32,8 @@ package object regex {
 
     def findMatchN[X: GroupExtractor](n: Int): Option[X] = {
 
-        @tailrec
-        def findRec(countDown: Int): Boolean = matcher.find && (countDown == 0 || findRec(countDown - 1))
+      @tailrec
+      def findRec(countDown: Int): Boolean = matcher.find && (countDown == 0 || findRec(countDown - 1))
 
       if (findRec(n))
         Some(value[X])

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/substring/SubstringExtractorFactory.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/substring/SubstringExtractorFactory.scala
@@ -24,15 +24,15 @@ object SubstringExtractorFactory extends CriterionExtractorFactory[String, Strin
 
   private def extractAll(prepared: String, criterion: String): List[Int] = {
 
-      @tailrec
-      def loop(fromIndex: Int, is: List[Int]): List[Int] =
-        if (fromIndex >= prepared.length)
-          is
-        else
-          prepared.indexOf(criterion, fromIndex) match {
-            case -1 => is
-            case i  => loop(i + criterion.length, i :: is)
-          }
+    @tailrec
+    def loop(fromIndex: Int, is: List[Int]): List[Int] =
+      if (fromIndex >= prepared.length)
+        is
+      else
+        prepared.indexOf(criterion, fromIndex) match {
+          case -1 => is
+          case i  => loop(i + criterion.length, i :: is)
+        }
 
     loop(0, Nil)
   }
@@ -43,19 +43,19 @@ object SubstringExtractorFactory extends CriterionExtractorFactory[String, Strin
       occurrence,
       text => {
 
-          @tailrec
-          def loop(fromIndex: Int, occ: Int): Validation[Option[Int]] =
-            if (fromIndex >= substring.length)
-              NoneSuccess
-            else
-              text.indexOf(substring, fromIndex) match {
-                case -1 => NoneSuccess
-                case i =>
-                  if (occ == occurrence)
-                    Some(i).success
-                  else
-                    loop(i + substring.length, occ + 1)
-              }
+        @tailrec
+        def loop(fromIndex: Int, occ: Int): Validation[Option[Int]] =
+          if (fromIndex >= substring.length)
+            NoneSuccess
+          else
+            text.indexOf(substring, fromIndex) match {
+              case -1 => NoneSuccess
+              case i =>
+                if (occ == occurrence)
+                  Some(i).success
+                else
+                  loop(i + substring.length, occ + 1)
+            }
 
         loop(0, 0)
       }

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/xpath/Saxon.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/xpath/Saxon.scala
@@ -38,13 +38,13 @@ class Saxon(configuration: GatlingConfiguration) {
 
   private val expressionToExecutableByNamespacesCache: LoadingCache[List[(String, String)], JFunction[String, XPathExecutable]] = {
 
-      def computer(namespaces: List[(String, String)]): JFunction[String, XPathExecutable] = {
-        val compiler = processor.newXPathCompiler
-        for {
-          (prefix, uri) <- namespaces
-        } compiler.declareNamespace(prefix, uri)
-        (compiler.compile _).asJava
-      }
+    def computer(namespaces: List[(String, String)]): JFunction[String, XPathExecutable] = {
+      val compiler = processor.newXPathCompiler
+      for {
+        (prefix, uri) <- namespaces
+      } compiler.declareNamespace(prefix, uri)
+      (compiler.compile _).asJava
+    }
 
     Cache.newConcurrentLoadingCache(configuration.core.extract.xpath.cacheMaxCapacity, computer)
   }

--- a/gatling-core/src/main/scala/io/gatling/core/check/extractor/xpath/XPathCheckBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/extractor/xpath/XPathCheckBuilder.scala
@@ -29,11 +29,11 @@ case class SaxonDom(document: XdmNode) extends Dom
 case class JdkDom(document: Document) extends Dom
 
 class XPathCheckBuilder(
-  path:       Expression[String],
-  namespaces: List[(String, String)],
-  xmlParsers: XmlParsers
+    path:       Expression[String],
+    namespaces: List[(String, String)],
+    xmlParsers: XmlParsers
 )
-    extends DefaultMultipleFindCheckBuilder[XPathCheckType, Option[Dom], String] {
+  extends DefaultMultipleFindCheckBuilder[XPathCheckType, Option[Dom], String] {
 
   override def findExtractor(occurrence: Int) = path.map(newXpathSingleExtractor(_, namespaces, occurrence, xmlParsers))
   override def findAllExtractor = path.map(newXpathMultipleExtractor(_, namespaces, xmlParsers))

--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
@@ -63,27 +63,27 @@ object GatlingConfiguration extends StrictLogging {
     case class Removed(path: String, advice: String) extends ObsoleteUsage(s"'$path' was removed, $advice.")
     case class Renamed(path: String, replacement: String) extends ObsoleteUsage(s"'$path' was renamed into $replacement.")
 
-      def loadObsoleteUsagesFromBundle[T <: ObsoleteUsage](bundleName: String, creator: (String, String) => T): Vector[T] = {
-        val bundle = ResourceBundle.getBundle(bundleName)
-        bundle.getKeys.asScala.map(key => creator(key, bundle.getString(key))).toVector
-      }
+    def loadObsoleteUsagesFromBundle[T <: ObsoleteUsage](bundleName: String, creator: (String, String) => T): Vector[T] = {
+      val bundle = ResourceBundle.getBundle(bundleName)
+      bundle.getKeys.asScala.map(key => creator(key, bundle.getString(key))).toVector
+    }
 
-      def warnAboutRemovedProperties(config: Config): Unit = {
-        val removedProperties = loadObsoleteUsagesFromBundle("config-removed", Removed.apply)
-        val renamedProperties = loadObsoleteUsagesFromBundle("config-renamed", Renamed.apply)
+    def warnAboutRemovedProperties(config: Config): Unit = {
+      val removedProperties = loadObsoleteUsagesFromBundle("config-removed", Removed.apply)
+      val renamedProperties = loadObsoleteUsagesFromBundle("config-renamed", Renamed.apply)
 
-        val obsoleteUsages =
-          (removedProperties ++ renamedProperties).collect { case obs if config.hasPath(obs.path) => obs.message }
+      val obsoleteUsages =
+        (removedProperties ++ renamedProperties).collect { case obs if config.hasPath(obs.path) => obs.message }
 
-        if (obsoleteUsages.nonEmpty) {
-          logger.error(
-            s"""|Your gatling.conf file is outdated, some properties have been renamed or removed.
+      if (obsoleteUsages.nonEmpty) {
+        logger.error(
+          s"""|Your gatling.conf file is outdated, some properties have been renamed or removed.
                 |Please update (check gatling.conf in Gatling bundle, or gatling-defaults.conf in gatling-core jar).
                 |Enabled obsolete properties:
                 |${obsoleteUsages.mkString("\n")}""".stripMargin
-          )
-        }
+        )
       }
+    }
 
     val classLoader = getClass.getClassLoader
 
@@ -154,19 +154,20 @@ object GatlingConfiguration extends StrictLogging {
         warmUpUrl = config.getString(http.WarmUpUrl).trimToOption,
         enableGA = config.getBoolean(http.EnableGA),
         ssl = {
-            def storeConfig(typeKey: String, fileKey: String, passwordKey: String, algorithmKey: String) = {
+          def storeConfig(typeKey: String, fileKey: String, passwordKey: String, algorithmKey: String) = {
 
-              val storeType = config.getString(typeKey).trimToOption
-              val storeFile = config.getString(fileKey).trimToOption
-              val storePassword = config.getString(passwordKey)
-              val storeAlgorithm = config.getString(algorithmKey).trimToOption
+            val storeType = config.getString(typeKey).trimToOption
+            val storeFile = config.getString(fileKey).trimToOption
+            val storePassword = config.getString(passwordKey)
+            val storeAlgorithm = config.getString(algorithmKey).trimToOption
 
-              storeFile.map(StoreConfiguration(storeType, _, storePassword, storeAlgorithm))
-            }
+            storeFile.map(StoreConfiguration(storeType, _, storePassword, storeAlgorithm))
+          }
 
           SslConfiguration(
             keyStore = storeConfig(http.ssl.keyStore.Type, http.ssl.keyStore.File, http.ssl.keyStore.Password, http.ssl.keyStore.Algorithm),
-            trustStore = storeConfig(http.ssl.trustStore.Type, http.ssl.trustStore.File, http.ssl.trustStore.Password, http.ssl.trustStore.Algorithm))
+            trustStore = storeConfig(http.ssl.trustStore.Type, http.ssl.trustStore.File, http.ssl.trustStore.Password, http.ssl.trustStore.Algorithm)
+          )
         },
         ahc = AhcConfiguration(
           keepAlive = config.getBoolean(http.ahc.KeepAlive),
@@ -258,24 +259,23 @@ object GatlingConfiguration extends StrictLogging {
       //
       //
       //
-      //
       // [fl]
       config = config
     )
 }
 
 case class CoreConfiguration(
-    version:                       String,
-    outputDirectoryBaseName:       Option[String],
-    runDescription:                Option[String],
-    encoding:                      String,
-    simulationClass:               Option[String],
-    extract:                       ExtractConfiguration,
-    directory:                     DirectoryConfiguration,
-    elFileBodiesCacheMaxCapacity:  Long,
-    rawFileBodiesCacheMaxCapacity: Long,
-    rawFileBodiesInMemoryMaxSize:  Long,
-    pebbleFileBodiesCacheMaxCapacity:  Long
+    version:                          String,
+    outputDirectoryBaseName:          Option[String],
+    runDescription:                   Option[String],
+    encoding:                         String,
+    simulationClass:                  Option[String],
+    extract:                          ExtractConfiguration,
+    directory:                        DirectoryConfiguration,
+    elFileBodiesCacheMaxCapacity:     Long,
+    rawFileBodiesCacheMaxCapacity:    Long,
+    rawFileBodiesInMemoryMaxSize:     Long,
+    pebbleFileBodiesCacheMaxCapacity: Long
 ) {
 
   val charset: Charset = Charset.forName(encoding)
@@ -283,111 +283,111 @@ case class CoreConfiguration(
 }
 
 case class ExtractConfiguration(
-  regex:    RegexConfiguration,
-  xpath:    XPathConfiguration,
-  jsonPath: JsonPathConfiguration,
-  css:      CssConfiguration
+    regex:    RegexConfiguration,
+    xpath:    XPathConfiguration,
+    jsonPath: JsonPathConfiguration,
+    css:      CssConfiguration
 )
 
 case class RegexConfiguration(
-  cacheMaxCapacity: Long
+    cacheMaxCapacity: Long
 )
 
 case class XPathConfiguration(
-  cacheMaxCapacity: Long
+    cacheMaxCapacity: Long
 )
 
 case class JsonPathConfiguration(
-  cacheMaxCapacity: Long,
-  preferJackson:    Boolean
+    cacheMaxCapacity: Long,
+    preferJackson:    Boolean
 )
 
 case class CssConfiguration(
-  cacheMaxCapacity: Long
+    cacheMaxCapacity: Long
 )
 
 case class DirectoryConfiguration(
-  data:        String,
-  bodies:      String,
-  sources:     String,
-  binaries:    Option[String],
-  reportsOnly: Option[String],
-  results:     String
+    data:        String,
+    bodies:      String,
+    sources:     String,
+    binaries:    Option[String],
+    reportsOnly: Option[String],
+    results:     String
 )
 
 case class ChartingConfiguration(
-  noReports:              Boolean,
-  maxPlotsPerSeries:      Int,
-  useGroupDurationMetric: Boolean,
-  indicators:             IndicatorsConfiguration
+    noReports:              Boolean,
+    maxPlotsPerSeries:      Int,
+    useGroupDurationMetric: Boolean,
+    indicators:             IndicatorsConfiguration
 )
 
 case class IndicatorsConfiguration(
-  lowerBound:  Int,
-  higherBound: Int,
-  percentile1: Double,
-  percentile2: Double,
-  percentile3: Double,
-  percentile4: Double
+    lowerBound:  Int,
+    higherBound: Int,
+    percentile1: Double,
+    percentile2: Double,
+    percentile3: Double,
+    percentile4: Double
 )
 
 case class HttpConfiguration(
-  fetchedCssCacheMaxCapacity:  Long,
-  fetchedHtmlCacheMaxCapacity: Long,
-  perUserCacheMaxCapacity:     Int,
-  warmUpUrl:                   Option[String],
-  enableGA:                    Boolean,
-  ssl:                         SslConfiguration,
-  ahc:                         AhcConfiguration,
-  dns:                         DnsConfiguration
+    fetchedCssCacheMaxCapacity:  Long,
+    fetchedHtmlCacheMaxCapacity: Long,
+    perUserCacheMaxCapacity:     Int,
+    warmUpUrl:                   Option[String],
+    enableGA:                    Boolean,
+    ssl:                         SslConfiguration,
+    ahc:                         AhcConfiguration,
+    dns:                         DnsConfiguration
 )
 
 case class JmsConfiguration(
-  replyTimeoutScanPeriod: Long
+    replyTimeoutScanPeriod: Long
 )
 
 case class AhcConfiguration(
-  keepAlive:                                   Boolean,
-  connectTimeout:                              Int,
-  handshakeTimeout:                            Int,
-  pooledConnectionIdleTimeout:                 Int,
-  readTimeout:                                 Int,
-  maxRetry:                                    Int,
-  requestTimeOut:                              Int,
-  disableHttpsEndpointIdentificationAlgorithm: Boolean,
-  useInsecureTrustManager:                     Boolean,
-  httpClientCodecMaxChunkSize:                 Int,
-  httpClientCodecInitialBufferSize:            Int,
-  sslEnabledProtocols:                         List[String],
-  sslEnabledCipherSuites:                      List[String],
-  sslSessionCacheSize:                         Int,
-  sslSessionTimeout:                           Int,
-  useOpenSsl:                                  Boolean,
-  useNativeTransport:                          Boolean,
-  tcpNoDelay:                                  Boolean,
-  soReuseAddress:                              Boolean,
-  soLinger:                                    Int,
-  soSndBuf:                                    Int,
-  soRcvBuf:                                    Int,
-  allocator:                                   String,
-  maxThreadLocalCharBufferSize:                Int
+    keepAlive:                                   Boolean,
+    connectTimeout:                              Int,
+    handshakeTimeout:                            Int,
+    pooledConnectionIdleTimeout:                 Int,
+    readTimeout:                                 Int,
+    maxRetry:                                    Int,
+    requestTimeOut:                              Int,
+    disableHttpsEndpointIdentificationAlgorithm: Boolean,
+    useInsecureTrustManager:                     Boolean,
+    httpClientCodecMaxChunkSize:                 Int,
+    httpClientCodecInitialBufferSize:            Int,
+    sslEnabledProtocols:                         List[String],
+    sslEnabledCipherSuites:                      List[String],
+    sslSessionCacheSize:                         Int,
+    sslSessionTimeout:                           Int,
+    useOpenSsl:                                  Boolean,
+    useNativeTransport:                          Boolean,
+    tcpNoDelay:                                  Boolean,
+    soReuseAddress:                              Boolean,
+    soLinger:                                    Int,
+    soSndBuf:                                    Int,
+    soRcvBuf:                                    Int,
+    allocator:                                   String,
+    maxThreadLocalCharBufferSize:                Int
 )
 
 case class DnsConfiguration(
-  queryTimeout: Int,
-  maxQueriesPerResolve: Int
+    queryTimeout:         Int,
+    maxQueriesPerResolve: Int
 )
 
 case class SslConfiguration(
-  keyStore:   Option[StoreConfiguration],
-  trustStore: Option[StoreConfiguration]
+    keyStore:   Option[StoreConfiguration],
+    trustStore: Option[StoreConfiguration]
 )
 
 case class StoreConfiguration(
-  storeType: Option[String],
-  file:      String,
-  password:  String,
-  algorithm: Option[String]
+    storeType: Option[String],
+    file:      String,
+    password:  String,
+    algorithm: Option[String]
 )
 
 case class DataConfiguration(
@@ -402,25 +402,25 @@ case class DataConfiguration(
 }
 
 case class FileDataWriterConfiguration(
-  bufferSize: Int
+    bufferSize: Int
 )
 
 case class LeakDataWriterConfiguration(
-  noActivityTimeout: Int
+    noActivityTimeout: Int
 )
 
 case class ConsoleDataWriterConfiguration(
-  light: Boolean
+    light: Boolean
 )
 
 case class GraphiteDataWriterConfiguration(
-  light:          Boolean,
-  host:           String,
-  port:           Int,
-  protocol:       TransportProtocol,
-  rootPathPrefix: String,
-  bufferSize:     Int,
-  writeInterval:  Int
+    light:          Boolean,
+    host:           String,
+    port:           Int,
+    protocol:       TransportProtocol,
+    rootPathPrefix: String,
+    bufferSize:     Int,
+    writeInterval:  Int
 )
 
 // [fl]
@@ -435,15 +435,15 @@ case class GraphiteDataWriterConfiguration(
 // [fl]
 
 case class GatlingConfiguration(
-  core:      CoreConfiguration,
-  charting:  ChartingConfiguration,
-  http:      HttpConfiguration,
-  jms:       JmsConfiguration,
-  data:      DataConfiguration,
-  // [fl]
-  //
-  // [fl]
-  config:    Config
+    core:      CoreConfiguration,
+    charting:  ChartingConfiguration,
+    http:      HttpConfiguration,
+    jms:       JmsConfiguration,
+    data:      DataConfiguration,
+    // [fl]
+    //
+    // [fl]
+    config:    Config
 ) {
   def resolve[T](value: T): T = value
 

--- a/gatling-core/src/main/scala/io/gatling/core/controller/Controller.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/controller/Controller.scala
@@ -39,7 +39,7 @@ object Controller {
 }
 
 class Controller(statsEngine: StatsEngine, throttler: Throttler, simulationParams: SimulationParams, configuration: GatlingConfiguration)
-    extends ControllerFSM {
+  extends ControllerFSM {
 
   import ControllerState._
   import ControllerData._

--- a/gatling-core/src/main/scala/io/gatling/core/controller/inject/Erf.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/controller/inject/Erf.scala
@@ -89,27 +89,27 @@ private[inject] object Erf {
 
   def erfinv(n: Double) = {
 
-      def evalPolynom(p: Seq[Double], x: Double) = p.reduceRight((c, v) => v * x + c)
+    def evalPolynom(p: Seq[Double], x: Double) = p.reduceRight((c, v) => v * x + c)
 
-      def positiveErfinv(u: Double) =
-        u match {
-          case _ if u >= 1.0 => Double.MaxValue
-          case _ if u <= 0.75 =>
-            val t = u * u - 0.5625
-            val v = evalPolynom(invP1, t)
-            val w = evalPolynom(invQ1, t)
-            (v / w) * u
-          case _ if u <= 0.9375 =>
-            val t = u * u - 0.87890625
-            val v = evalPolynom(invP2, t)
-            val w = evalPolynom(invQ2, t)
-            (v / w) * u
-          case _ =>
-            val t = 1.0 / sqrt(-log(1.0 - u))
-            val v = evalPolynom(invP3, t)
-            val w = evalPolynom(invQ3, t)
-            (v / w) / t
-        }
+    def positiveErfinv(u: Double) =
+      u match {
+        case _ if u >= 1.0 => Double.MaxValue
+        case _ if u <= 0.75 =>
+          val t = u * u - 0.5625
+          val v = evalPolynom(invP1, t)
+          val w = evalPolynom(invQ1, t)
+          (v / w) * u
+        case _ if u <= 0.9375 =>
+          val t = u * u - 0.87890625
+          val v = evalPolynom(invP2, t)
+          val w = evalPolynom(invQ2, t)
+          (v / w) * u
+        case _ =>
+          val t = 1.0 / sqrt(-log(1.0 - u))
+          val v = evalPolynom(invP3, t)
+          val w = evalPolynom(invQ3, t)
+          (v / w) / t
+      }
 
     require(abs(n) <= 1.0, s"n=$n is not in [-1, 1]")
 

--- a/gatling-core/src/main/scala/io/gatling/core/controller/inject/InjectionStep.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/controller/inject/InjectionStep.scala
@@ -268,10 +268,10 @@ case class HeavisideInjection(users: Int, duration: FiniteDuration) extends Inje
       AtOnceInjection(users).chain(chained)
 
     } else {
-        def heavisideInv(u: Int): Double = {
-          val x = u.toDouble / (users + 2)
-          Erf.erfinv(2 * x - 1)
-        }
+      def heavisideInv(u: Int): Double = {
+        val x = u.toDouble / (users + 2)
+        Erf.erfinv(2 * x - 1)
+      }
 
       val t0 = abs(heavisideInv(1))
       val d = t0 * 2
@@ -313,10 +313,10 @@ case class PoissonInjection(duration: FiniteDuration, startRate: Double, endRate
 
       // Uses Lewis and Shedler's thinning algorithm: http://www.dtic.mil/dtic/tr/fulltext/u2/a059904.pdf
       val maxLambda = startRate max endRate
-        def shouldKeep(d: Double) = {
-          val actualLambda = startRate + (endRate - startRate) * d / durationSecs
-          rand.nextDouble() < actualLambda / maxLambda
-        }
+      def shouldKeep(d: Double) = {
+        val actualLambda = startRate + (endRate - startRate) * d / durationSecs
+        rand.nextDouble() < actualLambda / maxLambda
+      }
 
       val rawIntervals = Iterator.continually {
         val u = rand.nextDouble()

--- a/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/json/Json.scala
@@ -56,7 +56,7 @@ object Json {
   private def writeArray(iterable: Traversable[_]) = fast"[${iterable.map(elem => fastringify(elem, false)).mkFastring(",")}]"
 
   private def writeMap(map: collection.Map[_, _]) = {
-      def serializeEntry(key: String, value: Any) = fast""""$key":${fastringify(value, false)}"""
+    def serializeEntry(key: String, value: Any) = fast""""$key":${fastringify(value, false)}"""
     fast"{${map.map { case (key, value) => serializeEntry(key.toString, value) }.mkFastring(",")}}"
   }
 }

--- a/gatling-core/src/main/scala/io/gatling/core/protocol/Protocol.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/protocol/Protocol.scala
@@ -62,9 +62,9 @@ class ProtocolComponentsRegistry(system: ActorSystem, coreComponents: CoreCompon
 
   def components(key: ProtocolKey): key.Components = {
 
-      def componentsFactory = componentsFactoryCache.getOrElseUpdate(key, key.newComponents(system, coreComponents)).asInstanceOf[key.Protocol => key.Components]
-      def protocol: key.Protocol = protocolCache.getOrElse(key, protocols.protocols.getOrElse(key.protocolClass, key.defaultProtocolValue(coreComponents.configuration))).asInstanceOf[key.Protocol]
-      def comps = componentsFactory(protocol)
+    def componentsFactory = componentsFactoryCache.getOrElseUpdate(key, key.newComponents(system, coreComponents)).asInstanceOf[key.Protocol => key.Components]
+    def protocol: key.Protocol = protocolCache.getOrElse(key, protocols.protocols.getOrElse(key.protocolClass, key.defaultProtocolValue(coreComponents.configuration))).asInstanceOf[key.Protocol]
+    def comps = componentsFactory(protocol)
 
     componentsCache.getOrElseUpdate(key, comps).asInstanceOf[key.Components]
   }

--- a/gatling-core/src/main/scala/io/gatling/core/session/Session.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/session/Session.scala
@@ -125,14 +125,14 @@ case class Session(
 
   def groupHierarchy: List[String] = {
 
-      @tailrec
-      def gh(blocks: List[Block]): List[String] = blocks match {
-        case Nil => Nil
-        case head :: tail => head match {
-          case g: GroupBlock => g.hierarchy
-          case _             => gh(tail)
-        }
+    @tailrec
+    def gh(blocks: List[Block]): List[String] = blocks match {
+      case Nil => Nil
+      case head :: tail => head match {
+        case g: GroupBlock => g.hierarchy
+        case _             => gh(tail)
       }
+    }
 
     gh(blockStack)
   }

--- a/gatling-core/src/main/scala/io/gatling/core/session/el/ElCompiler.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/session/el/ElCompiler.scala
@@ -69,7 +69,7 @@ case class SizePart(seqPart: Part[Any], name: String) extends Part[Int] {
 
 case class RandomPart(seq: Part[Any], name: String) extends Part[Any] {
   def apply(session: Session): Validation[Any] = {
-      def random(size: Int) = ThreadLocalRandom.current.nextInt(size)
+    def random(size: Int) = ThreadLocalRandom.current.nextInt(size)
 
     seq(session).flatMap {
       case seq: Seq[_]      => seq(random(seq.size)).success
@@ -109,21 +109,21 @@ case class JsonStringify(part: Part[Any], name: String) extends Part[String] {
 case class SeqElementPart(seq: Part[Any], seqName: String, index: String) extends Part[Any] {
   def apply(session: Session): Validation[Any] = {
 
-      def seqElementPart(index: Int): Validation[Any] = seq(session).flatMap {
-        case seq: Seq[_] =>
-          if (seq.isDefinedAt(index)) seq(index).success
-          else ElMessages.undefinedSeqIndex(seqName, index)
+    def seqElementPart(index: Int): Validation[Any] = seq(session).flatMap {
+      case seq: Seq[_] =>
+        if (seq.isDefinedAt(index)) seq(index).success
+        else ElMessages.undefinedSeqIndex(seqName, index)
 
-        case arr: Array[_] =>
-          if (index < arr.length) arr(index).success
-          else ElMessages.undefinedSeqIndex(seqName, index)
+      case arr: Array[_] =>
+        if (index < arr.length) arr(index).success
+        else ElMessages.undefinedSeqIndex(seqName, index)
 
-        case list: JList[_] =>
-          if (index < list.size) list.get(index).success
-          else ElMessages.undefinedSeqIndex(seqName, index)
+      case list: JList[_] =>
+        if (index < list.size) list.get(index).success
+        else ElMessages.undefinedSeqIndex(seqName, index)
 
-        case other => ElMessages.indexAccessNotSupported(other, seqName)
-      }
+      case other => ElMessages.indexAccessNotSupported(other, seqName)
+    }
 
     index match {
       case IntString(i) => seqElementPart(i)
@@ -204,14 +204,14 @@ object ElCompiler {
       val bytes: Expression[Array[Byte]] = part.map(_.toString.getBytes(charset))
     }
 
-      @tailrec
-      def loop(session: Session, bytes: List[Bytes], resolved: List[Array[Byte]]): Validation[Seq[Array[Byte]]] = bytes match {
-        case Nil => resolved.reverse.success
-        case head :: tail => head.bytes(session) match {
-          case Success(bs)      => loop(session, tail, bs :: resolved)
-          case failure: Failure => failure
-        }
+    @tailrec
+    def loop(session: Session, bytes: List[Bytes], resolved: List[Array[Byte]]): Validation[Seq[Array[Byte]]] = bytes match {
+      case Nil => resolved.reverse.success
+      case head :: tail => head.bytes(session) match {
+        case Success(bs)      => loop(session, tail, bs :: resolved)
+        case failure: Failure => failure
       }
+    }
 
     val parts = ElCompiler.parse(string)
     val bytes = parts.map {
@@ -264,8 +264,8 @@ class ElCompiler extends RegexParsers {
       val offset = in.offset
       val end = source.length
 
-        def success(i: Int) = Success(source.subSequence(offset, i).toString, in.drop(i - offset))
-        def failure = Failure("Not a static part", in)
+      def success(i: Int) = Success(source.subSequence(offset, i).toString, in.drop(i - offset))
+      def failure = Failure("Not a static part", in)
 
       source.indexOf("${", offset) match {
         case -1 if offset == end => failure

--- a/gatling-core/src/main/scala/io/gatling/core/session/package.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/session/package.scala
@@ -60,18 +60,18 @@ package object session {
 
   def resolveIterable[X](iterable: Iterable[(String, Expression[X])]): Expression[Seq[(String, X)]] = {
 
-      @tailrec
-      def resolveRec(session: Session, entries: Iterator[(String, Expression[X])], acc: List[(String, X)]): Validation[Seq[(String, X)]] = {
-        if (entries.isEmpty)
-          acc.reverse.success
-        else {
-          val (key, elValue) = entries.next()
-          elValue(session) match {
-            case Success(value)   => resolveRec(session, entries, (key -> value) :: acc)
-            case failure: Failure => failure
-          }
+    @tailrec
+    def resolveRec(session: Session, entries: Iterator[(String, Expression[X])], acc: List[(String, X)]): Validation[Seq[(String, X)]] = {
+      if (entries.isEmpty)
+        acc.reverse.success
+      else {
+        val (key, elValue) = entries.next()
+        elValue(session) match {
+          case Success(value)   => resolveRec(session, entries, (key -> value) :: acc)
+          case failure: Failure => failure
         }
       }
+    }
 
     (session: Session) => resolveRec(session, iterable.iterator, Nil)
   }

--- a/gatling-core/src/main/scala/io/gatling/core/stats/package.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/stats/package.scala
@@ -33,14 +33,14 @@ case class PercentVsTimePlot(time: Int, value: Double) {
 case class PieSlice(name: String, value: Double)
 case class PercentilesVsTimePlot(time: Int, percentiles: Option[Percentiles])
 case class Percentiles(
-  percentile0:   Int,
-  percentile25:  Int,
-  percentile50:  Int,
-  percentile75:  Int,
-  percentile80:  Int,
-  percentile85:  Int,
-  percentile90:  Int,
-  percentile95:  Int,
-  percentile99:  Int,
-  percentile100: Int
+    percentile0:   Int,
+    percentile25:  Int,
+    percentile50:  Int,
+    percentile75:  Int,
+    percentile80:  Int,
+    percentile85:  Int,
+    percentile90:  Int,
+    percentile95:  Int,
+    percentile99:  Int,
+    percentile100: Int
 )

--- a/gatling-core/src/main/scala/io/gatling/core/stats/writer/ConsoleDataWriter.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/stats/writer/ConsoleDataWriter.scala
@@ -39,15 +39,15 @@ class UserCounters(val userCount: Int) {
 class RequestCounters(var successfulCount: Int = 0, var failedCount: Int = 0)
 
 class ConsoleData(
-  val configuration:         GatlingConfiguration,
-  val startUpTime:           Long,
-  var complete:              Boolean                              = false,
-  val usersCounters:         mutable.Map[String, UserCounters]    = mutable.Map.empty[String, UserCounters],
-  val globalRequestCounters: RequestCounters                      = new RequestCounters,
-  val requestsCounters:      mutable.Map[String, RequestCounters] = mutable.LinkedHashMap.empty,
-  val errorsCounters:        mutable.Map[String, Int]             = mutable.LinkedHashMap.empty
+    val configuration:         GatlingConfiguration,
+    val startUpTime:           Long,
+    var complete:              Boolean                              = false,
+    val usersCounters:         mutable.Map[String, UserCounters]    = mutable.Map.empty[String, UserCounters],
+    val globalRequestCounters: RequestCounters                      = new RequestCounters,
+    val requestsCounters:      mutable.Map[String, RequestCounters] = mutable.LinkedHashMap.empty,
+    val errorsCounters:        mutable.Map[String, Int]             = mutable.LinkedHashMap.empty
 )
-    extends DataWriterData
+  extends DataWriterData
 
 class ConsoleDataWriter extends DataWriter[ConsoleData] {
 

--- a/gatling-core/src/main/scala/io/gatling/core/stats/writer/ConsoleSummary.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/stats/writer/ConsoleSummary.scala
@@ -47,44 +47,44 @@ object ConsoleSummary {
     time:                  Date                                 = new Date
   ) = {
 
-      def writeUsersCounters(scenarioName: String, userCounters: UserCounters): Fastring = {
+    def writeUsersCounters(scenarioName: String, userCounters: UserCounters): Fastring = {
 
-        import userCounters._
+      import userCounters._
 
-        val width = OutputLength - 6 // []3d%
+      val width = OutputLength - 6 // []3d%
 
-        val donePercent = floor(100 * doneCount.toDouble / userCount).toInt
-        val done = floor(width * doneCount.toDouble / userCount).toInt
-        val active = ceil(width * activeCount.toDouble / userCount).toInt
-        val waiting = width - done - active
+      val donePercent = floor(100 * doneCount.toDouble / userCount).toInt
+      val done = floor(width * doneCount.toDouble / userCount).toInt
+      val active = ceil(width * activeCount.toDouble / userCount).toInt
+      val waiting = width - done - active
 
-        fast"""${writeSubTitle(scenarioName)}
+      fast"""${writeSubTitle(scenarioName)}
 [${"#" * done}${"-" * active}${" " * waiting}]${donePercent.toString.leftPad(3)}%
           waiting: ${waitingCount.toString.rightPad(6)} / active: ${activeCount.toString.rightPad(6)} / done:${doneCount.toString.rightPad(6)}"""
-      }
+    }
 
-      def writeRequestsCounter(actionName: String, requestCounters: RequestCounters): Fastring = {
+    def writeRequestsCounter(actionName: String, requestCounters: RequestCounters): Fastring = {
 
-        import requestCounters._
-        val maxActionNameLength = OutputLength - 24
+      import requestCounters._
+      val maxActionNameLength = OutputLength - 24
 
-        fast"> ${actionName.truncate(maxActionNameLength - 3).rightPad(maxActionNameLength)} (OK=${successfulCount.toString.rightPad(6)} KO=${failedCount.toString.rightPad(6)})"
-      }
+      fast"> ${actionName.truncate(maxActionNameLength - 3).rightPad(maxActionNameLength)} (OK=${successfulCount.toString.rightPad(6)} KO=${failedCount.toString.rightPad(6)})"
+    }
 
-      def writeDetailedRequestsCounter: Fastring =
-        if (configuration.data.console.light)
-          EmptyFastring
-        else
-          requestsCounters.map { case (actionName, requestCounters) => writeRequestsCounter(actionName, requestCounters) }.mkFastring(Eol)
+    def writeDetailedRequestsCounter: Fastring =
+      if (configuration.data.console.light)
+        EmptyFastring
+      else
+        requestsCounters.map { case (actionName, requestCounters) => writeRequestsCounter(actionName, requestCounters) }.mkFastring(Eol)
 
-      def writeErrors: Fastring =
-        if (errorsCounters.nonEmpty) {
-          val errorsTotal = errorsCounters.values.sum
-          fast"""${writeSubTitle("Errors")}
+    def writeErrors: Fastring =
+      if (errorsCounters.nonEmpty) {
+        val errorsTotal = errorsCounters.values.sum
+        fast"""${writeSubTitle("Errors")}
 ${errorsCounters.toVector.sortBy(-_._2).map { case (message, count) => ConsoleErrorsWriter.writeError(ErrorStats(message, count, errorsTotal)) }.mkFastring(Eol)}
 """
-        } else
-          EmptyFastring
+      } else
+        EmptyFastring
 
     val text = fast"""
 $NewBlock

--- a/gatling-core/src/main/scala/io/gatling/core/stats/writer/DataWriterMessage.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/stats/writer/DataWriterMessage.scala
@@ -42,22 +42,22 @@ case object Stop extends DataWriterMessage
 sealed trait LoadEventMessage extends DataWriterMessage
 
 case class UserMessage(
-  session:   Session,
-  event:     MessageEvent,
-  timestamp: Long
+    session:   Session,
+    event:     MessageEvent,
+    timestamp: Long
 ) extends LoadEventMessage
 
 case class ResponseMessage(
-  scenario:       String,
-  userId:         Long,
-  groupHierarchy: List[String],
-  name:           String,
-  startTimestamp: Long,
-  endTimestamp:   Long,
-  status:         Status,
-  responseCode:   Option[String],
-  message:        Option[String],
-  extraInfo:      List[Any]
+    scenario:       String,
+    userId:         Long,
+    groupHierarchy: List[String],
+    name:           String,
+    startTimestamp: Long,
+    endTimestamp:   Long,
+    status:         Status,
+    responseCode:   Option[String],
+    message:        Option[String],
+    extraInfo:      List[Any]
 ) extends LoadEventMessage
 
 case class GroupMessage(

--- a/gatling-core/src/main/scala/io/gatling/core/structure/ChainBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/structure/ChainBuilder.scala
@@ -28,7 +28,7 @@ object ChainBuilder {
  * @param actionBuilders the builders that represent the chain of actions of a scenario/chain
  */
 case class ChainBuilder(actionBuilders: List[ActionBuilder])
-    extends StructureBuilder[ChainBuilder] {
+  extends StructureBuilder[ChainBuilder] {
 
   private[core] def newInstance(actionBuilders: List[ActionBuilder]) = ChainBuilder(actionBuilders)
 }

--- a/gatling-core/src/main/scala/io/gatling/core/structure/ScenarioBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/structure/ScenarioBuilder.scala
@@ -48,13 +48,13 @@ case class ScenarioBuilder(name: String, actionBuilders: List[ActionBuilder] = N
 }
 
 case class PopulationBuilder(
-  scenarioBuilder:       ScenarioBuilder,
-  injectionProfile:      InjectionProfile,
-  scenarioProtocols:     Protocols              = Protocols(),
-  scenarioThrottleSteps: Iterable[ThrottleStep] = Nil,
-  pauseType:             Option[PauseType]      = None
+    scenarioBuilder:       ScenarioBuilder,
+    injectionProfile:      InjectionProfile,
+    scenarioProtocols:     Protocols              = Protocols(),
+    scenarioThrottleSteps: Iterable[ThrottleStep] = Nil,
+    pauseType:             Option[PauseType]      = None
 )
-    extends LazyLogging {
+  extends LazyLogging {
 
   def protocols(protocols: Protocol*) = copy(scenarioProtocols = this.scenarioProtocols ++ protocols)
 
@@ -102,9 +102,9 @@ case class PopulationBuilder(
 }
 
 case class ScenarioContext(
-  system:                     ActorSystem,
-  coreComponents:             CoreComponents,
-  protocolComponentsRegistry: ProtocolComponentsRegistry,
-  pauseType:                  PauseType,
-  throttled:                  Boolean
+    system:                     ActorSystem,
+    coreComponents:             CoreComponents,
+    protocolComponentsRegistry: ProtocolComponentsRegistry,
+    pauseType:                  PauseType,
+    throttled:                  Boolean
 )

--- a/gatling-core/src/main/scala/io/gatling/core/structure/StructureBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/structure/StructureBuilder.scala
@@ -21,13 +21,13 @@ import io.gatling.core.action.Action
  * This trait defines most of the scenario related DSL
  */
 trait StructureBuilder[B <: StructureBuilder[B]]
-    extends Execs[B]
-    with Pauses[B]
-    with Feeds[B]
-    with Loops[B]
-    with ConditionalStatements[B]
-    with Errors[B]
-    with Groups[B] {
+  extends Execs[B]
+  with Pauses[B]
+  with Feeds[B]
+  with Loops[B]
+  with ConditionalStatements[B]
+  with Errors[B]
+  with Groups[B] {
 
   private[gatling] def build(ctx: ScenarioContext, chainNext: Action): Action =
     actionBuilders.foldLeft(chainNext) { (next, actionBuilder) =>

--- a/gatling-core/src/test/scala/io/gatling/AkkaSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/AkkaSpec.scala
@@ -23,10 +23,10 @@ import akka.testkit.{ TestKit, ImplicitSender }
 import org.scalatest.BeforeAndAfterAll
 
 abstract class AkkaSpec
-    extends TestKit(ActorSystem())
-    with BaseSpec
-    with ImplicitSender
-    with BeforeAndAfterAll {
+  extends TestKit(ActorSystem())
+  with BaseSpec
+  with ImplicitSender
+  with BeforeAndAfterAll {
 
   override def afterAll() = {
     val whenTerminated = system.terminate()

--- a/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionValidatorSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/assertion/AssertionValidatorSpec.scala
@@ -49,23 +49,23 @@ class AssertionValidatorSpec extends BaseSpec with AssertionSupport {
     conditions: Conditions[T],
     stats:      Stats*
   ) = {
-      def mockAssertion(source: GeneralStatsSource) = when(source.assertions) thenReturn conditions.map(_(metric))
+    def mockAssertion(source: GeneralStatsSource) = when(source.assertions) thenReturn conditions.map(_(metric))
 
-      def mockStats(stat: Stats, source: GeneralStatsSource) = {
-        when(source.requestGeneralStats(stat.request, stat.group, stat.status)) thenReturn stat.generalStats
-        stat.group.foreach { group =>
-          when(source.groupCumulatedResponseTimeGeneralStats(group, stat.status)) thenReturn stat.generalStats
-        }
+    def mockStats(stat: Stats, source: GeneralStatsSource) = {
+      when(source.requestGeneralStats(stat.request, stat.group, stat.status)) thenReturn stat.generalStats
+      stat.group.foreach { group =>
+        when(source.groupCumulatedResponseTimeGeneralStats(group, stat.status)) thenReturn stat.generalStats
       }
+    }
 
-      def statsPaths = stats.map(stat => (stat.request, stat.group)).map {
-        case (Some(request), group) => RequestStatsPath(request, group)
-        case (None, Some(group))    => GroupStatsPath(group)
-        case _                      => throw new AssertionError("Can't have neither a request or group stats path")
-      }.toList
+    def statsPaths = stats.map(stat => (stat.request, stat.group)).map {
+      case (Some(request), group) => RequestStatsPath(request, group)
+      case (None, Some(group))    => GroupStatsPath(group)
+      case _                      => throw new AssertionError("Can't have neither a request or group stats path")
+    }.toList
 
-      def mockStatsPath(source: GeneralStatsSource) =
-        when(source.statsPaths) thenReturn statsPaths
+    def mockStatsPath(source: GeneralStatsSource) =
+      when(source.statsPaths) thenReturn statsPaths
 
     val mockedGeneralStatsSource = mock[GeneralStatsSource]
 

--- a/gatling-core/src/test/scala/io/gatling/core/structure/ChainBuilderSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/structure/ChainBuilderSpec.scala
@@ -89,14 +89,14 @@ class ChainBuilderSpec extends BaseSpec with CoreDsl with ScenarioTestFixture {
 
   "tryMax" should "exit wrapped loop" in {
     scenarioTest { implicit ctx =>
-        def message(action: Int, i: Int, j: Int) =
-          s"action$action|$i|$j"
+      def message(action: Int, i: Int, j: Int) =
+        s"action$action|$i|$j"
 
-        def i(session: Session) =
-          session("i").as[Int]
+      def i(session: Session) =
+        session("i").as[Int]
 
-        def j(session: Session) =
-          session("j").as[Int]
+      def j(session: Session) =
+        session("j").as[Int]
 
       val outerGroup = "outerGroup"
       val innerGroup = "innerGroup"

--- a/gatling-http/src/main/scala/io/gatling/http/action/async/polling/PollingStart.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/async/polling/PollingStart.scala
@@ -50,15 +50,15 @@ class PollingStart(
 
   override def execute(session: Session): Unit = recover(session) {
 
-      def startPolling(period: FiniteDuration): Unit = {
-        logger.info(s"Starting poller $pollerName")
-        val pollingActor = system.actorOf(PollerActor.props(pollerName, period, httpRequestDef, responseBuilderFactory, statsEngine), name + "-actor-" + session.userId)
+    def startPolling(period: FiniteDuration): Unit = {
+      logger.info(s"Starting poller $pollerName")
+      val pollingActor = system.actorOf(PollerActor.props(pollerName, period, httpRequestDef, responseBuilderFactory, statsEngine), name + "-actor-" + session.userId)
 
-        val newSession = session.set(pollerName, pollingActor)
+      val newSession = session.set(pollerName, pollingActor)
 
-        pollingActor ! StartPolling(newSession)
-        next ! newSession
-      }
+      pollingActor ! StartPolling(newSession)
+      next ! newSession
+    }
 
     fetchActor(pollerName, session) match {
       case _: Success[_] =>

--- a/gatling-http/src/main/scala/io/gatling/http/action/async/polling/PollingStop.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/async/polling/PollingStop.scala
@@ -22,7 +22,7 @@ import io.gatling.core.util.NameGen
 import io.gatling.http.action.UnnamedRequestAction
 
 class PollingStop(pollerName: String, statsEngine: StatsEngine, val next: Action)
-    extends UnnamedRequestAction(statsEngine) with PollingAction with NameGen {
+  extends UnnamedRequestAction(statsEngine) with PollingAction with NameGen {
 
   override val name = genName("pollingStop")
 

--- a/gatling-http/src/main/scala/io/gatling/http/action/async/sse/SseHandler.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/async/sse/SseHandler.scala
@@ -35,10 +35,10 @@ import org.asynchttpclient.netty.request.NettyRequest
 import org.asynchttpclient.util.HttpConstants.ResponseStatusCodes._
 
 class SseHandler(tx: AsyncTx, sseActor: ActorRef) extends ExtendedAsyncHandler[Unit]
-    with AsyncHandlerExtensions
-    with SseStream
-    with EventStreamDispatcher
-    with StrictLogging {
+  with AsyncHandlerExtensions
+  with SseStream
+  with EventStreamDispatcher
+  with StrictLogging {
 
   private val done = new AtomicBoolean
   private var state: SseState = Opening

--- a/gatling-http/src/main/scala/io/gatling/http/action/async/sse/SseOpen.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/async/sse/SseOpen.scala
@@ -43,11 +43,11 @@ class SseOpen(
 
   override def execute(session: Session): Unit = {
 
-      def open(tx: AsyncTx): Unit = {
-        logger.info(s"Opening and getting sse '$sseName': Scenario '${session.scenario}', UserId #${session.userId}")
-        val sseActor = system.actorOf(SseActor.props(sseName, statsEngine), genName("sseActor"))
-        SseTx.start(tx, sseActor, httpComponents.httpEngine)
-      }
+    def open(tx: AsyncTx): Unit = {
+      logger.info(s"Opening and getting sse '$sseName': Scenario '${session.scenario}', UserId #${session.userId}")
+      val sseActor = system.actorOf(SseActor.props(sseName, statsEngine), genName("sseActor"))
+      SseTx.start(tx, sseActor, httpComponents.httpEngine)
+    }
 
     fetchActor(sseName, session) match {
       case _: Success[_] =>

--- a/gatling-http/src/main/scala/io/gatling/http/action/async/sse/SseStreamDecoder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/async/sse/SseStreamDecoder.scala
@@ -56,29 +56,29 @@ class SseStreamDecoder extends Utf8ByteBufCharsetDecoder {
 
     val lineLength = lineEnd - lineStart
 
-      def onFieldHeaderMatch(fieldHeader: Array[Char]): Option[String] = {
+    def onFieldHeaderMatch(fieldHeader: Array[Char]): Option[String] = {
 
-        val fieldHeaderLength = fieldHeader.length
+      val fieldHeaderLength = fieldHeader.length
 
-        if (lineLength < fieldHeaderLength) {
-          None
+      if (lineLength < fieldHeaderLength) {
+        None
 
-        } else if ((0 until fieldHeaderLength).forall { i => charArray(lineStart + i) == fieldHeader(i) }) {
-          val nextPos = lineStart + fieldHeaderLength
-          val valueStart =
-            if (charArray(nextPos) == ' ') {
-              // white space after colon, trim it
-              nextPos + 1
-            } else {
-              nextPos
-            }
+      } else if ((0 until fieldHeaderLength).forall { i => charArray(lineStart + i) == fieldHeader(i) }) {
+        val nextPos = lineStart + fieldHeaderLength
+        val valueStart =
+          if (charArray(nextPos) == ' ') {
+            // white space after colon, trim it
+            nextPos + 1
+          } else {
+            nextPos
+          }
 
-          Some(new String(charArray, valueStart, lineEnd - valueStart))
+        Some(new String(charArray, valueStart, lineEnd - valueStart))
 
-        } else {
-          None
-        }
+      } else {
+        None
       }
+    }
 
     if (lineLength == 0) {
       // empty line, flushing event

--- a/gatling-http/src/main/scala/io/gatling/http/action/async/ws/WsOpen.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/async/ws/WsOpen.scala
@@ -43,11 +43,11 @@ class WsOpen(
 
   def execute(session: Session): Unit = {
 
-      def open(tx: AsyncTx): Unit = {
-        logger.info(s"Opening websocket '$wsName': Scenario '${session.scenario}', UserId #${session.userId}")
-        val wsActor = system.actorOf(WsActor.props(wsName, statsEngine, httpComponents.httpEngine), genName("wsActor"))
-        WsTx.start(tx, wsActor, httpComponents.httpEngine, statsEngine)
-      }
+    def open(tx: AsyncTx): Unit = {
+      logger.info(s"Opening websocket '$wsName': Scenario '${session.scenario}', UserId #${session.userId}")
+      val wsActor = system.actorOf(WsActor.props(wsName, statsEngine, httpComponents.httpEngine), genName("wsActor"))
+      WsTx.start(tx, wsActor, httpComponents.httpEngine, statsEngine)
+    }
 
     fetchActor(wsName, session) match {
       case _: Success[_] =>

--- a/gatling-http/src/main/scala/io/gatling/http/action/sync/HttpRequestAction.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/sync/HttpRequestAction.scala
@@ -33,7 +33,7 @@ import akka.actor.ActorSystem
  * @param next the next action that will be executed after the request
  */
 class HttpRequestAction(httpRequestDef: HttpRequestDef, system: ActorSystem, val next: Action)
-    extends RequestAction with NameGen {
+  extends RequestAction with NameGen {
 
   import httpRequestDef._
 

--- a/gatling-http/src/main/scala/io/gatling/http/action/sync/HttpTx.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/sync/HttpTx.scala
@@ -38,12 +38,12 @@ object HttpTx extends NameGen with StrictLogging {
 
     val requestPart = request.config.httpComponents.httpProtocol.requestPart
 
-      def silentBecauseProtocolSilentURI: Boolean = requestPart.silentURI match {
-        case Some(silentUri) => silentUri.matcher(request.ahcRequest.getUrl).matches
-        case None            => false
-      }
+    def silentBecauseProtocolSilentURI: Boolean = requestPart.silentURI match {
+      case Some(silentUri) => silentUri.matcher(request.ahcRequest.getUrl).matches
+      case None            => false
+    }
 
-      def silentBecauseProtocolSilentResources = !root && requestPart.silentResources
+    def silentBecauseProtocolSilentResources = !root && requestPart.silentResources
 
     request.config.silent match {
       case None         => silentBecauseProtocolSilentURI || silentBecauseProtocolSilentResources

--- a/gatling-http/src/main/scala/io/gatling/http/action/ws2/fsm/WsActor.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws2/fsm/WsActor.scala
@@ -69,22 +69,22 @@ object WsActor {
 }
 
 class WsActor(
-  val wsName:               String,
-  val connectRequest:       Request,
-  val connectActionName:    String,
-  val connectCheckSequence: List[WsCheckSequence],
-  val onConnected:          Option[Action],
-  val statsEngine:          StatsEngine,
-  val httpEngine:           HttpEngine,
-  val httpProtocol:         HttpProtocol,
-  val configuration:        GatlingConfiguration
+    val wsName:               String,
+    val connectRequest:       Request,
+    val connectActionName:    String,
+    val connectCheckSequence: List[WsCheckSequence],
+    val onConnected:          Option[Action],
+    val statsEngine:          StatsEngine,
+    val httpEngine:           HttpEngine,
+    val httpProtocol:         HttpProtocol,
+    val configuration:        GatlingConfiguration
 ) extends WsActorFSM
-    with WhenInit
-    with WhenConnecting
-    with WhenPerformingCheck
-    with WhenIdle
-    with WhenClosing
-    with WhenCrashed {
+  with WhenInit
+  with WhenConnecting
+  with WhenPerformingCheck
+  with WhenIdle
+  with WhenClosing
+  with WhenCrashed {
 
   private var _timeoutId = 0L
   protected def scheduleTimeout(dur: FiniteDuration): Long = {

--- a/gatling-http/src/main/scala/io/gatling/http/action/ws2/fsm/WsActorFSM.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws2/fsm/WsActorFSM.scala
@@ -35,14 +35,14 @@ sealed trait WsActorData
 case object InitData extends WsActorData
 case class ConnectingData(session: Session, next: Either[Action, SendTextMessage], timestamp: Long, remainingTries: Int) extends WsActorData
 case class PerformingCheckData(
-  webSocket:               WebSocket,
-  currentCheck:            WsCheck,
-  remainingChecks:         List[WsCheck],
-  checkSequenceStart:      Long,
-  checkSequenceTimeoutId:  Long,
-  remainingCheckSequences: List[WsCheckSequence],
-  session:                 Session,
-  next:                    Either[Action, SendTextMessage]
+    webSocket:               WebSocket,
+    currentCheck:            WsCheck,
+    remainingChecks:         List[WsCheck],
+    checkSequenceStart:      Long,
+    checkSequenceTimeoutId:  Long,
+    remainingCheckSequences: List[WsCheckSequence],
+    session:                 Session,
+    next:                    Either[Action, SendTextMessage]
 ) extends WsActorData
 case class IdleData(session: Session, webSocket: WebSocket) extends WsActorData
 case class ClosingData(actionName: String, session: Session, next: Action, timestamp: Long) extends WsActorData

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/AhcRequestBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/AhcRequestBuilder.scala
@@ -19,7 +19,7 @@ import org.asynchttpclient.RequestBuilderBase
 import org.asynchttpclient.uri.Uri
 
 class AhcRequestBuilder(method: String, disableUrlEncoding: Boolean)
-    extends RequestBuilderBase[AhcRequestBuilder](method, disableUrlEncoding, false) {
+  extends RequestBuilderBase[AhcRequestBuilder](method, disableUrlEncoding, false) {
 
   def getUri: Uri = uri
 }

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
@@ -73,6 +73,8 @@ class HttpEngine(
 
       import httpComponents._
 
+      val debugEnabled = logger.underlying.isDebugEnabled
+
       if (httpProtocol.enginePart.perUserNameResolution) {
         // eager load
         val _ = defaultDnsNameResolver
@@ -80,20 +82,25 @@ class HttpEngine(
 
       httpProtocol.warmUpUrl match {
         case Some(url) =>
+          val connectionTimeout: Int = 1000
           val requestBuilder = new RequestBuilder().setUrl(url)
             .setHeader(Accept, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
             .setHeader(AcceptLanguage, "en-US,en;q=0.5")
             .setHeader(AcceptEncoding, "gzip")
             .setHeader(Connection, KeepAlive)
             .setHeader(UserAgent, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:16.0) Gecko/20100101 Firefox/16.0")
-            .setRequestTimeout(1000)
+            .setRequestTimeout(connectionTimeout)
 
           httpProtocol.proxyPart.proxy.foreach(requestBuilder.setProxyServer)
 
           try {
             ahcFactory.defaultAhc.executeRequest(requestBuilder.build).get
           } catch {
-            case NonFatal(e) => logger.info(s"Couldn't execute warm up request $url", e)
+            case NonFatal(e) => if (debugEnabled) {
+              logger.debug(s"Couldn't execute warm up request $url", e)
+            } else {
+              logger.info(s"Couldn't execute warm up request $url after {} ms", connectionTimeout)
+            }
           }
 
         case _ =>

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
@@ -27,6 +27,7 @@ import io.gatling.http.protocol.{ HttpComponents, HttpProtocol }
 import io.gatling.http.request.builder.Http
 import io.gatling.http.resolver.{ CacheOverrideNameResolver, ExtendedDnsNameResolver }
 import io.gatling.http.util.HttpTypeCaster
+import io.gatling.commons.util.Throwables._
 
 import akka.actor.ActorSystem
 import com.typesafe.scalalogging.StrictLogging
@@ -82,14 +83,13 @@ class HttpEngine(
 
       httpProtocol.warmUpUrl match {
         case Some(url) =>
-          val connectionTimeout: Int = 1000
           val requestBuilder = new RequestBuilder().setUrl(url)
             .setHeader(Accept, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
             .setHeader(AcceptLanguage, "en-US,en;q=0.5")
             .setHeader(AcceptEncoding, "gzip")
             .setHeader(Connection, KeepAlive)
             .setHeader(UserAgent, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:16.0) Gecko/20100101 Firefox/16.0")
-            .setRequestTimeout(connectionTimeout)
+            .setRequestTimeout(1000)
 
           httpProtocol.proxyPart.proxy.foreach(requestBuilder.setProxyServer)
 
@@ -99,7 +99,7 @@ class HttpEngine(
             case NonFatal(e) => if (debugEnabled)
               logger.debug(s"Couldn't execute warm up request $url", e)
             else
-              logger.info(s"Couldn't execute warm up request $url after {} ms", connectionTimeout)
+              logger.info(s"Couldn't execute warm up request $url: ${e.detailedMessage}")
           }
 
         case _ =>

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
@@ -96,11 +96,10 @@ class HttpEngine(
           try {
             ahcFactory.defaultAhc.executeRequest(requestBuilder.build).get
           } catch {
-            case NonFatal(e) => if (debugEnabled) {
+            case NonFatal(e) => if (debugEnabled)
               logger.debug(s"Couldn't execute warm up request $url", e)
-            } else {
+            else
               logger.info(s"Couldn't execute warm up request $url after {} ms", connectionTimeout)
-            }
           }
 
         case _ =>

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
@@ -41,11 +41,11 @@ object HttpEngine {
 }
 
 class HttpEngine(
-  system:                       ActorSystem,
-  protected val coreComponents: CoreComponents,
-  ahcFactory:                   AhcFactory
+    system:                       ActorSystem,
+    protected val coreComponents: CoreComponents,
+    ahcFactory:                   AhcFactory
 )
-    extends ResourceFetcher with NameGen with StrictLogging {
+  extends ResourceFetcher with NameGen with StrictLogging {
 
   def defaultDnsNameResolver: ExtendedDnsNameResolver = ahcFactory.defaultDnsNameResolver
 

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/HttpEngine.scala
@@ -74,8 +74,6 @@ class HttpEngine(
 
       import httpComponents._
 
-      val debugEnabled = logger.underlying.isDebugEnabled
-
       if (httpProtocol.enginePart.perUserNameResolution) {
         // eager load
         val _ = defaultDnsNameResolver
@@ -96,7 +94,7 @@ class HttpEngine(
           try {
             ahcFactory.defaultAhc.executeRequest(requestBuilder.build).get
           } catch {
-            case NonFatal(e) => if (debugEnabled)
+            case NonFatal(e) => if (logger.underlying.isDebugEnabled)
               logger.debug(s"Couldn't execute warm up request $url", e)
             else
               logger.info(s"Couldn't execute warm up request $url: ${e.detailedMessage}")

--- a/gatling-http/src/main/scala/io/gatling/http/ahc/ResponseProcessor.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/ahc/ResponseProcessor.scala
@@ -82,21 +82,21 @@ class ResponseProcessor(statsEngine: StatsEngine, httpEngine: HttpEngine, config
   ): Unit =
     if (!tx.silent) {
       val fullRequestName = tx.fullRequestName
-        def dump = {
-          // hack: pre-cache url because it would reset the StringBuilder
-          tx.request.ahcRequest.getUrl
-          val buff = stringBuilder
-          buff.append(Eol).append(">>>>>>>>>>>>>>>>>>>>>>>>>>").append(Eol)
-          buff.append("Request:").append(Eol).append(s"$fullRequestName: $status ${errorMessage.getOrElse("")}").append(Eol)
-          buff.append("=========================").append(Eol)
-          buff.append("Session:").append(Eol).append(tx.session).append(Eol)
-          buff.append("=========================").append(Eol)
-          buff.append("HTTP request:").append(Eol).appendRequest(tx.request.ahcRequest, response.nettyRequest, configuration.core.charset)
-          buff.append("=========================").append(Eol)
-          buff.append("HTTP response:").append(Eol).appendResponse(response).append(Eol)
-          buff.append("<<<<<<<<<<<<<<<<<<<<<<<<<")
-          buff.toString
-        }
+      def dump = {
+        // hack: pre-cache url because it would reset the StringBuilder
+        tx.request.ahcRequest.getUrl
+        val buff = stringBuilder
+        buff.append(Eol).append(">>>>>>>>>>>>>>>>>>>>>>>>>>").append(Eol)
+        buff.append("Request:").append(Eol).append(s"$fullRequestName: $status ${errorMessage.getOrElse("")}").append(Eol)
+        buff.append("=========================").append(Eol)
+        buff.append("Session:").append(Eol).append(tx.session).append(Eol)
+        buff.append("=========================").append(Eol)
+        buff.append("HTTP request:").append(Eol).appendRequest(tx.request.ahcRequest, response.nettyRequest, configuration.core.charset)
+        buff.append("=========================").append(Eol)
+        buff.append("HTTP response:").append(Eol).appendResponse(response).append(Eol)
+        buff.append("<<<<<<<<<<<<<<<<<<<<<<<<<")
+        buff.toString
+      }
 
       if (status == KO) {
         logger.warn(s"Request '$fullRequestName' failed: ${errorMessage.getOrElse("")}")
@@ -195,111 +195,111 @@ class ResponseProcessor(statsEngine: StatsEngine, httpEngine: HttpEngine, config
 
     import tx.request.config.httpComponents._
 
-      def redirectRequest(statusCode: Int, redirectUri: Uri, sessionWithUpdatedCookies: Session): Request = {
-        val originalRequest = tx.request.ahcRequest
-        val originalMethod = originalRequest.getMethod
+    def redirectRequest(statusCode: Int, redirectUri: Uri, sessionWithUpdatedCookies: Session): Request = {
+      val originalRequest = tx.request.ahcRequest
+      val originalMethod = originalRequest.getMethod
 
-        val switchToGet = originalMethod != GET && (statusCode == MOVED_PERMANENTLY_301 || statusCode == SEE_OTHER_303 || (statusCode == FOUND_302 && !httpProtocol.responsePart.strict302Handling))
-        val keepBody = statusCode == TEMPORARY_REDIRECT_307 || statusCode == PERMANENT_REDIRECT_308 || (statusCode == FOUND_302 && httpProtocol.responsePart.strict302Handling)
+      val switchToGet = originalMethod != GET && (statusCode == MOVED_PERMANENTLY_301 || statusCode == SEE_OTHER_303 || (statusCode == FOUND_302 && !httpProtocol.responsePart.strict302Handling))
+      val keepBody = statusCode == TEMPORARY_REDIRECT_307 || statusCode == PERMANENT_REDIRECT_308 || (statusCode == FOUND_302 && httpProtocol.responsePart.strict302Handling)
 
-        val newHeaders = originalRequest.getHeaders
-          .remove(HeaderNames.Host)
-          .remove(HeaderNames.ContentLength)
-          .remove(HeaderNames.Cookie)
+      val newHeaders = originalRequest.getHeaders
+        .remove(HeaderNames.Host)
+        .remove(HeaderNames.ContentLength)
+        .remove(HeaderNames.Cookie)
 
-        if (!keepBody)
-          newHeaders.remove(HeaderNames.ContentType)
+      if (!keepBody)
+        newHeaders.remove(HeaderNames.ContentType)
 
-        val requestBuilder = new AhcRequestBuilder(if (switchToGet) GET else originalMethod, false)
-          .setUri(redirectUri)
-          .setCharset(configuration.core.charset)
-          .setChannelPoolPartitioning(originalRequest.getChannelPoolPartitioning)
-          .setAddress(originalRequest.getAddress)
-          .setNameResolver(originalRequest.getNameResolver)
-          .setVirtualHost(originalRequest.getVirtualHost)
-          .setLocalAddress(originalRequest.getLocalAddress)
-          .setProxyServer(originalRequest.getProxyServer)
-          .setRealm(originalRequest.getRealm)
-          .setHeaders(newHeaders)
+      val requestBuilder = new AhcRequestBuilder(if (switchToGet) GET else originalMethod, false)
+        .setUri(redirectUri)
+        .setCharset(configuration.core.charset)
+        .setChannelPoolPartitioning(originalRequest.getChannelPoolPartitioning)
+        .setAddress(originalRequest.getAddress)
+        .setNameResolver(originalRequest.getNameResolver)
+        .setVirtualHost(originalRequest.getVirtualHost)
+        .setLocalAddress(originalRequest.getLocalAddress)
+        .setProxyServer(originalRequest.getProxyServer)
+        .setRealm(originalRequest.getRealm)
+        .setHeaders(newHeaders)
 
-        if (!httpProtocol.proxyPart.proxyExceptions.contains(redirectUri.getHost)) {
-          val originalRequestProxy = if (originalRequest.getUri.getHost == redirectUri.getHost) Option(originalRequest.getProxyServer) else None
-          val protocolProxy = httpProtocol.proxyPart.proxy
-          originalRequestProxy.orElse(protocolProxy).foreach(requestBuilder.setProxyServer)
-        }
-
-        if (keepBody) {
-          requestBuilder.setCharset(originalRequest.getCharset)
-          if (!originalRequest.getFormParams.isEmpty)
-            requestBuilder.setFormParams(originalRequest.getFormParams)
-          Option(originalRequest.getStringData).foreach(requestBuilder.setBody)
-          Option(originalRequest.getByteData).foreach(requestBuilder.setBody)
-          Option(originalRequest.getCompositeByteData).foreach(requestBuilder.setBody)
-          Option(originalRequest.getByteBufferData).foreach(requestBuilder.setBody)
-          Option(originalRequest.getBodyGenerator).foreach(requestBuilder.setBody)
-        }
-
-        for (cookie <- CookieSupport.getStoredCookies(sessionWithUpdatedCookies, redirectUri))
-          requestBuilder.addCookie(cookie)
-
-        requestBuilder.build
+      if (!httpProtocol.proxyPart.proxyExceptions.contains(redirectUri.getHost)) {
+        val originalRequestProxy = if (originalRequest.getUri.getHost == redirectUri.getHost) Option(originalRequest.getProxyServer) else None
+        val protocolProxy = httpProtocol.proxyPart.proxy
+        originalRequestProxy.orElse(protocolProxy).foreach(requestBuilder.setProxyServer)
       }
 
-      def redirect(statusCode: Int, update: Session => Session): Unit =
-        tx.request.config.maxRedirects match {
-          case Some(maxRedirects) if maxRedirects == tx.redirectCount =>
-            ko(tx, update, response, s"Too many redirects, max is $maxRedirects")
-
-          case _ =>
-            response.header(HeaderNames.Location) match {
-              case Some(location) =>
-                val redirectURI = resolveFromUri(tx.request.ahcRequest.getUri, location)
-
-                val cacheRedirectUpdate =
-                  if (httpProtocol.requestPart.cache)
-                    cacheRedirect(tx.request.ahcRequest, redirectURI)
-                  else
-                    Session.Identity
-
-                val groupUpdate = logGroupRequestUpdate(tx, OK, response.startTimestamp, response.endTimestamp)
-
-                val totalUpdate = update andThen cacheRedirectUpdate andThen groupUpdate
-                val newSession = totalUpdate(tx.session)
-
-                val loggedTx = tx.copy(session = newSession, update = totalUpdate)
-                logRequest(loggedTx, OK, response)
-
-                val newAhcRequest = redirectRequest(statusCode, redirectURI, newSession)
-                val redirectTx = loggedTx.copy(request = loggedTx.request.copy(ahcRequest = newAhcRequest), redirectCount = tx.redirectCount + 1)
-                HttpTx.start(redirectTx)
-
-              case None =>
-                ko(tx, update, response, "Redirect status, yet no Location header")
-            }
-        }
-
-      def cacheRedirect(originalRequest: Request, redirectUri: Uri): Session => Session =
-        response.statusCode match {
-          case Some(code) if HttpHelper.isPermanentRedirect(code) =>
-            httpCaches.addRedirect(_, originalRequest, redirectUri)
-          case _ => Session.Identity
-        }
-
-      def checkAndProceed(sessionUpdate: Session => Session, checks: List[HttpCheck]): Unit = {
-
-        val (checkSaveUpdate, checkError) = Check.check(response, tx.session, checks)
-
-        val status = checkError match {
-          case None => OK
-          case _    => KO
-        }
-
-        val cacheContentUpdate = httpCaches.cacheContent(httpProtocol, tx.request.ahcRequest, response)
-
-        val totalUpdate = sessionUpdate andThen cacheContentUpdate andThen checkSaveUpdate
-
-        logAndExecuteNext(tx, totalUpdate, status, response, checkError.map(_.message))
+      if (keepBody) {
+        requestBuilder.setCharset(originalRequest.getCharset)
+        if (!originalRequest.getFormParams.isEmpty)
+          requestBuilder.setFormParams(originalRequest.getFormParams)
+        Option(originalRequest.getStringData).foreach(requestBuilder.setBody)
+        Option(originalRequest.getByteData).foreach(requestBuilder.setBody)
+        Option(originalRequest.getCompositeByteData).foreach(requestBuilder.setBody)
+        Option(originalRequest.getByteBufferData).foreach(requestBuilder.setBody)
+        Option(originalRequest.getBodyGenerator).foreach(requestBuilder.setBody)
       }
+
+      for (cookie <- CookieSupport.getStoredCookies(sessionWithUpdatedCookies, redirectUri))
+        requestBuilder.addCookie(cookie)
+
+      requestBuilder.build
+    }
+
+    def redirect(statusCode: Int, update: Session => Session): Unit =
+      tx.request.config.maxRedirects match {
+        case Some(maxRedirects) if maxRedirects == tx.redirectCount =>
+          ko(tx, update, response, s"Too many redirects, max is $maxRedirects")
+
+        case _ =>
+          response.header(HeaderNames.Location) match {
+            case Some(location) =>
+              val redirectURI = resolveFromUri(tx.request.ahcRequest.getUri, location)
+
+              val cacheRedirectUpdate =
+                if (httpProtocol.requestPart.cache)
+                  cacheRedirect(tx.request.ahcRequest, redirectURI)
+                else
+                  Session.Identity
+
+              val groupUpdate = logGroupRequestUpdate(tx, OK, response.startTimestamp, response.endTimestamp)
+
+              val totalUpdate = update andThen cacheRedirectUpdate andThen groupUpdate
+              val newSession = totalUpdate(tx.session)
+
+              val loggedTx = tx.copy(session = newSession, update = totalUpdate)
+              logRequest(loggedTx, OK, response)
+
+              val newAhcRequest = redirectRequest(statusCode, redirectURI, newSession)
+              val redirectTx = loggedTx.copy(request = loggedTx.request.copy(ahcRequest = newAhcRequest), redirectCount = tx.redirectCount + 1)
+              HttpTx.start(redirectTx)
+
+            case None =>
+              ko(tx, update, response, "Redirect status, yet no Location header")
+          }
+      }
+
+    def cacheRedirect(originalRequest: Request, redirectUri: Uri): Session => Session =
+      response.statusCode match {
+        case Some(code) if HttpHelper.isPermanentRedirect(code) =>
+          httpCaches.addRedirect(_, originalRequest, redirectUri)
+        case _ => Session.Identity
+      }
+
+    def checkAndProceed(sessionUpdate: Session => Session, checks: List[HttpCheck]): Unit = {
+
+      val (checkSaveUpdate, checkError) = Check.check(response, tx.session, checks)
+
+      val status = checkError match {
+        case None => OK
+        case _    => KO
+      }
+
+      val cacheContentUpdate = httpCaches.cacheContent(httpProtocol, tx.request.ahcRequest, response)
+
+      val totalUpdate = sessionUpdate andThen cacheContentUpdate andThen checkSaveUpdate
+
+      logAndExecuteNext(tx, totalUpdate, status, response, checkError.map(_.message))
+    }
 
     response.status match {
 

--- a/gatling-http/src/main/scala/io/gatling/http/cache/ExpiresSupport.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/cache/ExpiresSupport.scala
@@ -42,20 +42,20 @@ trait ExpiresSupport {
 
   def extractExpiresValue(timestring: String): Option[Long] = {
 
-      def removeQuote(s: String) =
-        if (!s.isEmpty) {
-          var start = 0
-          var end = s.length
+    def removeQuote(s: String) =
+      if (!s.isEmpty) {
+        var start = 0
+        var end = s.length
 
-          if (s.charAt(0) == '"')
-            start += 1
+        if (s.charAt(0) == '"')
+          start += 1
 
-          if (s.charAt(s.length() - 1) == '"')
-            end -= 1
+        if (s.charAt(s.length() - 1) == '"')
+          end -= 1
 
-          s.substring(start, end)
-        } else
-          s
+        s.substring(start, end)
+      } else
+        s
 
     // FIXME use offset instead of 2 substrings
     val trimmedTimeString = removeQuote(timestring.trim)
@@ -64,16 +64,16 @@ trait ExpiresSupport {
   }
 
   def getResponseExpires(response: Response): Option[Long] = {
-      def pragmaNoCache = response.header(HeaderNames.Pragma).exists(_.contains(HeaderValues.NoCache))
-      def cacheControlNoCache = response.header(HeaderNames.CacheControl)
-        .exists(h => h.contains(HeaderValues.NoCache) || h.contains(HeaderValues.NoStore) || h.contains(MaxAgeZero))
-      def maxAgeAsExpiresValue = response.header(HeaderNames.CacheControl).flatMap(extractMaxAgeValue).map { maxAge =>
-        if (maxAge < 0)
-          maxAge
-        else
-          maxAge * 1000 + unpreciseNowMillis
-      }
-      def expiresValue = response.header(HeaderNames.Expires).flatMap(extractExpiresValue).filter(_ > unpreciseNowMillis)
+    def pragmaNoCache = response.header(HeaderNames.Pragma).exists(_.contains(HeaderValues.NoCache))
+    def cacheControlNoCache = response.header(HeaderNames.CacheControl)
+      .exists(h => h.contains(HeaderValues.NoCache) || h.contains(HeaderValues.NoStore) || h.contains(MaxAgeZero))
+    def maxAgeAsExpiresValue = response.header(HeaderNames.CacheControl).flatMap(extractMaxAgeValue).map { maxAge =>
+      if (maxAge < 0)
+        maxAge
+      else
+        maxAge * 1000 + unpreciseNowMillis
+    }
+    def expiresValue = response.header(HeaderNames.Expires).flatMap(extractExpiresValue).filter(_ > unpreciseNowMillis)
 
     if (pragmaNoCache || cacheControlNoCache) {
       None

--- a/gatling-http/src/main/scala/io/gatling/http/cache/HttpCaches.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/cache/HttpCaches.scala
@@ -22,12 +22,12 @@ import io.gatling.core.session.{ Expression, Session }
 import io.gatling.commons.validation.SuccessWrapper
 
 class HttpCaches(val configuration: GatlingConfiguration)
-    extends HttpContentCacheSupport
-    with PermanentRedirectCacheSupport
-    with DnsCacheSupport
-    with LocalAddressSupport
-    with BaseUrlSupport
-    with StrictLogging {
+  extends HttpContentCacheSupport
+  with PermanentRedirectCacheSupport
+  with DnsCacheSupport
+  with LocalAddressSupport
+  with BaseUrlSupport
+  with StrictLogging {
 
   val FlushCache: Expression[Session] = _.removeAll(
     HttpContentCacheSupport.HttpContentCacheAttributeName,

--- a/gatling-http/src/main/scala/io/gatling/http/cache/PermanentRedirectCacheSupport.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/cache/PermanentRedirectCacheSupport.scala
@@ -50,16 +50,16 @@ trait PermanentRedirectCacheSupport {
 
   private[this] def permanentRedirect(session: Session, request: Request): Option[(Uri, Int)] = {
 
-      @tailrec def permanentRedirectRec(from: PermanentRedirectCacheKey, redirectCount: Int): Option[(Uri, Int)] =
+    @tailrec def permanentRedirectRec(from: PermanentRedirectCacheKey, redirectCount: Int): Option[(Uri, Int)] =
 
-        httpPermanentRedirectCacheHandler.getEntry(session, from) match {
-          case Some(toUri) => permanentRedirectRec(new PermanentRedirectCacheKey(toUri, from.cookies), redirectCount + 1)
+      httpPermanentRedirectCacheHandler.getEntry(session, from) match {
+        case Some(toUri) => permanentRedirectRec(new PermanentRedirectCacheKey(toUri, from.cookies), redirectCount + 1)
 
-          case None => redirectCount match {
-            case 0 => None
-            case _ => Some((from.uri, redirectCount))
-          }
+        case None => redirectCount match {
+          case 0 => None
+          case _ => Some((from.uri, redirectCount))
         }
+      }
 
     permanentRedirectRec(PermanentRedirectCacheKey(request), 0)
   }

--- a/gatling-http/src/main/scala/io/gatling/http/check/HttpCheck.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/HttpCheck.scala
@@ -30,7 +30,7 @@ import io.gatling.http.response.{ Response, ResponseBodyUsageStrategy }
  * @param responseBodyUsageStrategy how this check uses the response body
  */
 case class HttpCheck(wrapped: Check[Response], scope: HttpCheckScope, responseBodyUsageStrategy: Option[ResponseBodyUsageStrategy])
-    extends Check[Response] {
+  extends Check[Response] {
   override def check(response: Response, session: Session)(implicit cache: mutable.Map[Any, Any]): Validation[CheckResult] =
     wrapped.check(response, session)
 }

--- a/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncJsonPathCheckBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncJsonPathCheckBuilder.scala
@@ -33,14 +33,14 @@ object AsyncJsonPathCheckBuilder {
 }
 
 class AsyncJsonPathCheckBuilder[X: JsonFilter](
-  private[async] val path:        Expression[String],
-  private[async] val specializer: Specializer[AsyncCheck, String],
-  private[async] val jsonParsers: JsonParsers
+    private[async] val path:        Expression[String],
+    private[async] val specializer: Specializer[AsyncCheck, String],
+    private[async] val jsonParsers: JsonParsers
 )(implicit extractorFactory: OldJsonPathExtractorFactory)
-    extends OldDefaultMultipleFindCheckBuilder[AsyncCheck, String, Any, X](
-      specializer,
-      jsonParsers.safeParse
-    ) {
+  extends OldDefaultMultipleFindCheckBuilder[AsyncCheck, String, Any, X](
+    specializer,
+    jsonParsers.safeParse
+  ) {
 
   import extractorFactory._
 

--- a/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncJsonpJsonPathCheckBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncJsonpJsonPathCheckBuilder.scala
@@ -37,11 +37,11 @@ object AsyncJsonpJsonPathCheckBuilder {
 }
 
 class AsyncJsonpJsonPathCheckBuilder[X: JsonFilter](
-  private[async] val path:        Expression[String],
-  private[async] val specializer: Specializer[AsyncCheck, String],
-  private[async] val jsonParsers: JsonParsers
+    private[async] val path:        Expression[String],
+    private[async] val specializer: Specializer[AsyncCheck, String],
+    private[async] val jsonParsers: JsonParsers
 )(implicit extractorFactory: OldJsonPathExtractorFactory)
-    extends OldDefaultMultipleFindCheckBuilder[AsyncCheck, String, Any, X](specializer, AsyncJsonpJsonPathCheckBuilder.asyncJsonpPreparer(jsonParsers)) {
+  extends OldDefaultMultipleFindCheckBuilder[AsyncCheck, String, Any, X](specializer, AsyncJsonpJsonPathCheckBuilder.asyncJsonpPreparer(jsonParsers)) {
 
   import extractorFactory._
 

--- a/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncRegexCheckBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/async/AsyncRegexCheckBuilder.scala
@@ -33,10 +33,10 @@ object AsyncRegexCheckBuilder {
 }
 
 class AsyncRegexCheckBuilder[X: GroupExtractor](
-  private[async] val expression:  Expression[String],
-  private[async] val specializer: Specializer[AsyncCheck, String]
+    private[async] val expression:  Expression[String],
+    private[async] val specializer: Specializer[AsyncCheck, String]
 )(implicit extractorFactory: OldRegexExtractorFactory)
-    extends OldDefaultMultipleFindCheckBuilder[AsyncCheck, String, CharSequence, X](specializer, PassThroughMessagePreparer) {
+  extends OldDefaultMultipleFindCheckBuilder[AsyncCheck, String, CharSequence, X](specializer, PassThroughMessagePreparer) {
 
   import extractorFactory._
 

--- a/gatling-http/src/main/scala/io/gatling/http/check/header/HttpHeaderRegexCheckBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/header/HttpHeaderRegexCheckBuilder.scala
@@ -38,11 +38,11 @@ object HttpHeaderRegexCheckBuilder {
 }
 
 class HttpHeaderRegexCheckBuilder[X: GroupExtractor](
-  private[header] val headerName: Expression[String],
-  private[header] val pattern:    Expression[String],
-  private[header] val patterns:   Patterns
+    private[header] val headerName: Expression[String],
+    private[header] val pattern:    Expression[String],
+    private[header] val patterns:   Patterns
 )
-    extends DefaultMultipleFindCheckBuilder[HttpHeaderRegexCheckType, Response, X] {
+  extends DefaultMultipleFindCheckBuilder[HttpHeaderRegexCheckType, Response, X] {
 
   import HttpHeaderRegexExtractorFactory._
 

--- a/gatling-http/src/main/scala/io/gatling/http/check/url/CurrentLocationRegexCheckBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/check/url/CurrentLocationRegexCheckBuilder.scala
@@ -39,10 +39,10 @@ object CurrentLocationRegexCheckBuilder {
 }
 
 class CurrentLocationRegexCheckBuilder[X: GroupExtractor](
-  private[url] val pattern:  Expression[String],
-  private[url] val patterns: Patterns
+    private[url] val pattern:  Expression[String],
+    private[url] val patterns: Patterns
 )
-    extends DefaultMultipleFindCheckBuilder[CurrentLocationRegexCheckType, CharSequence, X] {
+  extends DefaultMultipleFindCheckBuilder[CurrentLocationRegexCheckType, CharSequence, X] {
 
   import CurrentLocationRegexCheckBuilder.ExtractorFactory._
 

--- a/gatling-http/src/main/scala/io/gatling/http/cookie/CookieJar.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/cookie/CookieJar.scala
@@ -45,11 +45,11 @@ object CookieJar {
   // rfc6265#section-5.2.4
   private def cookiePath(rawCookiePath: Option[String], requestPath: String) = {
 
-      // rfc6265#section-5.1.4
-      def defaultCookiePath() = requestPath match {
-        case p if !p.isEmpty && p.charAt(0) == '/' && p.count(_ == '/') > 1 => p.substring(0, p.lastIndexOf('/'))
-        case _ => "/"
-      }
+    // rfc6265#section-5.1.4
+    def defaultCookiePath() = requestPath match {
+      case p if !p.isEmpty && p.charAt(0) == '/' && p.count(_ == '/') > 1 => p.substring(0, p.lastIndexOf('/'))
+      case _ => "/"
+    }
 
     rawCookiePath match {
       case Some(path) if !path.isEmpty && path.charAt(0) == '/' => path
@@ -117,10 +117,10 @@ case class CookieJar(store: Map[CookieKey, StoredCookie]) {
     if (store.isEmpty) {
       Nil
     } else {
-        def isCookieMatching(key: CookieKey, storedCookie: StoredCookie) =
-          domainsMatch(key.domain, domain, storedCookie.hostOnly) &&
-            pathsMatch(key.path, path) &&
-            !isSecuredUri.exists(secured => !secured && storedCookie.cookie.isSecure)
+      def isCookieMatching(key: CookieKey, storedCookie: StoredCookie) =
+        domainsMatch(key.domain, domain, storedCookie.hostOnly) &&
+          pathsMatch(key.path, path) &&
+          !isSecuredUri.exists(secured => !secured && storedCookie.cookie.isSecure)
 
       val matchingCookies = store.filter {
         case (key, storedCookie) => isCookieMatching(key, storedCookie)

--- a/gatling-http/src/main/scala/io/gatling/http/fetch/CssParser.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/fetch/CssParser.scala
@@ -47,58 +47,58 @@ object CssParser extends StrictLogging {
       var protectChar: Option[Char] = None
       var broken = false
 
-        @tailrec
-        def trimLeft(cur: Int): Int =
-          if (cur == end)
-            cur
-          else
-            (string.charAt(cur): @switch) match {
-              case ' ' | '\r' | '\n' => trimLeft(cur + 1)
-              case '\'' =>
-                protectChar match {
-                  case None =>
-                    protectChar = SingleQuoteEscapeChar
-                    trimLeft(cur + 1)
-                  case _ =>
-                    broken = true
-                    cur
+      @tailrec
+      def trimLeft(cur: Int): Int =
+        if (cur == end)
+          cur
+        else
+          (string.charAt(cur): @switch) match {
+            case ' ' | '\r' | '\n' => trimLeft(cur + 1)
+            case '\'' =>
+              protectChar match {
+                case None =>
+                  protectChar = SingleQuoteEscapeChar
+                  trimLeft(cur + 1)
+                case _ =>
+                  broken = true
+                  cur
 
-                }
-              case '"' =>
-                protectChar match {
-                  case None =>
-                    protectChar = DoubleQuoteEscapeChar
-                    trimLeft(cur + 1)
-                  case _ =>
-                    broken = true
-                    cur
-                }
-              case _ => cur
-            }
-
-        @tailrec
-        def trimRight(cur: Int, leftLimit: Int): Int =
-          if (cur == leftLimit)
-            cur
-          else
-            (string.charAt(cur - 1): @switch) match {
-              case ' ' | '\r' | '\n' => trimRight(cur - 1, leftLimit)
-              case '\'' => protectChar match {
-                case `SingleQuoteEscapeChar` =>
-                  trimRight(cur - 1, leftLimit)
+              }
+            case '"' =>
+              protectChar match {
+                case None =>
+                  protectChar = DoubleQuoteEscapeChar
+                  trimLeft(cur + 1)
                 case _ =>
                   broken = true
                   cur
               }
-              case '"' => protectChar match {
-                case `DoubleQuoteEscapeChar` =>
-                  trimRight(cur - 1, leftLimit)
-                case _ =>
-                  broken = true
-                  cur
-              }
-              case _ => cur
+            case _ => cur
+          }
+
+      @tailrec
+      def trimRight(cur: Int, leftLimit: Int): Int =
+        if (cur == leftLimit)
+          cur
+        else
+          (string.charAt(cur - 1): @switch) match {
+            case ' ' | '\r' | '\n' => trimRight(cur - 1, leftLimit)
+            case '\'' => protectChar match {
+              case `SingleQuoteEscapeChar` =>
+                trimRight(cur - 1, leftLimit)
+              case _ =>
+                broken = true
+                cur
             }
+            case '"' => protectChar match {
+              case `DoubleQuoteEscapeChar` =>
+                trimRight(cur - 1, leftLimit)
+              case _ =>
+                broken = true
+                cur
+            }
+            case _ => cur
+          }
 
       val trimmedStart = trimLeft(start)
       val trimmedEnd = trimRight(end, trimmedStart)
@@ -124,21 +124,21 @@ object CssParser extends StrictLogging {
     var withinUrl = false
     var urlStart = 0
 
-      def charsMatch(i: Int, chars: Array[Char]): Boolean = {
+    def charsMatch(i: Int, chars: Array[Char]): Boolean = {
 
-          @tailrec
-          def charsMatchRec(j: Int): Boolean = {
-            if (j == chars.length)
-              true
-            else if (cssContent.charAt(i + j) != chars(j))
-              false
-            else
-              charsMatchRec(j + 1)
+      @tailrec
+      def charsMatchRec(j: Int): Boolean = {
+        if (j == chars.length)
+          true
+        else if (cssContent.charAt(i + j) != chars(j))
+          false
+        else
+          charsMatchRec(j + 1)
 
-          }
-
-        i < cssContent.length - chars.length && charsMatchRec(1)
       }
+
+      i < cssContent.length - chars.length && charsMatchRec(1)
+    }
 
     var i = 0
     while (i < cssContent.length) {

--- a/gatling-http/src/main/scala/io/gatling/http/fetch/ResourceFetcher.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/fetch/ResourceFetcher.scala
@@ -79,11 +79,11 @@ trait ResourceFetcher {
     val httpComponents = config.httpComponents
     val httpProtocol = httpComponents.httpProtocol
 
-      def inferredResourcesRequests(): List[HttpRequest] = {
-        val inferred = new HtmlParser().getEmbeddedResources(htmlDocumentUri, response.body.string, UserAgent.getAgent(request))
-        val filtered = applyResourceFilters(inferred, httpProtocol.responsePart.htmlResourcesInferringFilters)
-        resourcesToRequests(filtered, session, coreComponents, httpComponents, config.throttled)
-      }
+    def inferredResourcesRequests(): List[HttpRequest] = {
+      val inferred = new HtmlParser().getEmbeddedResources(htmlDocumentUri, response.body.string, UserAgent.getAgent(request))
+      val filtered = applyResourceFilters(inferred, httpProtocol.responsePart.htmlResourcesInferringFilters)
+      resourcesToRequests(filtered, session, coreComponents, httpComponents, config.throttled)
+    }
 
     response.statusCode match {
       case Some(200) =>
@@ -244,13 +244,13 @@ class ResourceFetcherActor(rootTx: HttpTx, initialResources: Seq[HttpRequest]) e
 
   private def fetchOrBufferResources(resources: Iterable[HttpRequest]): Unit = {
 
-      def fetchResources(host: String, resources: Iterable[HttpRequest]): Unit = {
-        resources.foreach(fetchResource)
-        availableTokensByHost += host -> (availableTokensByHost(host) - resources.size)
-      }
+    def fetchResources(host: String, resources: Iterable[HttpRequest]): Unit = {
+      resources.foreach(fetchResource)
+      availableTokensByHost += host -> (availableTokensByHost(host) - resources.size)
+    }
 
-      def bufferResources(host: String, resources: Iterable[HttpRequest]): Unit =
-        bufferedResourcesByHost += host -> (bufferedResourcesByHost(host) ::: resources.toList)
+    def bufferResources(host: String, resources: Iterable[HttpRequest]): Unit =
+      bufferedResourcesByHost += host -> (bufferedResourcesByHost(host) ::: resources.toList)
 
     alreadySeen ++= resources.map(_.ahcRequest.getUri)
     pendingResourcesCount += resources.size
@@ -289,29 +289,29 @@ class ResourceFetcherActor(rootTx: HttpTx, initialResources: Seq[HttpRequest]) e
 
   private def resourceFetched(uri: Uri, status: Status, silent: Boolean): Unit = {
 
-      def releaseToken(host: String): Unit =
-        bufferedResourcesByHost.get(uri.getHost) match {
-          case Some(Nil) | None =>
-            // nothing to send for this host for now
-            availableTokensByHost += host -> (availableTokensByHost(host) + 1)
+    def releaseToken(host: String): Unit =
+      bufferedResourcesByHost.get(uri.getHost) match {
+        case Some(Nil) | None =>
+          // nothing to send for this host for now
+          availableTokensByHost += host -> (availableTokensByHost(host) + 1)
 
-          case Some(request :: tail) =>
-            bufferedResourcesByHost += host -> tail
-            val ahcRequest = request.ahcRequest
-            httpCaches.contentCacheEntry(session, ahcRequest) match {
-              case None =>
-                // recycle token, fetch a buffered resource
-                fetchResource(request)
+        case Some(request :: tail) =>
+          bufferedResourcesByHost += host -> tail
+          val ahcRequest = request.ahcRequest
+          httpCaches.contentCacheEntry(session, ahcRequest) match {
+            case None =>
+              // recycle token, fetch a buffered resource
+              fetchResource(request)
 
-              case Some(ContentCacheEntry(Some(expire), _, _)) if unpreciseNowMillis > expire =>
-                // expire reached
-                session = httpCaches.clearContentCache(session, ahcRequest)
-                fetchResource(request)
+            case Some(ContentCacheEntry(Some(expire), _, _)) if unpreciseNowMillis > expire =>
+              // expire reached
+              session = httpCaches.clearContentCache(session, ahcRequest)
+              fetchResource(request)
 
-              case _ =>
-                handleCachedResource(request)
-            }
-        }
+            case _ =>
+              handleCachedResource(request)
+          }
+      }
 
     logger.debug(s"Resource $uri was fetched")
     pendingResourcesCount -= 1
@@ -327,12 +327,12 @@ class ResourceFetcherActor(rootTx: HttpTx, initialResources: Seq[HttpRequest]) e
 
   private def cssFetched(uri: Uri, status: Status, statusCode: Option[Int], lastModifiedOrEtag: Option[String], content: String): Unit = {
 
-      def parseCssResources(): List[HttpRequest] = {
-        val computer = CssParser.extractResources(_: Uri, content)
-        val inferred = httpEngine.CssContentCache.computeIfAbsent(uri, computer.asJava)
-        val filtered = httpEngine.applyResourceFilters(inferred, filters)
-        httpEngine.resourcesToRequests(filtered, session, coreComponents, httpComponents, throttled)
-      }
+    def parseCssResources(): List[HttpRequest] = {
+      val computer = CssParser.extractResources(_: Uri, content)
+      val inferred = httpEngine.CssContentCache.computeIfAbsent(uri, computer.asJava)
+      val filtered = httpEngine.applyResourceFilters(inferred, filters)
+      httpEngine.resourcesToRequests(filtered, session, coreComponents, httpComponents, throttled)
+    }
 
     if (status == OK) {
       // this css might contain some resources

--- a/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
@@ -139,37 +139,37 @@ case class HttpProtocol(
 }
 
 case class HttpProtocolEnginePart(
-  shareClient:           Boolean,
-  shareConnections:      Boolean,
-  maxConnectionsPerHost: Int,
-  perUserNameResolution: Boolean,
-  hostNameAliases:       Map[String, InetAddress],
-  virtualHost:           Option[Expression[String]],
-  localAddresses:        List[InetAddress]
+    shareClient:           Boolean,
+    shareConnections:      Boolean,
+    maxConnectionsPerHost: Int,
+    perUserNameResolution: Boolean,
+    hostNameAliases:       Map[String, InetAddress],
+    virtualHost:           Option[Expression[String]],
+    localAddresses:        List[InetAddress]
 )
 
 case class HttpProtocolRequestPart(
-  headers:             Map[String, Expression[String]],
-  realm:               Option[Expression[Realm]],
-  autoReferer:         Boolean,
-  cache:               Boolean,
-  disableUrlEncoding:  Boolean,
-  silentURI:           Option[Pattern],
-  silentResources:     Boolean,
-  signatureCalculator: Option[Expression[SignatureCalculator]]
+    headers:             Map[String, Expression[String]],
+    realm:               Option[Expression[Realm]],
+    autoReferer:         Boolean,
+    cache:               Boolean,
+    disableUrlEncoding:  Boolean,
+    silentURI:           Option[Pattern],
+    silentResources:     Boolean,
+    signatureCalculator: Option[Expression[SignatureCalculator]]
 )
 
 case class HttpProtocolResponsePart(
-  followRedirect:                Boolean,
-  maxRedirects:                  Option[Int],
-  strict302Handling:             Boolean,
-  discardResponseChunks:         Boolean,
-  responseTransformer:           Option[PartialFunction[Response, Response]],
-  checks:                        List[HttpCheck],
-  extraInfoExtractor:            Option[ExtraInfoExtractor],
-  inferHtmlResources:            Boolean,
-  inferredHtmlResourcesNaming:   Uri => String,
-  htmlResourcesInferringFilters: Option[Filters]
+    followRedirect:                Boolean,
+    maxRedirects:                  Option[Int],
+    strict302Handling:             Boolean,
+    discardResponseChunks:         Boolean,
+    responseTransformer:           Option[PartialFunction[Response, Response]],
+    checks:                        List[HttpCheck],
+    extraInfoExtractor:            Option[ExtraInfoExtractor],
+    inferHtmlResources:            Boolean,
+    inferredHtmlResourcesNaming:   Uri => String,
+    htmlResourcesInferringFilters: Option[Filters]
 )
 
 case class HttpProtocolWsPart(
@@ -200,6 +200,6 @@ case class HttpProtocolWsPart(
 }
 
 case class HttpProtocolProxyPart(
-  proxy:           Option[ProxyServer],
-  proxyExceptions: Seq[String]
+    proxy:           Option[ProxyServer],
+    proxyExceptions: Seq[String]
 )

--- a/gatling-http/src/main/scala/io/gatling/http/protocol/Proxy.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/protocol/Proxy.scala
@@ -18,8 +18,8 @@ package io.gatling.http.protocol
 import io.gatling.commons.model.Credentials
 
 case class Proxy(
-  host:        String,
-  port:        Int,
-  securePort:  Int,
-  credentials: Option[Credentials] = None
+    host:        String,
+    port:        Int,
+    securePort:  Int,
+    credentials: Option[Credentials] = None
 )

--- a/gatling-http/src/main/scala/io/gatling/http/request/ExtraInfo.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/ExtraInfo.scala
@@ -22,9 +22,9 @@ import io.gatling.http.response.Response
 import org.asynchttpclient.Request
 
 case class ExtraInfo(
-  requestName: String,
-  status:      Status,
-  session:     Session,
-  request:     Request,
-  response:    Response
+    requestName: String,
+    status:      Status,
+    session:     Session,
+    request:     Request,
+    response:    Response
 )

--- a/gatling-http/src/main/scala/io/gatling/http/request/HttpRequest.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/HttpRequest.scala
@@ -25,17 +25,17 @@ import io.gatling.http.response.Response
 import org.asynchttpclient.Request
 
 case class HttpRequestConfig(
-  checks:                List[HttpCheck],
-  responseTransformer:   Option[PartialFunction[Response, Response]],
-  extraInfoExtractor:    Option[ExtraInfoExtractor],
-  maxRedirects:          Option[Int],
-  throttled:             Boolean,
-  silent:                Option[Boolean],
-  followRedirect:        Boolean,
-  discardResponseChunks: Boolean,
-  coreComponents:        CoreComponents,
-  httpComponents:        HttpComponents,
-  explicitResources:     List[HttpRequestDef]
+    checks:                List[HttpCheck],
+    responseTransformer:   Option[PartialFunction[Response, Response]],
+    extraInfoExtractor:    Option[ExtraInfoExtractor],
+    maxRedirects:          Option[Int],
+    throttled:             Boolean,
+    silent:                Option[Boolean],
+    followRedirect:        Boolean,
+    discardResponseChunks: Boolean,
+    coreComponents:        CoreComponents,
+    httpComponents:        HttpComponents,
+    explicitResources:     List[HttpRequestDef]
 )
 
 case class HttpRequestDef(

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestBuilder.scala
@@ -29,18 +29,18 @@ import io.gatling.http.response.Response
 import com.softwaremill.quicklens._
 
 case class HttpAttributes(
-  checks:                List[HttpCheck]                             = Nil,
-  ignoreDefaultChecks:   Boolean                                     = false,
-  silent:                Option[Boolean]                             = None,
-  followRedirect:        Boolean                                     = true,
-  discardResponseChunks: Boolean                                     = true,
-  responseTransformer:   Option[PartialFunction[Response, Response]] = None,
-  explicitResources:     List[HttpRequestBuilder]                    = Nil,
-  body:                  Option[Body]                                = None,
-  bodyParts:             List[BodyPart]                              = Nil,
-  formParams:            List[HttpParam]                             = Nil,
-  form:                  Option[Expression[Map[String, Any]]]        = None,
-  extraInfoExtractor:    Option[ExtraInfoExtractor]                  = None
+    checks:                List[HttpCheck]                             = Nil,
+    ignoreDefaultChecks:   Boolean                                     = false,
+    silent:                Option[Boolean]                             = None,
+    followRedirect:        Boolean                                     = true,
+    discardResponseChunks: Boolean                                     = true,
+    responseTransformer:   Option[PartialFunction[Response, Response]] = None,
+    explicitResources:     List[HttpRequestBuilder]                    = Nil,
+    body:                  Option[Body]                                = None,
+    bodyParts:             List[BodyPart]                              = Nil,
+    formParams:            List[HttpParam]                             = Nil,
+    form:                  Option[Expression[Map[String, Any]]]        = None,
+    extraInfoExtractor:    Option[ExtraInfoExtractor]                  = None
 )
 
 object HttpRequestBuilder {

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestExpressionBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestExpressionBuilder.scala
@@ -34,7 +34,7 @@ import org.asynchttpclient.request.body.generator.InputStreamBodyGenerator
 import org.asynchttpclient.request.body.multipart.StringPart
 
 class HttpRequestExpressionBuilder(commonAttributes: CommonAttributes, httpAttributes: HttpAttributes, coreComponents: CoreComponents, httpComponents: HttpComponents)
-    extends RequestExpressionBuilder(commonAttributes, coreComponents, httpComponents) {
+  extends RequestExpressionBuilder(commonAttributes, coreComponents, httpComponents) {
 
   import RequestExpressionBuilder._
 
@@ -59,33 +59,33 @@ class HttpRequestExpressionBuilder(commonAttributes: CommonAttributes, httpAttri
   private val configureParts0: RequestBuilderConfigure =
     session => requestBuilder => {
 
-        def setBody(body: Body): Validation[AhcRequestBuilder] =
-          body match {
-            case StringBody(string) => string(session).map(requestBuilder.setBody)
-            case RawFileBody(resourceWithCachedBytes) => resourceWithCachedBytes(session).map {
-              case ResourceAndCachedBytes(resource, cachedBytes) =>
-                cachedBytes match {
-                  case Some(bytes) => requestBuilder.setBody(bytes)
-                  case None =>
-                    resource match {
-                      case FileResource(_, file) => requestBuilder.setBody(file)
-                      case _                     => requestBuilder.setBody(resource.bytes)
-                    }
-                }
-            }
-            case ByteArrayBody(bytes)             => bytes(session).map(requestBuilder.setBody)
-            case CompositeByteArrayBody(bytes, _) => bytes(session).map(bs => requestBuilder.setBody(bs.asJava))
-            case InputStreamBody(is)              => is(session).map(is => requestBuilder.setBody(new InputStreamBodyGenerator(is)))
-            case body: PebbleBody                 => body.apply(session).map(requestBuilder.setBody)
+      def setBody(body: Body): Validation[AhcRequestBuilder] =
+        body match {
+          case StringBody(string) => string(session).map(requestBuilder.setBody)
+          case RawFileBody(resourceWithCachedBytes) => resourceWithCachedBytes(session).map {
+            case ResourceAndCachedBytes(resource, cachedBytes) =>
+              cachedBytes match {
+                case Some(bytes) => requestBuilder.setBody(bytes)
+                case None =>
+                  resource match {
+                    case FileResource(_, file) => requestBuilder.setBody(file)
+                    case _                     => requestBuilder.setBody(resource.bytes)
+                  }
+              }
           }
+          case ByteArrayBody(bytes)             => bytes(session).map(requestBuilder.setBody)
+          case CompositeByteArrayBody(bytes, _) => bytes(session).map(bs => requestBuilder.setBody(bs.asJava))
+          case InputStreamBody(is)              => is(session).map(is => requestBuilder.setBody(new InputStreamBodyGenerator(is)))
+          case body: PebbleBody                 => body.apply(session).map(requestBuilder.setBody)
+        }
 
-        def setBodyParts(bodyParts: List[BodyPart]): Validation[AhcRequestBuilder] =
-          bodyParts.foldLeft(requestBuilder.success) { (requestBuilder, part) =>
-            for {
-              requestBuilder <- requestBuilder
-              part <- part.toMultiPart(session)
-            } yield requestBuilder.addBodyPart(part)
-          }
+      def setBodyParts(bodyParts: List[BodyPart]): Validation[AhcRequestBuilder] =
+        bodyParts.foldLeft(requestBuilder.success) { (requestBuilder, part) =>
+          for {
+            requestBuilder <- requestBuilder
+            part <- part.toMultiPart(session)
+          } yield requestBuilder.addBodyPart(part)
+        }
 
       httpAttributes.body match {
         case None       => setBodyParts(httpAttributes.bodyParts)

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestBuilder.scala
@@ -32,16 +32,16 @@ import org.asynchttpclient.proxy._
 import org.asynchttpclient.uri.Uri
 
 case class CommonAttributes(
-  requestName:         Expression[String],
-  method:              String,
-  urlOrURI:            Either[Expression[String], Uri],
-  disableUrlEncoding:  Option[Boolean]                         = None,
-  queryParams:         List[HttpParam]                         = Nil,
-  headers:             Map[String, Expression[String]]         = Map.empty,
-  realm:               Option[Expression[Realm]]               = None,
-  virtualHost:         Option[Expression[String]]              = None,
-  proxy:               Option[ProxyServer]                     = None,
-  signatureCalculator: Option[Expression[SignatureCalculator]] = None
+    requestName:         Expression[String],
+    method:              String,
+    urlOrURI:            Either[Expression[String], Uri],
+    disableUrlEncoding:  Option[Boolean]                         = None,
+    queryParams:         List[HttpParam]                         = Nil,
+    headers:             Map[String, Expression[String]]         = Map.empty,
+    realm:               Option[Expression[Realm]]               = None,
+    virtualHost:         Option[Expression[String]]              = None,
+    proxy:               Option[ProxyServer]                     = None,
+    signatureCalculator: Option[Expression[SignatureCalculator]] = None
 )
 
 object RequestBuilder {
@@ -58,10 +58,12 @@ object RequestBuilder {
   val AllHeaderHeaderValueExpression = "*/*".expressionSuccess
   val CssHeaderHeaderValueExpression = "text/css,*/*;q=0.1".expressionSuccess
 
-  def oauth1SignatureCalculator(consumerKey: Expression[String],
-                               clientSharedSecret: Expression[String],
-                               token: Expression[String],
-                               tokenSecret: Expression[String]): Expression[SignatureCalculator] = session =>
+  def oauth1SignatureCalculator(
+    consumerKey:        Expression[String],
+    clientSharedSecret: Expression[String],
+    token:              Expression[String],
+    tokenSecret:        Expression[String]
+  ): Expression[SignatureCalculator] = session =>
     for {
       ck <- consumerKey(session)
       css <- clientSharedSecret(session)

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestExpressionBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/RequestExpressionBuilder.scala
@@ -42,7 +42,7 @@ object RequestExpressionBuilder {
 }
 
 abstract class RequestExpressionBuilder(commonAttributes: CommonAttributes, coreComponents: CoreComponents, httpComponents: HttpComponents)
-    extends LazyLogging {
+  extends LazyLogging {
 
   import RequestExpressionBuilder._
   protected val protocol = httpComponents.httpProtocol

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/package.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/package.scala
@@ -62,52 +62,52 @@ package object builder {
 
     def resolveParamJList(session: Session): Validation[JList[Param]] = {
 
-        def update(ahcParams: JList[Param], param: HttpParam): Validation[JList[Param]] = param match {
-          case SimpleParam(key, value) =>
-            for {
-              key <- key(session)
-              value <- value(session)
-            } yield {
-              ahcParams.add(new Param(key, value.toString))
-              ahcParams
-            }
+      def update(ahcParams: JList[Param], param: HttpParam): Validation[JList[Param]] = param match {
+        case SimpleParam(key, value) =>
+          for {
+            key <- key(session)
+            value <- value(session)
+          } yield {
+            ahcParams.add(new Param(key, value.toString))
+            ahcParams
+          }
 
-          case MultivaluedParam(key, values) =>
-            for {
-              key <- key(session)
-              values <- values(session)
-            } yield {
-              values.foreach(value => ahcParams.add(new Param(key, value.toString)))
-              ahcParams
-            }
+        case MultivaluedParam(key, values) =>
+          for {
+            key <- key(session)
+            values <- values(session)
+          } yield {
+            values.foreach(value => ahcParams.add(new Param(key, value.toString)))
+            ahcParams
+          }
 
-          case ParamSeq(seq) =>
-            for {
-              seq <- seq(session)
-            } yield {
-              seq.foreach { case (key, value) => ahcParams.add(new Param(key, value.toString)) }
-              ahcParams
-            }
+        case ParamSeq(seq) =>
+          for {
+            seq <- seq(session)
+          } yield {
+            seq.foreach { case (key, value) => ahcParams.add(new Param(key, value.toString)) }
+            ahcParams
+          }
 
-          case ParamMap(map) =>
-            for {
-              map <- map(session)
-            } yield {
-              map.foreach { case (key, value) => ahcParams.add(new Param(key, value.toString)) }
-              ahcParams
+        case ParamMap(map) =>
+          for {
+            map <- map(session)
+          } yield {
+            map.foreach { case (key, value) => ahcParams.add(new Param(key, value.toString)) }
+            ahcParams
+          }
+      }
+
+      @tailrec
+      def resolveParamJListRec(ahcParams: JList[Param], currentParams: List[HttpParam]): Validation[JList[Param]] =
+        currentParams match {
+          case Nil => ahcParams.success
+          case head :: tail =>
+            update(ahcParams, head) match {
+              case Success(newAhcParams) => resolveParamJListRec(newAhcParams, tail)
+              case f                     => f
             }
         }
-
-        @tailrec
-        def resolveParamJListRec(ahcParams: JList[Param], currentParams: List[HttpParam]): Validation[JList[Param]] =
-          currentParams match {
-            case Nil => ahcParams.success
-            case head :: tail =>
-              update(ahcParams, head) match {
-                case Success(newAhcParams) => resolveParamJListRec(newAhcParams, tail)
-                case f                     => f
-              }
-          }
 
       if (params.isEmpty)
         EmptyParamJListSuccess

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/sse/SseOpenRequestBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/sse/SseOpenRequestBuilder.scala
@@ -39,7 +39,7 @@ object SseOpenRequestBuilder {
 }
 
 case class SseOpenRequestBuilder(commonAttributes: CommonAttributes, sseName: String)
-    extends RequestBuilder[SseOpenRequestBuilder] {
+  extends RequestBuilder[SseOpenRequestBuilder] {
 
   override private[http] def newInstance(commonAttributes: CommonAttributes) = new SseOpenRequestBuilder(commonAttributes, sseName)
 

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/sse/SseRequestExpressionBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/sse/SseRequestExpressionBuilder.scala
@@ -25,7 +25,7 @@ import io.gatling.http.request.builder.{ CommonAttributes, RequestExpressionBuil
 import org.asynchttpclient.uri.Uri
 
 class SseRequestExpressionBuilder(commonAttributes: CommonAttributes, coreComponents: CoreComponents, httpComponents: HttpComponents)
-    extends RequestExpressionBuilder(commonAttributes, coreComponents, httpComponents) {
+  extends RequestExpressionBuilder(commonAttributes, coreComponents, httpComponents) {
 
   override protected def configureRequestBuilder(session: Session, uri: Uri, requestBuilder: AhcRequestBuilder): Validation[AhcRequestBuilder] = {
     // disable request timeout for SSE

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/ws/WsRequestExpressionBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/ws/WsRequestExpressionBuilder.scala
@@ -21,7 +21,7 @@ import io.gatling.http.protocol.HttpComponents
 import io.gatling.http.request.builder.{ CommonAttributes, RequestExpressionBuilder }
 
 class WsRequestExpressionBuilder(commonAttributes: CommonAttributes, coreComponents: CoreComponents, httpComponents: HttpComponents)
-    extends RequestExpressionBuilder(commonAttributes, coreComponents, httpComponents) {
+  extends RequestExpressionBuilder(commonAttributes, coreComponents, httpComponents) {
 
   override protected def baseUrl: Session => Option[String] = httpCaches.wsBaseUrl
 }

--- a/gatling-http/src/main/scala/io/gatling/http/resolver/CacheOverrideNameResolver.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/resolver/CacheOverrideNameResolver.scala
@@ -30,7 +30,7 @@ object CacheOverrideNameResolver {
 }
 
 case class CacheOverrideNameResolver(resolver: ExtendedDnsNameResolver, cache: DnsCache)
-    extends NameResolver[InetAddress] {
+  extends NameResolver[InetAddress] {
 
   import CacheOverrideNameResolver._
 

--- a/gatling-http/src/main/scala/io/gatling/http/resolver/ExtendedDnsNameResolver.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/resolver/ExtendedDnsNameResolver.scala
@@ -45,25 +45,25 @@ object ExtendedDnsNameResolver extends StrictLogging {
  * @param configuration the config
  */
 class ExtendedDnsNameResolver(val eventLoop: EventLoop, configuration: GatlingConfiguration)
-    extends DnsNameResolver(
-      eventLoop, // eventLoop
-      ExtendedDnsNameResolver.NioDatagramChannelFactory, // channelFactory
-      NoopDnsCache.INSTANCE, // resolveCache
-      NoopDnsCache.INSTANCE, // authoritativeDnsServerCache
-      NoopDnsQueryLifecycleObserverFactory.INSTANCE, // dnsQueryLifecycleObserverFactory
-      configuration.http.dns.queryTimeout, // queryTimeoutMillis
-      null, // resolvedAddressTypes, defaults to DEFAULT_RESOLVE_ADDRESS_TYPES
-      true, // recursionDesired
-      configuration.http.dns.maxQueriesPerResolve, // maxQueriesPerResolve
-      ExtendedDnsNameResolver.DebugEnabled, // traceEnabled
-      4096, // maxPayloadSize
-      true, // optResourceEnabled
-      HostsFileEntriesResolver.DEFAULT, // hostsFileEntriesResolver
-      DnsServerAddressStreamProviders.platformDefault, // dnsServerAddressStreamProvider
-      null, // searchDomains
-      1, // ndots
-      true // decodeIdn
-    ) {
+  extends DnsNameResolver(
+    eventLoop, // eventLoop
+    ExtendedDnsNameResolver.NioDatagramChannelFactory, // channelFactory
+    NoopDnsCache.INSTANCE, // resolveCache
+    NoopDnsCache.INSTANCE, // authoritativeDnsServerCache
+    NoopDnsQueryLifecycleObserverFactory.INSTANCE, // dnsQueryLifecycleObserverFactory
+    configuration.http.dns.queryTimeout, // queryTimeoutMillis
+    null, // resolvedAddressTypes, defaults to DEFAULT_RESOLVE_ADDRESS_TYPES
+    true, // recursionDesired
+    configuration.http.dns.maxQueriesPerResolve, // maxQueriesPerResolve
+    ExtendedDnsNameResolver.DebugEnabled, // traceEnabled
+    4096, // maxPayloadSize
+    true, // optResourceEnabled
+    HostsFileEntriesResolver.DEFAULT, // hostsFileEntriesResolver
+    DnsServerAddressStreamProviders.platformDefault, // dnsServerAddressStreamProvider
+    null, // searchDomains
+    1, // ndots
+    true // decodeIdn
+  ) {
   override def doResolveAll(inetHost: String, additionals: Array[DnsRecord], promise: Promise[JList[InetAddress]], resolveCache: DnsCache): Unit =
     super.doResolveAll(inetHost, additionals, promise, resolveCache)
 }

--- a/gatling-http/src/main/scala/io/gatling/http/response/ResponseBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/response/ResponseBuilder.scala
@@ -164,7 +164,7 @@ class ResponseBuilder(
   def build: Response = {
 
     // time measurement is imprecise due to multi-core nature
-    // moreover, ProgressListener might be called AFTER ChannelHandler methods 
+    // moreover, ProgressListener might be called AFTER ChannelHandler methods
     // ensure response doesn't end before starting
     endTimestamp = max(endTimestamp, startTimestamp)
 

--- a/gatling-http/src/main/scala/io/gatling/http/util/HttpHelper.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/util/HttpHelper.scala
@@ -40,7 +40,7 @@ object HttpHelper extends StrictLogging {
   val RedirectStatusCodes = Vector(301, 302, 303, 307, 308)
 
   def parseFormBody(body: String): List[(String, String)] = {
-      def utf8Decode(s: String) = URLDecoder.decode(s, UTF8.name)
+    def utf8Decode(s: String) = URLDecoder.decode(s, UTF8.name)
 
     body
       .split("&")

--- a/gatling-http/src/test/scala/io/gatling/http/HttpServer.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/HttpServer.scala
@@ -34,10 +34,10 @@ import io.netty.util.internal.logging.{ Slf4JLoggerFactory, InternalLoggerFactor
 
 @Sharable
 private[http] class ServerHandler(
-  requestHandler: PartialFunction[FullHttpRequest, ChannelHandlerContext => Unit],
-  requests:       ConcurrentLinkedQueue[FullHttpRequest]
+    requestHandler: PartialFunction[FullHttpRequest, ChannelHandlerContext => Unit],
+    requests:       ConcurrentLinkedQueue[FullHttpRequest]
 )
-    extends ChannelInboundHandlerAdapter with LazyLogging {
+  extends ChannelInboundHandlerAdapter with LazyLogging {
 
   override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = {
     msg match {
@@ -58,7 +58,7 @@ private[http] class ServerHandler(
 }
 
 private[http] class HttpServer(requestHandler: PartialFunction[FullHttpRequest, ChannelHandlerContext => Unit], port: Int)
-    extends LazyLogging {
+  extends LazyLogging {
 
   val requests = new ConcurrentLinkedQueue[FullHttpRequest]
 

--- a/gatling-http/src/test/scala/io/gatling/http/WsCompileTest.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/WsCompileTest.scala
@@ -66,12 +66,12 @@ class WsCompileTest extends Simulation {
                 .check(wsListen.within(30 seconds).expect(1).message)
             ).exec(
                 ws("Cancel").wsName("foo")
-                .cancelCheck
+                  .cancelCheck
               ).exec(
-                ws("Message4")
-                  .sendText("""{"text": "Hello, I'm ${id} and this is message ${i}!"}""")
-                  .check(wsAwait.within(30 seconds).until(1))
-              )
+                  ws("Message4")
+                    .sendText("""{"text": "Hello, I'm ${id} and this is message ${i}!"}""")
+                    .check(wsAwait.within(30 seconds).until(1))
+                )
     .exec(ws("Close WS").close)
     .exec(ws("Open Named", "foo").open("/bar"))
 

--- a/gatling-http/src/test/scala/io/gatling/http/request/builder/HttpRequestBuilderSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/request/builder/HttpRequestBuilderSpec.scala
@@ -56,7 +56,7 @@ class HttpRequestBuilderSpec extends BaseSpec with ValidationValues {
   }
 
   it should "work when passed as a function" in {
-      def sigCalc(request: Request, rb: RequestBuilderBase[_]): Unit = rb.addHeader("X-Token", "foo")
+    def sigCalc(request: Request, rb: RequestBuilderBase[_]): Unit = rb.addHeader("X-Token", "foo")
 
     httpRequestDef(_.signatureCalculator(sigCalc _))
       .build("requestName", Session("scenarioName", 0))

--- a/gatling-jdbc/src/main/scala/io/gatling/jdbc/feeder/JdbcFeederSource.scala
+++ b/gatling-jdbc/src/main/scala/io/gatling/jdbc/feeder/JdbcFeederSource.scala
@@ -34,13 +34,13 @@ object JdbcFeederSource {
 
       val columnLabels = for (i <- 1 to columnCount) yield metadata.getColumnLabel(i)
 
-        def computeRecord: Record[Any] =
-          (for (i <- 1 to columnCount) yield columnLabels(i - 1) -> resultSet.getObject(i))(breakOut)
+      def computeRecord: Record[Any] =
+        (for (i <- 1 to columnCount) yield columnLabels(i - 1) -> resultSet.getObject(i))(breakOut)
 
-        @tailrec
-        def loadRec(records: Vector[Record[Any]]): Vector[Record[Any]] =
-          if (!resultSet.next) records
-          else loadRec(records :+ computeRecord)
+      @tailrec
+      def loadRec(records: Vector[Record[Any]]): Vector[Record[Any]] =
+        if (!resultSet.next) records
+        else loadRec(records :+ computeRecord)
 
       loadRec(Vector.empty)
     }

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/JmsAction.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/JmsAction.scala
@@ -26,7 +26,7 @@ import io.gatling.jms.protocol.JmsProtocol
 import io.gatling.jms.request._
 
 abstract class JmsAction(attributes: JmsAttributes, protocol: JmsProtocol, pool: JmsConnectionPool)
-    extends RequestAction with JmsLogging with NameGen {
+  extends RequestAction with JmsLogging with NameGen {
 
   override val requestName = attributes.requestName
 

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/RequestReply.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/RequestReply.scala
@@ -32,7 +32,7 @@ import io.gatling.jms.request._
  * This implementation then forwards it on to a tracking actor.
  */
 class RequestReply(attributes: JmsAttributes, replyDestination: JmsDestination, protocol: JmsProtocol, jmsConnectionPool: JmsConnectionPool, val statsEngine: StatsEngine, val next: Action)
-    extends JmsAction(attributes, protocol, jmsConnectionPool) {
+  extends JmsAction(attributes, protocol, jmsConnectionPool) {
 
   override val name = genName("jmsRequestReply")
 

--- a/gatling-jms/src/main/scala/io/gatling/jms/action/Send.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/Send.scala
@@ -33,7 +33,7 @@ import io.gatling.jms.request._
  * This handles the core "send"ing of messages. Gatling calls the execute method to trigger a send.
  */
 class Send(attributes: JmsAttributes, protocol: JmsProtocol, jmsConnectionPool: JmsConnectionPool, val statsEngine: StatsEngine, configuration: GatlingConfiguration, val next: Action)
-    extends JmsAction(attributes, protocol, jmsConnectionPool) {
+  extends JmsAction(attributes, protocol, jmsConnectionPool) {
 
   override val name: String = genName("jmsSend")
 

--- a/gatling-jms/src/main/scala/io/gatling/jms/client/Tracker.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/client/Tracker.scala
@@ -37,22 +37,22 @@ import akka.actor.{ Timers, Props }
  * Advise actor a message was sent to JMS provider
  */
 case class MessageSent(
-  matchId:      String,
-  sent:         Long,
-  replyTimeout: Long,
-  checks:       List[JmsCheck],
-  session:      Session,
-  next:         Action,
-  requestName:  String
+    matchId:      String,
+    sent:         Long,
+    replyTimeout: Long,
+    checks:       List[JmsCheck],
+    session:      Session,
+    next:         Action,
+    requestName:  String
 )
 
 /**
  * Advise actor a response message was received from JMS provider
  */
 case class MessageReceived(
-  matchId:  String,
-  received: Long,
-  message:  Message
+    matchId:  String,
+    received: Long,
+    message:  Message
 )
 
 case object TimeoutScan

--- a/gatling-jms/src/main/scala/io/gatling/jms/request/JmsAttributes.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/request/JmsAttributes.scala
@@ -28,11 +28,11 @@ import io.gatling.jms.JmsCheck
  * @author jasonk@bluedevel.com
  */
 case class JmsAttributes(
-  requestName:       Expression[String],
-  destination:       JmsDestination,
-  selector:          Option[String],
-  message:           JmsMessage,
-  messageProperties: Map[Expression[String], Expression[Any]] = Map.empty,
-  jmsType:           Option[Expression[String]]               = None,
-  checks:            List[JmsCheck]                           = Nil
+    requestName:       Expression[String],
+    destination:       JmsDestination,
+    selector:          Option[String],
+    message:           JmsMessage,
+    messageProperties: Map[Expression[String], Expression[Any]] = Map.empty,
+    jmsType:           Option[Expression[String]]               = None,
+    checks:            List[JmsCheck]                           = Nil
 )

--- a/gatling-metrics/src/main/scala/io/gatling/metrics/GraphiteDataWriter.scala
+++ b/gatling-metrics/src/main/scala/io/gatling/metrics/GraphiteDataWriter.scala
@@ -31,11 +31,11 @@ import io.gatling.metrics.types._
 import akka.actor.ActorRef
 
 case class GraphiteData(
-  configuration:   GatlingConfiguration,
-  metricsSender:   ActorRef,
-  requestsByPath:  mutable.Map[GraphitePath, RequestMetricsBuffer],
-  usersByScenario: mutable.Map[GraphitePath, UserBreakdownBuffer],
-  format:          GraphitePathPattern
+    configuration:   GatlingConfiguration,
+    metricsSender:   ActorRef,
+    requestsByPath:  mutable.Map[GraphitePath, RequestMetricsBuffer],
+    usersByScenario: mutable.Map[GraphitePath, UserBreakdownBuffer],
+    format:          GraphitePathPattern
 ) extends DataWriterData
 
 private[gatling] class GraphiteDataWriter extends DataWriter[GraphiteData] with NameGen {

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
@@ -107,17 +107,17 @@ private[recorder] object RecorderConfiguration extends StrictLogging {
   private def buildConfig(config: Config): RecorderConfiguration = {
     import ConfigKeys._
 
-      def getOutputFolder(folder: String) = {
-        folder.trimToOption match {
-          case Some(f)                               => f
-          case _ if sys.env.contains("GATLING_HOME") => sourcesDirectory.toFile.toString
-          case _                                     => userHome
-        }
+    def getOutputFolder(folder: String) = {
+      folder.trimToOption match {
+        case Some(f)                               => f
+        case _ if sys.env.contains("GATLING_HOME") => sourcesDirectory.toFile.toString
+        case _                                     => userHome
       }
+    }
 
-      def getBodiesFolder =
-        if (config.hasPath(core.BodiesFolder)) config.getString(core.BodiesFolder)
-        else bodiesDirectory.toFile.toString
+    def getBodiesFolder =
+      if (config.hasPath(core.BodiesFolder)) config.getString(core.BodiesFolder)
+      else bodiesDirectory.toFile.toString
 
     RecorderConfiguration(
       core = CoreConfiguration(
@@ -191,69 +191,69 @@ private[recorder] case class FiltersConfiguration(
 }
 
 private[recorder] case class CoreConfiguration(
-  mode:                      RecorderMode,
-  encoding:                  String,
-  outputFolder:              String,
-  bodiesFolder:              String,
-  pkg:                       String,
-  className:                 String,
-  thresholdForPauseCreation: Duration,
-  saveConfig:                Boolean,
-  headless:                  Boolean,
-  harFilePath:               Option[String]
+    mode:                      RecorderMode,
+    encoding:                  String,
+    outputFolder:              String,
+    bodiesFolder:              String,
+    pkg:                       String,
+    className:                 String,
+    thresholdForPauseCreation: Duration,
+    saveConfig:                Boolean,
+    headless:                  Boolean,
+    harFilePath:               Option[String]
 )
 
 private[recorder] case class HttpConfiguration(
-  automaticReferer:    Boolean,
-  followRedirect:      Boolean,
-  inferHtmlResources:  Boolean,
-  removeCacheHeaders:  Boolean,
-  checkResponseBodies: Boolean
+    automaticReferer:    Boolean,
+    followRedirect:      Boolean,
+    inferHtmlResources:  Boolean,
+    removeCacheHeaders:  Boolean,
+    checkResponseBodies: Boolean
 )
 
 private[recorder] case class KeyStoreConfiguration(
-  path:         String,
-  password:     String,
-  keyStoreType: KeyStoreType
+    path:         String,
+    password:     String,
+    keyStoreType: KeyStoreType
 )
 
 private[recorder] case class CertificateAuthorityConfiguration(
-  certificatePath: String,
-  privateKeyPath:  String
+    certificatePath: String,
+    privateKeyPath:  String
 )
 
 private[recorder] case class HttpsModeConfiguration(
-  mode:                 HttpsMode,
-  keyStore:             KeyStoreConfiguration,
-  certificateAuthority: CertificateAuthorityConfiguration
+    mode:                 HttpsMode,
+    keyStore:             KeyStoreConfiguration,
+    certificateAuthority: CertificateAuthorityConfiguration
 )
 
 private[recorder] case class OutgoingProxyConfiguration(
-  host:     Option[String],
-  username: Option[String],
-  password: Option[String],
-  port:     Option[Int],
-  sslPort:  Option[Int]
+    host:     Option[String],
+    username: Option[String],
+    password: Option[String],
+    port:     Option[Int],
+    sslPort:  Option[Int]
 )
 
 private[recorder] case class ProxyConfiguration(
-  port:     Int,
-  https:    HttpsModeConfiguration,
-  outgoing: OutgoingProxyConfiguration
+    port:     Int,
+    https:    HttpsModeConfiguration,
+    outgoing: OutgoingProxyConfiguration
 )
 
 private[recorder] case class NettyConfiguration(
-  maxInitialLineLength: Int,
-  maxHeaderSize:        Int,
-  maxChunkSize:         Int,
-  maxContentLength:     Int
+    maxInitialLineLength: Int,
+    maxHeaderSize:        Int,
+    maxChunkSize:         Int,
+    maxContentLength:     Int
 )
 
 private[recorder] case class RecorderConfiguration(
-  core:    CoreConfiguration,
-  filters: FiltersConfiguration,
-  http:    HttpConfiguration,
-  proxy:   ProxyConfiguration,
-  netty:   NettyConfiguration,
-  config:  Config
+    core:    CoreConfiguration,
+    filters: FiltersConfiguration,
+    http:    HttpConfiguration,
+    proxy:   ProxyConfiguration,
+    netty:   NettyConfiguration,
+    config:  Config
 )

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarReader.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/har/HarReader.scala
@@ -58,9 +58,9 @@ private[recorder] object HarReader {
   }
 
   private def createRequestWithArrivalTime(entry: Entry): TimedScenarioElement[RequestElement] = {
-      def buildContent(postParams: Seq[PostParam]): RequestBody =
-        RequestBodyParams(postParams.map(postParam => (postParam.name, postParam.value)).toList)
-      def decode(s: String): String = URLDecoder.decode(s, UTF8.name)
+    def buildContent(postParams: Seq[PostParam]): RequestBody =
+      RequestBodyParams(postParams.map(postParam => (postParam.name, postParam.value)).toList)
+    def decode(s: String): String = URLDecoder.decode(s, UTF8.name)
 
     val uri = entry.request.url
     val method = entry.request.method

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/PlainNoProxyMitmActor.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/PlainNoProxyMitmActor.scala
@@ -38,11 +38,11 @@ import io.netty.handler.codec.http.FullHttpRequest
  * @param trafficLogger log the traffic
  */
 class PlainNoProxyMitmActor(
-  serverChannel:   Channel,
-  clientBootstrap: Bootstrap,
-  trafficLogger:   TrafficLogger
+    serverChannel:   Channel,
+    clientBootstrap: Bootstrap,
+    trafficLogger:   TrafficLogger
 )
-    extends PlainMitmActor(serverChannel, clientBootstrap, trafficLogger) {
+  extends PlainMitmActor(serverChannel, clientBootstrap, trafficLogger) {
 
   override protected def connectedRemote(requestRemote: Remote): Remote =
     requestRemote

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/PlainWithProxyMitmActor.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/PlainWithProxyMitmActor.scala
@@ -40,12 +40,12 @@ import org.asynchttpclient.util.Base64
  * @param trafficLogger log the traffic
  */
 class PlainWithProxyMitmActor(
-  serverChannel:   Channel,
-  clientBootstrap: Bootstrap,
-  proxy:           OutgoingProxy,
-  trafficLogger:   TrafficLogger
+    serverChannel:   Channel,
+    clientBootstrap: Bootstrap,
+    proxy:           OutgoingProxy,
+    trafficLogger:   TrafficLogger
 )
-    extends PlainMitmActor(serverChannel, clientBootstrap, trafficLogger) {
+  extends PlainMitmActor(serverChannel, clientBootstrap, trafficLogger) {
 
   private val proxyRemote = Remote(proxy.host, proxy.port)
   private val proxyBasicAuthHeader = proxy.credentials.map(credentials => "Basic " + Base64.encode((credentials.username + ":" + credentials.password).getBytes(UTF_8)))

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/SecuredNoProxyMitmActor.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/SecuredNoProxyMitmActor.scala
@@ -43,12 +43,12 @@ import io.netty.handler.ssl.SslHandler
  * @param trafficLogger log the traffic
  */
 class SecuredNoProxyMitmActor(
-  serverChannel:    Channel,
-  clientBootstrap:  Bootstrap,
-  sslServerContext: SslServerContext,
-  trafficLogger:    TrafficLogger
+    serverChannel:    Channel,
+    clientBootstrap:  Bootstrap,
+    sslServerContext: SslServerContext,
+    trafficLogger:    TrafficLogger
 )
-    extends SecuredMitmActor(serverChannel, clientBootstrap, sslServerContext) {
+  extends SecuredMitmActor(serverChannel, clientBootstrap, sslServerContext) {
 
   override protected def connectedRemote(requestRemote: Remote): Remote = requestRemote
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/SecuredWithProxyMitmActor.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/flows/SecuredWithProxyMitmActor.scala
@@ -52,14 +52,14 @@ import org.asynchttpclient.util.Base64
  * @param httpClientCodecFactory create new HttpClientCodecs
  */
 class SecuredWithProxyMitmActor(
-  serverChannel:          Channel,
-  clientBootstrap:        Bootstrap,
-  sslServerContext:       SslServerContext,
-  proxy:                  OutgoingProxy,
-  trafficLogger:          TrafficLogger,
-  httpClientCodecFactory: () => HttpClientCodec
+    serverChannel:          Channel,
+    clientBootstrap:        Bootstrap,
+    sslServerContext:       SslServerContext,
+    proxy:                  OutgoingProxy,
+    trafficLogger:          TrafficLogger,
+    httpClientCodecFactory: () => HttpClientCodec
 )
-    extends SecuredMitmActor(serverChannel, clientBootstrap, sslServerContext) {
+  extends SecuredMitmActor(serverChannel, clientBootstrap, sslServerContext) {
 
   private val proxyRemote = Remote(proxy.host, proxy.port)
   private val proxyBasicAuthHeader = proxy.credentials.map(credentials => "Basic " + Base64.encode((credentials.username + ":" + credentials.password).getBytes(UTF_8)))

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslCertHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/http/ssl/SslCertHelper.scala
@@ -67,23 +67,23 @@ private[recorder] object SslCertUtil extends StrictLogging {
   def generateGatlingCAPEMFiles(dir: Path, privKeyFileName: String, certFileName: String): Unit = {
     assert(dir.isDirectory, s"$dir isn't a directory")
 
-      def generateCACertificate(pair: KeyPair): X509CertificateHolder = {
-        val dn = s"C=FR, ST=Val de marne, O=GatlingCA, CN=Gatling"
-        val now = nowMillis
+    def generateCACertificate(pair: KeyPair): X509CertificateHolder = {
+      val dn = s"C=FR, ST=Val de marne, O=GatlingCA, CN=Gatling"
+      val now = nowMillis
 
-        // has to be v1 for CA
-        val certGen = new JcaX509v1CertificateBuilder(
-          new X500Principal(dn), // issuer
-          BigInteger.valueOf(now), // serial
-          new Date(now), // notBefore
-          new Date(now + 365.days.toMillis), // notAfter
-          new X500Principal(dn), //subject
-          pair.getPublic
-        ) // publicKey
+      // has to be v1 for CA
+      val certGen = new JcaX509v1CertificateBuilder(
+        new X500Principal(dn), // issuer
+        BigInteger.valueOf(now), // serial
+        new Date(now), // notBefore
+        new Date(now + 365.days.toMillis), // notAfter
+        new X500Principal(dn), //subject
+        pair.getPublic
+      ) // publicKey
 
-        val signer = newSigner(pair.getPrivate)
-        certGen.build(signer)
-      }
+      val signer = newSigner(pair.getPrivate)
+      certGen.build(signer)
+    }
 
     val pair = newRSAKeyPair
     val crtHolder = generateCACertificate(pair)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioElement.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioElement.scala
@@ -27,7 +27,7 @@ import io.gatling.http.HeaderValues._
 import io.gatling.http.fetch.{ EmbeddedResource, HtmlParser }
 import io.gatling.http.util.HttpHelper.parseFormBody
 import io.gatling.recorder.config.RecorderConfiguration
-import io.gatling.recorder.http.model.{SafeHttpRequest, SafeHttpResponse}
+import io.gatling.recorder.http.model.{ SafeHttpRequest, SafeHttpResponse }
 
 import org.asynchttpclient.util.Base64
 import org.asynchttpclient.uri.Uri
@@ -145,13 +145,13 @@ private[recorder] case class RequestElement(
   }
 
   val basicAuthCredentials: Option[(String, String)] = {
-      def parseCredentials(header: String) =
-        new String(Base64.decode(header.split(" ")(1))).split(":") match {
-          case Array(username, password) =>
-            val credentials = (username, password)
-            Some(credentials)
-          case _ => None
-        }
+    def parseCredentials(header: String) =
+      new String(Base64.decode(header.split(" ")(1))).split(":") match {
+        case Array(username, password) =>
+          val credentials = (username, password)
+          Some(credentials)
+        case _ => None
+      }
 
     headers.get(Authorization).filter(_.startsWith("Basic ")).flatMap(parseCredentials)
   }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ExtractedUris.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ExtractedUris.scala
@@ -81,15 +81,15 @@ private[scenario] class ExtractedUris(scenarioElements: Seq[ScenarioElement]) {
     })
 
   private def longestCommonRoot(pathsStrs: List[String]): String = {
-      def longestCommonRoot2(sa1: Array[String], sa2: Array[String]) = {
-        val minLen = math.min(sa1.length, sa2.length)
-        var p = 0
-        while (p < minLen && sa1(p) == sa2(p)) {
-          p += 1
-        }
-
-        sa1.slice(0, p)
+    def longestCommonRoot2(sa1: Array[String], sa2: Array[String]) = {
+      val minLen = math.min(sa1.length, sa2.length)
+      var p = 0
+      while (p < minLen && sa1(p) == sa2(p)) {
+        p += 1
       }
+
+      sa1.slice(0, p)
+    }
 
     val paths = pathsStrs.map(_.split("/"))
     paths.reduce(longestCommonRoot2).toSeq.mkString("/")

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/ProtocolTemplate.scala
@@ -30,68 +30,68 @@ private[scenario] object ProtocolTemplate {
 
   def render(protocol: ProtocolDefinition)(implicit config: RecorderConfiguration) = {
 
-      def renderProxy = {
+    def renderProxy = {
 
-          def renderSslPort = config.proxy.outgoing.sslPort match {
-            case Some(proxySslPort) => s".httpsPort($proxySslPort)"
-            case _                  => ""
-          }
-
-          def renderCredentials = {
-            val credentials = for {
-              proxyUsername <- config.proxy.outgoing.username
-              proxyPassword <- config.proxy.outgoing.password
-            } yield s"""$Eol$Indent.credentials(${protectWithTripleQuotes(proxyUsername)},${protectWithTripleQuotes(proxyPassword)})"""
-            credentials.getOrElse("")
-          }
-
-        val protocol = for {
-          proxyHost <- config.proxy.outgoing.host
-          proxyPort <- config.proxy.outgoing.port
-        } yield fast"""$Eol$Indent.proxy(Proxy("$proxyHost", $proxyPort)$renderSslPort$renderCredentials)"""
-
-        protocol.getOrElse(EmptyFastring)
+      def renderSslPort = config.proxy.outgoing.sslPort match {
+        case Some(proxySslPort) => s".httpsPort($proxySslPort)"
+        case _                  => ""
       }
 
-      def renderFollowRedirect = if (!config.http.followRedirect) fast"$Eol$Indent.disableFollowRedirect" else fast""
-
-      def renderInferHtmlResources =
-        if (config.http.inferHtmlResources) {
-          val filtersConfig = config.filters
-
-            def quotedStringList(xs: Seq[String]): String = xs.map(p => "\"\"\"" + p + "\"\"\"").mkString(", ")
-            def blackListPatterns = fast"BlackList(${quotedStringList(filtersConfig.blackList.patterns)})"
-            def whiteListPatterns = fast"WhiteList(${quotedStringList(filtersConfig.whiteList.patterns)})"
-
-          val patterns = filtersConfig.filterStrategy match {
-            case FilterStrategy.WhitelistFirst => fast"$whiteListPatterns, $blackListPatterns"
-            case FilterStrategy.BlacklistFirst => fast"$blackListPatterns, $whiteListPatterns"
-            case FilterStrategy.Disabled       => EmptyFastring
-          }
-
-          fast"$Eol$Indent.inferHtmlResources($patterns)"
-        } else fast""
-
-      def renderAutomaticReferer = if (!config.http.automaticReferer) fast"$Eol$Indent.disableAutoReferer" else fast""
-
-      def renderHeaders = {
-          def renderHeader(methodName: String, headerValue: String) = fast"""$Eol$Indent.$methodName(${protectWithTripleQuotes(headerValue)})"""
-        protocol.headers.toList.sorted
-          .filter {
-            case (HeaderNames.Connection, value) => value == "close"
-            case _                               => true
-          }.flatMap {
-            case (headerName, headerValue) =>
-              val properHeaderValue =
-                if (headerName.equalsIgnoreCase(HeaderNames.AcceptEncoding)) {
-                  HttpUtils.filterSupportedEncodings(headerValue)
-                } else {
-                  headerValue
-                }
-
-              BaseHeaders.get(headerName).map(renderHeader(_, properHeaderValue))
-          }.mkFastring
+      def renderCredentials = {
+        val credentials = for {
+          proxyUsername <- config.proxy.outgoing.username
+          proxyPassword <- config.proxy.outgoing.password
+        } yield s"""$Eol$Indent.credentials(${protectWithTripleQuotes(proxyUsername)},${protectWithTripleQuotes(proxyPassword)})"""
+        credentials.getOrElse("")
       }
+
+      val protocol = for {
+        proxyHost <- config.proxy.outgoing.host
+        proxyPort <- config.proxy.outgoing.port
+      } yield fast"""$Eol$Indent.proxy(Proxy("$proxyHost", $proxyPort)$renderSslPort$renderCredentials)"""
+
+      protocol.getOrElse(EmptyFastring)
+    }
+
+    def renderFollowRedirect = if (!config.http.followRedirect) fast"$Eol$Indent.disableFollowRedirect" else fast""
+
+    def renderInferHtmlResources =
+      if (config.http.inferHtmlResources) {
+        val filtersConfig = config.filters
+
+        def quotedStringList(xs: Seq[String]): String = xs.map(p => "\"\"\"" + p + "\"\"\"").mkString(", ")
+        def blackListPatterns = fast"BlackList(${quotedStringList(filtersConfig.blackList.patterns)})"
+        def whiteListPatterns = fast"WhiteList(${quotedStringList(filtersConfig.whiteList.patterns)})"
+
+        val patterns = filtersConfig.filterStrategy match {
+          case FilterStrategy.WhitelistFirst => fast"$whiteListPatterns, $blackListPatterns"
+          case FilterStrategy.BlacklistFirst => fast"$blackListPatterns, $whiteListPatterns"
+          case FilterStrategy.Disabled       => EmptyFastring
+        }
+
+        fast"$Eol$Indent.inferHtmlResources($patterns)"
+      } else fast""
+
+    def renderAutomaticReferer = if (!config.http.automaticReferer) fast"$Eol$Indent.disableAutoReferer" else fast""
+
+    def renderHeaders = {
+      def renderHeader(methodName: String, headerValue: String) = fast"""$Eol$Indent.$methodName(${protectWithTripleQuotes(headerValue)})"""
+      protocol.headers.toList.sorted
+        .filter {
+          case (HeaderNames.Connection, value) => value == "close"
+          case _                               => true
+        }.flatMap {
+          case (headerName, headerValue) =>
+            val properHeaderValue =
+              if (headerName.equalsIgnoreCase(HeaderNames.AcceptEncoding)) {
+                HttpUtils.filterSupportedEncodings(headerValue)
+              } else {
+                headerValue
+              }
+
+            BaseHeaders.get(headerName).map(renderHeader(_, properHeaderValue))
+        }.mkFastring
+    }
 
     fast"""
 		.baseURL("${protocol.baseUrl}")$renderProxy$renderFollowRedirect$renderInferHtmlResources$renderAutomaticReferer$renderHeaders""".toString

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/RecorderFrontEnd.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/RecorderFrontEnd.scala
@@ -28,9 +28,9 @@ private[recorder] object RecorderFrontend {
 }
 private[recorder] abstract class RecorderFrontend(controller: RecorderController) {
 
-  /******************************/
+/******************************/
   /**  Controller => Frontend  **/
-  /******************************/
+/******************************/
 
   def selectedRecorderMode: RecorderMode
 
@@ -54,9 +54,9 @@ private[recorder] abstract class RecorderFrontend(controller: RecorderController
 
   def receiveEventInfo(eventInfo: EventInfo): Unit
 
-  /******************************/
+/******************************/
   /**  Frontend => Controller  **/
-  /******************************/
+/******************************/
 
   def addTag(tag: String): Unit = controller.addTag(tag)
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DisplayedSelectionFileChooser.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/DisplayedSelectionFileChooser.scala
@@ -34,14 +34,14 @@ private[swing] case object Open extends ChooserType
 private[swing] case object Save extends ChooserType
 
 private[swing] class DisplayedSelectionFileChooser(
-  creator:         Container,
-  textFieldLength: Int,
-  chooserType:     ChooserType,
-  buttonText:      String              = "Browse",
-  selectionMode:   SelectionMode.Value = SelectionMode.FilesAndDirectories,
-  fileFilter:      FileFilter          = new AcceptAllFileFilter
+    creator:         Container,
+    textFieldLength: Int,
+    chooserType:     ChooserType,
+    buttonText:      String              = "Browse",
+    selectionMode:   SelectionMode.Value = SelectionMode.FilesAndDirectories,
+    fileFilter:      FileFilter          = new AcceptAllFileFilter
 )
-    extends BoxPanel(Orientation.Horizontal) {
+  extends BoxPanel(Orientation.Horizontal) {
 
   val selectionDisplay = new TextField(textFieldLength)
   private val fileChooser = new FileChooser { fileSelectionMode = selectionMode; fileFilter = fileFilter }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/FilterTable.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/component/FilterTable.scala
@@ -119,8 +119,8 @@ private[swing] class FilterTable(headerTitle: String) extends ScrollPane {
       case e: MouseButtonEvent => maybeShowPopup(e)
     }
 
-      def maybeShowPopup(e: MouseEvent): Unit =
-        if (e.peer.isPopupTrigger)
-          popup.show(e.peer.getComponent, e.peer.getX, e.peer.getY)
+    def maybeShowPopup(e: MouseEvent): Unit =
+      if (e.peer.isPopupTrigger)
+        popup.show(e.peer.getComponent, e.peer.getX, e.peer.getY)
   }
 }

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
@@ -43,9 +43,9 @@ import io.gatling.recorder.ui.swing.util.UIHelper._
 
 private[swing] class ConfigurationFrame(frontend: RecorderFrontend)(implicit configuration: RecorderConfiguration) extends MainFrame {
 
-  /************************************/
+/************************************/
   /**           COMPONENTS           **/
-  /************************************/
+/************************************/
 
   /* Top panel components */
   private val modeSelector = new LabelledComboBox[RecorderMode](RecorderMode.AllModes)
@@ -109,9 +109,9 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontend)(implicit con
   private val savePreferences = new CheckBox("Save preferences") { horizontalTextPosition = Alignment.Left }
   private val start = Button("Start !")(reloadConfigurationAndStart())
 
-  /**********************************/
+/**********************************/
   /**           UI SETUP           **/
-  /**********************************/
+/**********************************/
 
   /* Frame setup */
   title = "Gatling Recorder - Configuration"
@@ -310,9 +310,9 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontend)(implicit con
   registerValidators()
   populateItemsFromConfiguration()
 
-  /*****************************************/
+/*****************************************/
   /**           EVENTS HANDLING           **/
-  /*****************************************/
+/*****************************************/
 
   def toggleModeSelector(mode: RecorderMode): Unit = mode match {
     case Proxy =>
@@ -466,14 +466,14 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontend)(implicit con
     Dialog.showMessage(
       title = "Download successful",
       message =
-      s"""|Gatling's CA certificate and key were successfully saved to
+        s"""|Gatling's CA certificate and key were successfully saved to
            |$directory .""".stripMargin
     )
   }
 
-  /****************************************/
+/****************************************/
   /**           CONFIGURATION            **/
-  /****************************************/
+/****************************************/
 
   /**
    * Configure fields, checkboxes, filters... based on the current Recorder configuration
@@ -508,7 +508,7 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontend)(implicit con
       outgoingProxyUsername.enabled = true
       outgoingProxyPassword.enabled = true
     }
-    configuration.core.pkg.trimToOption.map(simulationPackage.text = _)
+    configuration.core.pkg.trimToOption.map(simulationPackage.text= _)
     simulationClassName.text = configuration.core.className
     filterStrategies.selection.item = configuration.filters.filterStrategy
     followRedirects.selected = configuration.http.followRedirect

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/RunningFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/RunningFrame.scala
@@ -33,9 +33,9 @@ import io.gatling.recorder.ui.swing.util.UIHelper._
 
 private[swing] class RunningFrame(frontend: RecorderFrontend) extends MainFrame with StrictLogging {
 
-  /************************************/
+/************************************/
   /**           COMPONENTS           **/
-  /************************************/
+/************************************/
 
   /* Top panel components */
   private val tagField = new TextField(15)
@@ -57,9 +57,9 @@ private[swing] class RunningFrame(frontend: RecorderFrontend) extends MainFrame 
   /* Bottom panel components */
   private val hostsRequiringCertificates = new ListView[String] { foreground = Color.red }
 
-  /**********************************/
+/**********************************/
   /**           UI SETUP           **/
-  /**********************************/
+/**********************************/
 
   /* Frame setup */
   title = "Gatling Recorder - Running..."
@@ -134,9 +134,9 @@ private[swing] class RunningFrame(frontend: RecorderFrontend) extends MainFrame 
 
   centerOnScreen()
 
-  /*****************************************/
+/*****************************************/
   /**           EVENTS HANDLING           **/
-  /*****************************************/
+/*****************************************/
 
   /* Reactions */
   listenTo(events.selection)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ValidationHelper.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ValidationHelper.scala
@@ -27,10 +27,10 @@ import io.gatling.commons.util.StringHelper.RichString
 private[swing] object ValidationHelper {
 
   case class Validator(
-    condition:       String => Boolean,
-    successCallback: Component => Unit = setStandardBorder,
-    failureCallback: Component => Unit = setErrorBorder,
-    alwaysValid:     Boolean           = false
+      condition:       String => Boolean,
+      successCallback: Component => Unit = setStandardBorder,
+      failureCallback: Component => Unit = setErrorBorder,
+      alwaysValid:     Boolean           = false
   )
 
   // Those are lazy vals to avoid unneccessary component creation when they're not needed (e.g. tests)

--- a/gatling-redis/src/main/scala/io/gatling/redis/feeder/RedisFeeder.scala
+++ b/gatling-redis/src/main/scala/io/gatling/redis/feeder/RedisFeeder.scala
@@ -46,10 +46,10 @@ object RedisFeeder {
       def build(ctx: ScenarioContext): Feeder[String] = {
         ctx.system.registerOnTermination(clientPool.close)
 
-          def next = clientPool.withClient { client =>
-            val value = redisCommand(client, key)
-            value.map(value => Map(key -> value))
-          }
+        def next = clientPool.withClient { client =>
+          val value = redisCommand(client, key)
+          value.map(value => Map(key -> value))
+        }
 
         Iterator.continually(next).takeWhile(_.isDefined).map(_.get)
       }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -7,7 +7,7 @@ import com.typesafe.sbt.site.SphinxSupport.Sphinx
 import sbt.Keys._
 import sbt._
 import sbtunidoc.Plugin.UnidocKeys._
-import sbtunidoc.Plugin.{ScalaUnidoc, unidocSettings}
+import sbtunidoc.Plugin.{ ScalaUnidoc, unidocSettings }
 
 object BuildSettings {
 
@@ -44,9 +44,9 @@ object BuildSettings {
     GatlingDeveloper("achaouat@gatling.io", "Alexandre Chaouat", isGatlingCorp = true)
   )
 
-  /****************************/
+/****************************/
   /** Documentation settings **/
-  /****************************/
+/****************************/
 
   lazy val scaladocSettings = Seq(
     autoAPIMappings := true
@@ -57,9 +57,9 @@ object BuildSettings {
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(excludedProjects: _*)
   ) ++ scaladocSettings
 
-  /**************************************/
+/**************************************/
   /** gatling-charts specific settings **/
-  /**************************************/
+/**************************************/
 
   lazy val chartTestsSettings = Seq(
     fork := true,

--- a/project/ConfigFiles.scala
+++ b/project/ConfigFiles.scala
@@ -34,7 +34,7 @@ object ConfigFiles {
     val outputPath = sourceDirectory / "conf"
     val configFiles = resources.filter(_.getName.endsWith("conf"))
     configFiles.map(generateFile(outputPath, _))
-   }
+  }
 
   private def copyGatlingDefaultConfigFile(destDirectory: File, resourceDirectory: File): Seq[File] = {
     val configFile = (resourceDirectory ** new ExactFilter("gatling-defaults.conf")).get.head

--- a/project/CopyLogback.scala
+++ b/project/CopyLogback.scala
@@ -11,7 +11,7 @@ object CopyLogback {
   )
 
   private def copyDummyLogbackXml(resources: Seq[File], sourceDirectory: File): Seq[File] = {
-    val configFile = resources.filter(_.getName ==  "logback.dummy").head
+    val configFile = resources.filter(_.getName == "logback.dummy").head
     val outputPath = sourceDirectory / "conf"
     val targetFile = outputPath / (configFile.base + ".xml")
     IO.copyFile(configFile, targetFile)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,10 +2,9 @@ import sbt._
 
 object Dependencies { 
 
-  /**************************/
-  /** Compile dependencies **/
-  /**************************/
+  // Compile dependencies
 
+  // format: OFF
   private def scalaReflect(version: String) = "org.scala-lang"                         % "scala-reflect"                 % version
   private val scalaSwing                    = "org.scala-lang.modules"                %% "scala-swing"                   % "2.0.0"
   private val scalaXml                      = "org.scala-lang.modules"                %% "scala-xml"                     % "1.0.6"
@@ -56,9 +55,7 @@ object Dependencies {
   private val guava                         = "com.google.guava"                       % "guava"                         % "23.0"
   private val findbugs                      = "com.google.code.findbugs"               % "jsr305"                        % "3.0.2"
 
-  /***********************/
-  /** Test dependencies **/
-  /***********************/
+  // Test dependencies
 
   private val scalaTest                      = "org.scalatest"                         %% "scalatest"                    % "3.0.4"             % "test"
   private val scalaCheck                     = "org.scalacheck"                        %% "scalacheck"                   % "1.13.5"            % "test"
@@ -68,14 +65,13 @@ object Dependencies {
   private val h2                             = "com.h2database"                         % "h2"                           % "1.4.196"           % "test"
   private val ffmq                           = "net.timewalker.ffmq"                    % "ffmq3-core"                   % "3.0.7"             % "test" exclude("log4j", "log4j") exclude("javax.jms", "jms")
   private val jmh                            = "org.openjdk.jmh"                        % "jmh-core"                     % "1.19"
+  // format: ON
 
   private val loggingDeps = Seq(slf4jApi, scalaLogging, logback)
   private val testDeps = Seq(scalaTest, scalaCheck, akkaTestKit, mockitoCore)
   private val parserDeps = Seq(jsonpath, jackson, boon, saxon, joddLagarto)
 
-  /****************************/
-  /** Dependencies by module **/
-  /****************************/
+  // Dependencies by module
 
   def commonsDependencies(scalaVersion: String) =
     Seq(scalaReflect(scalaVersion), config, fastring, boopickle, quicklens, java8Compat, ahcNettyUtils, pebble, guava, findbugs) ++ loggingDeps ++ testDeps

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.url("gatling", url("http://dl.bintray.com/content/gatling/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("io.gatling" % "gatling-build-plugin" % "2.0.4")
+addSbtPlugin("io.gatling" % "gatling-build-plugin" % "2.0.6")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.6.4")
 

--- a/src/sphinx/code/AdvancedTutorial.scala
+++ b/src/sphinx/code/AdvancedTutorial.scala
@@ -28,10 +28,10 @@ class AdvancedTutorial extends Simulation {
       .get("/"))
       .pause(7)
       .exec(http("Search")
-      .get("/computers?f=macbook"))
+        .get("/computers?f=macbook"))
       .pause(2)
       .exec(http("Select")
-      .get("/computers/6"))
+        .get("/computers/6"))
       .pause(3)
   }
 
@@ -81,11 +81,11 @@ object Search {
     .pause(1)
     .feed(feeder) // 3
     .exec(http("Search")
-    .get("/computers?f=${searchCriterion}") // 4
-    .check(css("a:contains('${searchComputerName}')", "href").saveAs("computerURL"))) // 5
+      .get("/computers?f=${searchCriterion}") // 4
+      .check(css("a:contains('${searchComputerName}')", "href").saveAs("computerURL"))) // 5
     .pause(1)
     .exec(http("Select")
-    .get("${computerURL}")) // 6
+      .get("${computerURL}")) // 6
     .pause(1)
 }
 //#feeder
@@ -126,8 +126,8 @@ object CheckAndTryMax {
     .get("/computers/new"))
     .pause(1)
     .exec(http("Post")
-    .post("/computers")
-    .check(status.is(session => 200 + ThreadLocalRandom.current.nextInt(2)))) // 2
+      .post("/computers")
+      .check(status.is(session => 200 + ThreadLocalRandom.current.nextInt(2)))) // 2
   //#check
 
   //#tryMax-exitHereIfFailed

--- a/src/sphinx/code/Jms.scala
+++ b/src/sphinx/code/Jms.scala
@@ -43,8 +43,7 @@ class TestJmsDsl extends Simulation {
       .textMessage("hello from gatling jms dsl")
       .property("test_header", "test_value")
       .jmsType("test_jms_type")
-      .check(simpleCheck(checkBodyTextCorrect))
-    )
+      .check(simpleCheck(checkBodyTextCorrect)))
   }
 
   setUp(scn.inject(rampUsersPerSec(10) to 1000 during (2 minutes)))
@@ -54,7 +53,7 @@ class TestJmsDsl extends Simulation {
     // this assumes that the service just does an "uppercase" transform on the text
     m match {
       case tm: TextMessage => tm.getText == "HELLO FROM GATLING JMS DSL"
-      case _ => false
+      case _               => false
     }
   }
 }

--- a/src/sphinx/code/QuickStart.scala
+++ b/src/sphinx/code/QuickStart.scala
@@ -31,8 +31,8 @@ class BasicSimulation extends Simulation { // 3
     .userAgentHeader("Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0")
 
   val scn = scenario("BasicSimulation") // 7
-    .exec(http("request_1")  // 8
-    .get("/")) // 9
+    .exec(http("request_1") // 8
+      .get("/")) // 9
     .pause(5) // 10
 
   setUp( // 11

--- a/src/sphinx/cookbook/code/HandlingJsf.scala
+++ b/src/sphinx/cookbook/code/HandlingJsf.scala
@@ -53,29 +53,30 @@ class HandlingJsf {
         .formParam("javax.faces.partial.render", "form:display")
         .formParam("form:btn", "form:btn")
         .formParam("form", "form")
-        .formParam("form:name", "foo"))
+        .formParam("form:name", "foo")
+    )
   //#example-scenario
 
- object Trinidad {
-   //#trinidad
-   val jsfPageFlowCheck = regex("""\?_afPfm=([^"]*)"""").saveAs("afPfm")
-   val jsfViewStateCheck = regex("""="javax.faces.ViewState" value="([^"]*)"""")
-     .saveAs("viewState")
+  object Trinidad {
+    //#trinidad
+    val jsfPageFlowCheck = regex("""\?_afPfm=([^"]*)"""").saveAs("afPfm")
+    val jsfViewStateCheck = regex("""="javax.faces.ViewState" value="([^"]*)"""")
+      .saveAs("viewState")
 
-   def jsfGet(name: String, url: Expression[String]) = http(name).get(url)
-     .check(jsfViewStateCheck)
-   def jsfPost(name: String, url: Expression[String]) = http(name).post(url)
-     .formParam("javax.faces.ViewState", "${viewState}")
-     .check(jsfViewStateCheck).check(jsfPageFlowCheck)
+    def jsfGet(name: String, url: Expression[String]) = http(name).get(url)
+      .check(jsfViewStateCheck)
+    def jsfPost(name: String, url: Expression[String]) = http(name).post(url)
+      .formParam("javax.faces.ViewState", "${viewState}")
+      .check(jsfViewStateCheck).check(jsfPageFlowCheck)
 
-   def trinidadPost(name: String, url: Expression[String]) = http(name).post(url)
-     .formParam("javax.faces.ViewState", "${viewState}")
-     .queryParam("_afPfm", "${afPfm}")
-     .check(jsfViewStateCheck)
-     .check(jsfPageFlowCheck)
-   def trinidadDownload(name: String, url: Expression[String]) = http(name).post(url)
-     .formParam("javax.faces.ViewState", "${viewState}")
-     .queryParam("_afPfm", "${afPfm}")
-   //#trinidad
- }
+    def trinidadPost(name: String, url: Expression[String]) = http(name).post(url)
+      .formParam("javax.faces.ViewState", "${viewState}")
+      .queryParam("_afPfm", "${afPfm}")
+      .check(jsfViewStateCheck)
+      .check(jsfPageFlowCheck)
+    def trinidadDownload(name: String, url: Expression[String]) = http(name).post(url)
+      .formParam("javax.faces.ViewState", "${viewState}")
+      .queryParam("_afPfm", "${afPfm}")
+    //#trinidad
+  }
 }

--- a/src/sphinx/cookbook/code/PassingParameters.scala
+++ b/src/sphinx/cookbook/code/PassingParameters.scala
@@ -25,7 +25,7 @@ class PassingParameters extends Simulation {
 
   //#injection-from-props
   val nbUsers = Integer.getInteger("users", 1)
-  val myRamp  = java.lang.Long.getLong("ramp", 0L)
+  val myRamp = java.lang.Long.getLong("ramp", 0L)
   setUp(scn.inject(rampUsers(nbUsers) over (myRamp seconds)))
   //#injection-from-props
 }

--- a/src/sphinx/general/code/ComputerWorld.scala
+++ b/src/sphinx/general/code/ComputerWorld.scala
@@ -35,7 +35,8 @@ class ComputerWorld extends Simulation {
       .check(
         status.is(200),
         regex("""\d+ computers found"""),
-        css("#add", "href").saveAs("addComputer")))
+        css("#add", "href").saveAs("addComputer")
+      ))
 
     //#print-all-session-values
     .exec { session =>
@@ -52,8 +53,8 @@ class ComputerWorld extends Simulation {
     //#print-session-value
 
     .exec(http("addNewComputer")
-    .get("${addComputer}")
-    .check(substring("Add a computer")))
+      .get("${addComputer}")
+      .check(substring("Add a computer")))
 
     .exec(_.set("homeComputer", s"homeComputer_${java.util.concurrent.ThreadLocalRandom.current.nextInt(Int.MaxValue)}"))
     .exec(http("postComputers")
@@ -65,6 +66,6 @@ class ComputerWorld extends Simulation {
       .check(substring("${homeComputer}")))
 
   setUp(computerDbScn.inject(
-    constantUsersPerSec(2) during(1 minutes)
+    constantUsersPerSec(2) during (1 minutes)
   ).protocols(httpProtocol))
 }

--- a/src/sphinx/general/code/Scenario.scala
+++ b/src/sphinx/general/code/Scenario.scala
@@ -90,9 +90,9 @@ class Scenario {
   //#repeat-example
 
   //#repeat-variants
-  repeat(20) {myChain}     // will loop on myChain 20 times
-  repeat("${myKey}") {myChain}    // will loop on myChain (Int value of the Session attribute myKey) times
-  repeat(session => session("foo").as[Int] /* or anything that returns an Int*/) {myChain}
+  repeat(20) { myChain } // will loop on myChain 20 times
+  repeat("${myKey}") { myChain } // will loop on myChain (Int value of the Session attribute myKey) times
+  repeat(session => session("foo").as[Int] /* or anything that returns an Int*/ ) { myChain }
   //#repeat-variants
 
   //#foreach
@@ -183,19 +183,19 @@ class Scenario {
   val percentage1, percentage2 = .50
 
   //#doSwitch
-  doSwitch("${myKey}") ( // beware: use parentheses, not curly braces!
+  doSwitch("${myKey}")( // beware: use parentheses, not curly braces!
     key1 -> chain1,
-    key1-> chain2
+    key1 -> chain2
   )
   //#doSwitch
 
   //#doSwitchOrElse
-  doSwitchOrElse("${myKey}") ( // beware: use parentheses, not curly braces!
+  doSwitchOrElse("${myKey}")( // beware: use parentheses, not curly braces!
     key1 -> chain1,
-    key1-> chain2
-  ) (
-    myFallbackChain
-  )
+    key1 -> chain2
+  )(
+      myFallbackChain
+    )
   //#doSwitchOrElse
 
   //#randomSwitch
@@ -210,8 +210,8 @@ class Scenario {
     percentage1 -> chain1,
     percentage2 -> chain2
   ) {
-    myFallbackChain
-  }
+      myFallbackChain
+    }
   //#randomSwitchOrElse
 
   //#uniformRandomSwitch

--- a/src/sphinx/general/code/SimulationSetup.scala
+++ b/src/sphinx/general/code/SimulationSetup.scala
@@ -27,20 +27,20 @@ class SimulationSetup extends Simulation {
     scn.inject(
       nothingFor(4 seconds), // 1
       atOnceUsers(10), // 2
-      rampUsers(10) over(5 seconds), // 3
-      constantUsersPerSec(20) during(15 seconds), // 4
-      constantUsersPerSec(20) during(15 seconds) randomized, // 5
-      rampUsersPerSec(10) to 20 during(10 minutes), // 6
-      rampUsersPerSec(10) to 20 during(10 minutes) randomized, // 7
-      splitUsers(1000) into(rampUsers(10) over(10 seconds)) separatedBy(10 seconds), // 8
-      splitUsers(1000) into(rampUsers(10) over(10 seconds)) separatedBy atOnceUsers(30), // 9
-      heavisideUsers(1000) over(20 seconds) // 10
+      rampUsers(10) over (5 seconds), // 3
+      constantUsersPerSec(20) during (15 seconds), // 4
+      constantUsersPerSec(20) during (15 seconds) randomized, // 5
+      rampUsersPerSec(10) to 20 during (10 minutes), // 6
+      rampUsersPerSec(10) to 20 during (10 minutes) randomized, // 7
+      splitUsers(1000) into (rampUsers(10) over (10 seconds)) separatedBy (10 seconds), // 8
+      splitUsers(1000) into (rampUsers(10) over (10 seconds)) separatedBy atOnceUsers(30), // 9
+      heavisideUsers(1000) over (20 seconds) // 10
     ).protocols(httpConf)
   )
   //#injection
 
   //#throttling
-  setUp(scn.inject(constantUsersPerSec(100) during(30 minutes))).throttle(
+  setUp(scn.inject(constantUsersPerSec(100) during (30 minutes))).throttle(
     reachRps(100) in (10 seconds),
     holdFor(1 minute),
     jumpToRps(50),
@@ -49,6 +49,6 @@ class SimulationSetup extends Simulation {
   //#throttling
 
   //#max-duration
-  setUp(scn.inject(rampUsers(1000) over(20 minutes))).maxDuration(10 minutes)
+  setUp(scn.inject(rampUsers(1000) over (20 minutes))).maxDuration(10 minutes)
   //#max-duration
 }

--- a/src/sphinx/http/code/Checks.scala
+++ b/src/sphinx/http/code/Checks.scala
@@ -49,9 +49,9 @@ class Checks {
     //#headerRegex-example
 
     //#substring
-    substring("foo")                           // same as substring("foo").find.exists
+    substring("foo") // same as substring("foo").find.exists
     substring("foo").findAll.saveAs("indices") // saves a Seq[Int]
-    substring("foo").count.saveAs("counts")    // saves the number of occurrences of foo
+    substring("foo").count.saveAs("counts") // saves the number of occurrences of foo
     //#substring
 
     //#regex
@@ -106,14 +106,14 @@ class Checks {
     //#css-ofType
 
     jsonPath("$..foo.bar[2].baz").
-    //#transform
-    transform(string => string + "foo")
+      //#transform
+      transform(string => string + "foo")
 
     //#transform
 
     jsonPath("$..foo.bar[2].baz").
-    //#transformOption
-    transformOption(extract => extract.orElse(Some("default")).success)
+      //#transformOption
+      transformOption(extract => extract.orElse(Some("default")).success)
     //#transformOption
 
     //#is

--- a/src/sphinx/http/code/HttpProtocol.scala
+++ b/src/sphinx/http/code/HttpProtocol.scala
@@ -35,10 +35,12 @@ class HttpProtocol extends Simulation {
     val scn = scenario("My Scenario")
       .exec(
         http("My Request")
-          .get("/my_path")) // Will actually make a request on "http://my.website.tld/my_path"
+          .get("/my_path")
+      ) // Will actually make a request on "http://my.website.tld/my_path"
       .exec(
         http("My Other Request")
-          .get("http://other.website.tld")) // Will make a request on "http://other.website.tld"
+          .get("http://other.website.tld")
+      ) // Will make a request on "http://other.website.tld"
 
     setUp(scn.inject(atOnceUsers(1)).protocols(httpConf))
     //#baseUrl
@@ -76,7 +78,7 @@ class HttpProtocol extends Simulation {
       //#headers
       .header("foo", "bar")
       .headers(Map("foo" -> "bar", "baz" -> "qix"))
-      //#headers
+    //#headers
   }
 
   {

--- a/src/sphinx/http/code/HttpRequest.scala
+++ b/src/sphinx/http/code/HttpRequest.scala
@@ -131,7 +131,7 @@ class HttpRequest {
     //#outgoing-proxy
     http("Getting issues")
       .get("https://github.com/gatling/gatling/issues")
-      .proxy(Proxy("myProxyHost", 8080).httpsPort(8143).credentials("myUsername","myPassword"))
+      .proxy(Proxy("myProxyHost", 8080).httpsPort(8143).credentials("myUsername", "myPassword"))
     //#outgoing-proxy
 
     //#virtual-host
@@ -174,7 +174,7 @@ class HttpRequest {
           .get("http://gatling.io/assets/images/img1.png")
           .notSilent
       )
-      //#notSilent
+    //#notSilent
 
     //#formParam
     http("My Form Data")
@@ -241,7 +241,7 @@ class HttpRequest {
       // myFileBody.json is a file that contains
       // { "myContent": "{myDynamicValue}" }
       .body(PebbleFileBody("myFileBody.json")).asJSON
-      //#PebbleBody
+    //#PebbleBody
 
     //#templates
     object Templates {
@@ -262,14 +262,15 @@ class HttpRequest {
     //#resp-processors-imports
 
     http("foo").get("bar")
-    //#response-processors
+      //#response-processors
 
-    // ignore when response isn't received (e.g. when connection refused)
-    .transformResponse { case response if response.isReceived =>
-      new ResponseWrapper(response) {
-        override val body = new ByteArrayResponseBody(Base64.decode(response.body.string), UTF_8)
+      // ignore when response isn't received (e.g. when connection refused)
+      .transformResponse {
+        case response if response.isReceived =>
+          new ResponseWrapper(response) {
+            override val body = new ByteArrayResponseBody(Base64.decode(response.body.string), UTF_8)
+          }
       }
-    }
     //#response-processors
   }
 

--- a/src/sphinx/http/code/Sse.scala
+++ b/src/sphinx/http/code/Sse.scala
@@ -30,7 +30,7 @@ class Sse {
   //#sseClose
   exec(sse("Close SSE").close())
   //#sseClose
-  
+
   //#reconciliate
   exec(sse("Reconciliate states").reconciliate)
   //#reconciliate
@@ -64,7 +64,8 @@ class Sse {
   val scn = scenario("Server Sent Event")
     .exec(
       sse("Stocks").open("/stocks/prices")
-      .check(wsAwait.within(10).until(1).regex(""""event":"snapshot(.*)"""")))
+        .check(wsAwait.within(10).until(1).regex(""""event":"snapshot(.*)""""))
+    )
     .pause(15)
     .exec(sse("Close SSE").close())
   //#stock-market-sample

--- a/src/sphinx/http/code/WebSocket.scala
+++ b/src/sphinx/http/code/WebSocket.scala
@@ -81,12 +81,11 @@ class WebSocket {
     .exec(ws("Connect WS").open("/room/chat?username=${id}"))
     .pause(1)
     .repeat(2, "i") {
-    exec(ws("Say Hello WS")
-      .sendText("""{"text": "Hello, I'm ${id} and this is message ${i}!"}""")
-      .check(wsAwait.within(30).until(1).regex(".*I'm still alive.*"))
-    )
-      .pause(1)
-  }
+      exec(ws("Say Hello WS")
+        .sendText("""{"text": "Hello, I'm ${id} and this is message ${i}!"}""")
+        .check(wsAwait.within(30).until(1).regex(".*I'm still alive.*")))
+        .pause(1)
+    }
     .exec(ws("Close WS").close)
   //#chatroom-example
 }

--- a/src/sphinx/project/code/FAQ.scala
+++ b/src/sphinx/project/code/FAQ.scala
@@ -39,8 +39,8 @@ class FAQ {
     import ChainLibrary2._
 
     val scn = scenario("Name")
-      .exec(chain1, chain2,/* etc... */ chain100)
-      .exec(chain101, chain102,/* etc... */ chain150)
+      .exec(chain1, chain2, /* etc... */ chain100)
+      .exec(chain101, chain102, /* etc... */ chain150)
   }
   //#chains
 }

--- a/src/sphinx/session/code/Feeders.scala
+++ b/src/sphinx/session/code/Feeders.scala
@@ -33,11 +33,11 @@ class Feeders {
 
     csv("foo")
       //#strategies
-      .queue    // default behavior: use an Iterator on the underlying sequence
-      .random   // randomly pick an entry in the sequence
-      .shuffle  // shuffle entries, then behave like queue
+      .queue // default behavior: use an Iterator on the underlying sequence
+      .random // randomly pick an entry in the sequence
+      .shuffle // shuffle entries, then behave like queue
       .circular // go back to the top of the sequence once the end is reached
-      //#strategies
+    //#strategies
   }
 
   {
@@ -45,7 +45,8 @@ class Feeders {
     val feeder = Array(
       Map("foo" -> "foo1", "bar" -> "bar1"),
       Map("foo" -> "foo2", "bar" -> "bar2"),
-      Map("foo" -> "foo3", "bar" -> "bar3")).random
+      Map("foo" -> "foo3", "bar" -> "bar3")
+    ).random
     //#feeder-from-array-with-random
   }
 
@@ -160,29 +161,29 @@ class Feeders {
 
     // index records by project
     val recordsByProject: Map[String, IndexedSeq[Record[String]]] =
-      csv("projectIssue.csv").records.groupBy{ record => record("project") }
+      csv("projectIssue.csv").records.groupBy { record => record("project") }
 
     // convert the Map values to get only the issues instead of the full records
     val issuesByProject: Map[String, IndexedSeq[String]] =
-      recordsByProject.mapValues{ records => records.map {record => record("issue")} }
+      recordsByProject.mapValues { records => records.map { record => record("issue") } }
 
     // inject project
     feed(csv("userProject.csv"))
 
       .exec { session =>
-      // fetch project from  session
-      session("project").validate[String].map { project =>
+        // fetch project from  session
+        session("project").validate[String].map { project =>
 
-        // fetch project's issues
-        val issues = issuesByProject(project)
+          // fetch project's issues
+          val issues = issuesByProject(project)
 
-        // randomly select an issue
-        val selectedIssue = issues(ThreadLocalRandom.current.nextInt(issues.length))
+          // randomly select an issue
+          val selectedIssue = issues(ThreadLocalRandom.current.nextInt(issues.length))
 
-        // inject the issue in the session
-        session.set("issue", selectedIssue)
+          // inject the issue in the session
+          session.set("issue", selectedIssue)
+        }
       }
-    }
     //#user-dependent-data
   }
 }

--- a/src/sphinx/session/code/SessionSpec.scala
+++ b/src/sphinx/session/code/SessionSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.gatling.core.session.{SessionAttribute, Session}
+import io.gatling.core.session.{ SessionAttribute, Session }
 
 class SessionSpec {
 


### PR DESCRIPTION
Info log level now shows no exception and provides the timeout in the message for clarity (previously not stated):
16:53:20.762 [INFO ] i.g.h.a.HttpEngine - Start warm up
16:53:20.850 [INFO ] i.g.h.a.HttpEngine - Couldn't execute warm up request http://gatling.io after 1000 ms
16:53:20.852 [INFO ] i.g.h.a.HttpEngine - Warm up done

