### PR TITLE
doc compile error when sbt publishM2

### DIFF
--- a/gatling-core/src/main/java/io/gatling/core/jodd/FixedLazyMap.java
+++ b/gatling-core/src/main/java/io/gatling/core/jodd/FixedLazyMap.java
@@ -62,7 +62,7 @@ public class FixedLazyMap extends AbstractMap {
   }
 
   @Override
-  public Set<Entry<Object, Object>> entrySet() {
+  public Set<Map.Entry<Object, Object>> entrySet() {
     buildIfNeeded();
     return map.entrySet();
   }


### PR DESCRIPTION
ERROR message:

[info] Main Scala API documentation to /pp/gatling/gatling-test-framework/target/api...
[error] /pp/gatling/gatling-core/src/main/java/io/gatling/core/jodd/FixedLazyMap.java:65:14: not found: type Entry
[error]   public Set<Entry<Object, Object>> entrySet() {
[error]      