### PR TITLE
Doc: Fix typo in gatling-defaults.conf file

### DIFF
--- a/gatling-core/src/main/resources/gatling-defaults.conf
+++ b/gatling-core/src/main/resources/gatling-defaults.conf
@@ -73,7 +73,7 @@ gatling {
     }
     ahc {
       connectTimeout = 10000                              # Timeout when establishing a connection
-      handshakeTimeout = 10000                            # Timeout when performing TLS hashshake
+      handshakeTimeout = 10000                            # Timeout when performing TLS handshake
       pooledConnectionIdleTimeout = 60000                 # Timeout when a connection stays unused in the pool
       maxRetry = 2                                        # Number of times that a request should be tried again
       requestTimeout = 60000                              # Timeout of the requests


### PR DESCRIPTION
Change `hashshake` → `handshake` in the gatling-defaults.conf file