### PR TITLE
Tiny formatting change

### DIFF
--- a/src/sphinx/general/assertions.rst
+++ b/src/sphinx/general/assertions.rst
@@ -119,7 +119,7 @@ To help you understand how to use assertions, here is a list of examples :
 Reports
 =======
 
-If a simulation defines assertions, Gatling will generate 2 reports in the js result directory:
+If a simulation defines assertions, Gatling will generate 2 reports in the ``js`` result directory:
 
 * a JSON file
 * a JUnit file


### PR DESCRIPTION
The `js` directory is highlighted to stand up more from the text. It's hard to notice and people may actually miss it, partially because `js` is a strange directory where to store statistics. More suitable would be the root or separate `stats` directory