### PR TITLE
JMS: Tracker Destination can by specified independent from replyTo Destination with doc

### DIFF
--- a/gatling-jms/src/main/scala/io/gatling/jms/action/RequestReplyBuilder.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/action/RequestReplyBuilder.scala
@@ -24,7 +24,7 @@ import io.gatling.core.structure.ScenarioContext
 import io.gatling.jms.protocol.{ JmsComponents, JmsProtocol }
 import io.gatling.jms.request.{ JmsAttributes, JmsDestination }
 
-case class RequestReplyBuilder(attributes: JmsAttributes, replyDestination: JmsDestination, configuration: GatlingConfiguration) extends ActionBuilder {
+case class RequestReplyBuilder(attributes: JmsAttributes, replyDestination: JmsDestination, trackerDestination: Option[JmsDestination], configuration: GatlingConfiguration) extends ActionBuilder {
 
   private def components(protocolComponentsRegistry: ProtocolComponentsRegistry): JmsComponents =
     protocolComponentsRegistry.components(JmsProtocol.JmsProtocolKey)
@@ -33,6 +33,6 @@ case class RequestReplyBuilder(attributes: JmsAttributes, replyDestination: JmsD
     import ctx._
     val statsEngine = coreComponents.statsEngine
     val jmsComponents = components(protocolComponentsRegistry)
-    new RequestReply(attributes, replyDestination, jmsComponents.jmsProtocol, jmsComponents.jmsConnectionPool, statsEngine, next)
+    new RequestReply(attributes, replyDestination, trackerDestination, jmsComponents.jmsProtocol, jmsComponents.jmsConnectionPool, statsEngine, next)
   }
 }

--- a/gatling-jms/src/main/scala/io/gatling/jms/request/JmsDslBuilder.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/request/JmsDslBuilder.scala
@@ -53,7 +53,7 @@ case class RequestReplyDslBuilderQueue(
 
   def queue(name: Expression[String]) = destination(JmsQueue(name))
 
-  def destination(destination: JmsDestination) = RequestReplyDslBuilderMessage(requestName, destination, JmsTemporaryQueue, None, configuration)
+  def destination(destination: JmsDestination) = RequestReplyDslBuilderMessage(requestName, destination, JmsTemporaryQueue, None, None, configuration)
 }
 
 case class SendDslDslBuilderMessage(
@@ -74,6 +74,7 @@ case class RequestReplyDslBuilderMessage(
     requestName:     Expression[String],
     destination:     JmsDestination,
     replyDest:       JmsDestination,
+    trackerDest:     Option[JmsDestination],
     messageSelector: Option[String],
     configuration:   GatlingConfiguration
 ) {
@@ -82,6 +83,8 @@ case class RequestReplyDslBuilderMessage(
    */
   def replyQueue(name: Expression[String]) = replyDestination(JmsQueue(name))
   def replyDestination(destination: JmsDestination) = this.copy(replyDest = destination)
+  def trackerQueue(name: Expression[String]) = trackerDestination(JmsQueue(name))
+  def trackerDestination(destination: JmsDestination) = this.copy(trackerDest = Some(destination))
 
   /**
    * defines selector for reply destination that is used for responses
@@ -95,7 +98,7 @@ case class RequestReplyDslBuilderMessage(
   def objectMessage(o: Expression[JSerializable]) = message(ObjectJmsMessage(o))
 
   private def message(mess: JmsMessage) =
-    RequestReplyDslBuilder(JmsAttributes(requestName, destination, messageSelector, mess), RequestReplyBuilder.apply(_, replyDest, configuration))
+    RequestReplyDslBuilder(JmsAttributes(requestName, destination, messageSelector, mess), RequestReplyBuilder.apply(_, replyDest, trackerDest, configuration))
 }
 
 case class SendDslBuilder(attributes: JmsAttributes, factory: JmsAttributes => ActionBuilder) {

--- a/src/sphinx/cheat-sheet.html
+++ b/src/sphinx/cheat-sheet.html
@@ -3118,6 +3118,21 @@
               </div>
 
               <div class="function">
+                <label class="function-syntax" for="trackerDestination">trackerDestination</label>
+                <input type="checkbox" id="trackerDestination" name="trackerDestination">
+
+                <div class="function-details">
+                  On default gatling tracks the replies on the <code>replyDestination</code>.
+                  Optionally you can overwrite this destination with the parameter <code>trackerDestination</code>
+                  <dl>
+                    <dt>(destination)</dt>
+                    <dd>Where <i>destination</i> is an instance of JmsDestination</dd>
+                  </dl>
+                </div>
+              </div>
+
+
+              <div class="function">
                 <label class="function-syntax" for="selector">selector</label>
                 <input type="checkbox" id="selector" name="selector">
 

--- a/src/sphinx/cheat-sheet.html
+++ b/src/sphinx/cheat-sheet.html
@@ -3048,7 +3048,7 @@
               <h3>Commons</h3>
 
               <div class="function">
-                <label class="function-syntax" for="reqreply">reqreply</label>
+                <label class="function-syntax" for="reqreply">requestReply</label>
                 <input type="checkbox" id="reqreply" name="reqreply">
 
                 <div class="function-details">

--- a/src/sphinx/jms.rst
+++ b/src/sphinx/jms.rst
@@ -62,6 +62,9 @@ Optionally define reply destination with ``replyQueue("responseQueue")`` or ``re
 
 Additionally for reply destination JMS selector can be defined with ``selector("selector")``
 
+If you have the need, to measure the time when a message arrive at a different message queue then the ``replyDestination(JmsDestination)``
+you can additional define a ``trackerDestination(JmsDestination)``.
+
 
 Message Matching
 ----------------


### PR DESCRIPTION
Fix the comments from #3401, adjust the code, so that at can be merged into master and added documentation.
The motivation for the pull request can be found in detail at #3401.
