### PR TITLE
Fixed broken link to CSS Selectors documentation

### DIFF
--- a/src/sphinx/http/http_check.rst
+++ b/src/sphinx/http/http_check.rst
@@ -236,7 +236,7 @@ Same as :ref:`jsonPath <http-check-jsonpath>` but for `JSONP <http://en.wikipedi
 
 * ``css(expression, attribute)``
 
-Gatling supports `CSS Selectors <http://jodd.org/doc/csselly>`_.
+Gatling supports `CSS Selectors <https://jodd.org/csselly/>`_.
 
 *expression*  can be a plain ``String``, a ``String`` using Gatling EL or an ``Expression[String]``.
 


### PR DESCRIPTION
http://jodd.org/doc/csselly -> https://jodd.org/csselly/