### PR TITLE
Add method 'runForResults' to run Gatling and get run result

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/GatlingRunResult.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/GatlingRunResult.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2011-2017 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package io.gatling.app
+
+import io.gatling.app.cli.StatusCode
+
+case class GatlingRunResult(statusCode: StatusCode, runResult: RunResult)


### PR DESCRIPTION
Hello,

The main idea is provide functionality to get gatling run result for following processing. Gatling saves an execution results and simulation log in autogenerated folder. There is no way to get autogeneraed value, but thvaule is stored in 'RunResult'.
I suggest adding a method that returns the result of gatling run.

Thanks
Maksym