### PR TITLE
On the Statistics chart, sort group names and request names by name.

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/template/StatsJsTemplate.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/template/StatsJsTemplate.scala
@@ -44,14 +44,16 @@ ${fieldName("stats")}: $jsonStats"""
     }
 
     def renderSubGroups(group: GroupContainer): Iterable[Fastring] =
-      group.groups.values.map { subGroup =>
+      group.groups.toSeq.sortBy(_._1).map { grpTmp =>
+        val subGroup = grpTmp._2
         fast""""${subGroup.name.toGroupFileName(charset)}": {
           ${renderGroup(subGroup)}
      }"""
       }
 
     def renderSubRequests(group: GroupContainer): Iterable[Fastring] =
-      group.requests.values.map { request =>
+      group.requests.toSeq.sortBy(_._1).map { reqTmp =>
+        val request = reqTmp._2
         fast""""${request.name.toRequestFileName(charset)}": {
         ${fieldName("type")}: "$Request",
         ${renderStats(request.stats, request.stats.path.toRequestFileName(charset))}


### PR DESCRIPTION
This is a suggestion.
In the Statistics chart, it is easy to see that group names and request names are sorted by name.

For example:
![example](https://user-images.githubusercontent.com/15319200/33113569-59669afa-cf9c-11e7-8362-31da99784225.png)


