### PR TITLE
added import to documentation (assertions didn't work without it)

### DIFF
--- a/src/sphinx/general/assertions.rst
+++ b/src/sphinx/general/assertions.rst
@@ -27,7 +27,10 @@ All the assertions are evaluated after running the simulation. If at least one a
 Scope
 =====
 
-An assertion can test a statistic calculated from all requests or only a part.
+An assertion can test a statistic calculated from all requests or only a part. 
+To use a scope you need to add this import ``import io.gatling.core.Predef._``.
+
+Following scopes are available:
 
 * ``global``: use statistics calculated from all requests.
 


### PR DESCRIPTION
an example didn't work without it. Actually none of the functions/scopes described were usable without this import.
This is an attempt to improve documentation, as I stumbled upon the problem while trying to do things described.