### PR TITLE
Allow the user to pass arbitrary scala compiler options

### DIFF
--- a/gatling-bundle/src/universal/bin/gatling.sh
+++ b/gatling-bundle/src/universal/bin/gatling.sh
@@ -47,7 +47,12 @@ GATLING_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_HOME/user-files:$COMMON_CLASSPAT
 # Build compilation classpath
 COMPILATION_CLASSPATH=`find "$GATLING_HOME/lib" -maxdepth 1 -name "*.jar" -type f -exec printf :{} ';'`
 
+# Use the extra compiler options flag only if zinc options are provided
+if [ -n "$ZINC_OPTIONS" ]; then
+    EXTRA_COMPILER_OPTIONS="-co $ZINC_OPTIONS"
+fi
+
 # Run the compiler
-"$JAVA" $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler -ccp "$COMPILATION_CLASSPATH" "$@"  2> /dev/null
+"$JAVA" $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler $EXTRA_COMPILER_OPTIONS -ccp "$COMPILATION_CLASSPATH" "$@"  2> /dev/null
 # Run Gatling
 "$JAVA" $DEFAULT_JAVA_OPTS $JAVA_OPTS -cp "$GATLING_CLASSPATH" io.gatling.app.Gatling "$@"

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/ZincCompiler.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/ZincCompiler.scala
@@ -48,7 +48,7 @@ object ZincCompiler extends App {
     "-unchecked",
     "-language:implicitConversions",
     "-language:postfixOps"
-  )
+  ) ++ configuration.extraCompilerOptions
 
   Files.createDirectories(configuration.binariesDirectory)
 

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/CompilerConfiguration.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/CompilerConfiguration.scala
@@ -29,7 +29,8 @@ private[compiler] case class CompilerConfiguration(
     encoding:             String,
     simulationsDirectory: Path,
     binariesDirectory:    Path,
-    classpathElements:    Seq[File]
+    classpathElements:    Seq[File],
+    extraCompilerOptions: Seq[String]
 )
 
 private[compiler] object CompilerConfiguration {
@@ -65,8 +66,9 @@ private[compiler] object CompilerConfiguration {
     val simulationsDirectory = resolvePath(Paths.get(config.getString(simulationsDirectoryKey)))
     val binariesDirectory = string2option(config.getString(binariesDirectoryKey)).map(path => resolvePath(path)).getOrElse(GatlingHome / "target" / "test-classes")
     val classpathElements = commandLineOverrides.classpathElements.split(File.pathSeparator).map(new File(_))
+    val compilerOptions = commandLineOverrides.compilerOptions.split(",").toSeq
 
-    CompilerConfiguration(encoding, simulationsDirectory, binariesDirectory, classpathElements)
+    CompilerConfiguration(encoding, simulationsDirectory, binariesDirectory, classpathElements, compilerOptions)
   }
 
 }

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/ArgsParser.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/ArgsParser.scala
@@ -22,7 +22,8 @@ import io.gatling.compiler.config.cli.CommandLineConstants._
 private[config] case class CommandLineOverrides(
     simulationsDirectory: String = "",
     binariesFolder:       String = "",
-    classpathElements:    String = ""
+    classpathElements:    String = "",
+    compilerOptions:      String = ""
 )
 
 private[config] class ArgsParser(args: Array[String]) {
@@ -45,6 +46,9 @@ private[config] class ArgsParser(args: Array[String]) {
 
     opt[String](CompilerClasspath)
       .action { (classpath, c) => c.copy(classpathElements = classpath) }
+
+    opt[String](CompilerOptions)
+      .action { (options, c) => c.copy(compilerOptions = options) }
   }
 
   def parseArguments =

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/CommandLineConstants.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/CommandLineConstants.scala
@@ -20,5 +20,6 @@ private[cli] case class CommandLineConstant(full: String, abbr: String)
 private[cli] object CommandLineConstants {
   val SimulationsFolder = CommandLineConstant("simulations-folder", "sf")
   val CompilerClasspath = CommandLineConstant("compilerClasspath", "ccp")
+  val CompilerOptions = CommandLineConstant("compilerOptions", "co")
   val BinariesFolder = CommandLineConstant("binaries-folder", "bf")
 }


### PR DESCRIPTION
With the DSE java-driver, we need to pass `-Ybreak-cycles` to the scala compiler.  Instead of hardcoding that option in `ZincCompiler`, this PR introduces a new command line parameter: `-co` or `--compilerOptions` that allows arbitrary options to be passed.

A new environment variable has been added in `gatling.sh`: ZINC_OPTIONS.  If it is set, then its content is used as the value for `-co`.  I added it because I think compiler arguments should not be passed in `$@` and end up in the real `Gatling` invocation.

Q: in `CommandLineConstants.scala`, two long parameters are in kebab-case, while the third one (related to the compiler) is in camelCase.  I did not know which one to choose.  Should I favour consistency with other compiler parameters (camel) or with the majority of parameters (kebab)?

I tested this code locally as follows:

```
$ ./bin/gatling.sh
GATLING_HOME is set to /tmp/gatling
13:18:00.810 [WARN ] i.g.c.ZincCompiler$ - Pruning sources from previous analysis, due to incompatible CompileSetup.
13:18:02.753 [ERROR] i.g.c.ZincCompiler$ - /tmp/gatling/user-files/simulations/ExampleDseSimulation.scala:11: illegal cyclic reference involving class Cluster
13:18:02.754 [ERROR] i.g.c.ZincCompiler$ -   private val cluster = DseCluster.builder().addContactPoint("127.0.0.1").build()
13:18:02.754 [ERROR] i.g.c.ZincCompiler$ -                                    ^
13:18:02.773 [ERROR] i.g.c.ZincCompiler$ - /tmp/gatling/user-files/simulations/ExampleDseSimulation.scala:13: illegal cyclic reference involving class Cluster
13:18:02.773 [ERROR] i.g.c.ZincCompiler$ -   private val statement: PreparedStatement = session.prepare("SELECT now() FROM system.local;")
13:18:02.773 [ERROR] i.g.c.ZincCompiler$ -                                                      ^
13:18:05.911 [ERROR] i.g.c.ZincCompiler$ - two errors found
13:18:05.913 [ERROR] i.g.c.ZincCompiler$ - Compilation crashed
[...]

$ ZINC_OPTIONS="-Ybreak-cycles" ./bin/gatling.sh
GATLING_HOME is set to /tmp/gatling
13:29:53.734 [WARN ] i.g.c.ZincCompiler$ - Breaking cycle in base class computation of class Cluster in com.datastax.driver.core (List(class Cluster, trait Closeable, trait AutoCloseable, class Object, class Any))
[...]
Choose a simulation number:
[...]
```