### PR TITLE
Lookup JMS Queues and Topics via JNDI

### DIFF
--- a/gatling-jms/src/main/scala/io/gatling/jms/client/JmsClient.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/client/JmsClient.scala
@@ -84,8 +84,8 @@ abstract class JmsClient(
 
   def createDestination(destination: JmsDestination): Destination =
     destination match {
-      case JmsQueue(name)    => session.createQueue(name)
-      case JmsTopic(name)    => session.createTopic(name)
+      case JmsQueue(name)    => ctx.lookup(name).asInstanceOf[Queue]
+      case JmsTopic(name)    => ctx.lookup(name).asInstanceOf[Topic]
       case JmsTemporaryQueue => session.createTemporaryQueue()
       case JmsTemporaryTopic => session.createTemporaryTopic()
     }


### PR DESCRIPTION
JEE recommends to lookup JMS Queues and Topics via JNDI instead of using
createQueue/createTopic.

see https://docs.oracle.com/javaee/7/api/javax/jms/Session.html#createQueue-java.lang.String-