### PR TITLE
App: Allow the user to pass arbitrary scalac options

### DIFF
--- a/gatling-bundle/src/universal/bin/gatling.sh
+++ b/gatling-bundle/src/universal/bin/gatling.sh
@@ -43,7 +43,13 @@ COMPILER_OPTS="-Xss100M $DEFAULT_JAVA_OPTS $JAVA_OPTS"
 COMPILER_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_CONF:"
 GATLING_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_HOME/user-files:$GATLING_CONF:"
 
+
+# Use the extra compiler options flag only if they are provided
+if [ -n "$EXTRA_SCALAC_OPTIONS" ]; then
+    EXTRA_COMPILER_OPTIONS="-eso $EXTRA_SCALAC_OPTIONS"
+fi
+
 # Run the compiler
-"$JAVA" $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler "$@" 2> /dev/null
+"$JAVA" $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler $EXTRA_COMPILER_OPTIONS "$@" 2> /dev/null
 # Run Gatling
 "$JAVA" $DEFAULT_JAVA_OPTS $JAVA_OPTS -cp "$GATLING_CLASSPATH" io.gatling.app.Gatling "$@"

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/ZincCompiler.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/ZincCompiler.scala
@@ -190,7 +190,7 @@ object ZincCompiler extends App with ProblemStringFormats {
         "-unchecked",
         "-language:implicitConversions",
         "-language:postfixOps"
-      ),
+      ) ++ configuration.extraScalacOptions,
       javacOptions = Array.empty,
       maxErrors,
       sourcePositionMappers = Array.empty,

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/CompilerConfiguration.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/CompilerConfiguration.scala
@@ -28,7 +28,8 @@ import com.typesafe.config.ConfigFactory
 private[compiler] case class CompilerConfiguration(
     encoding:             String,
     simulationsDirectory: Path,
-    binariesDirectory:    Path
+    binariesDirectory:    Path,
+    extraScalacOptions:   Seq[String]
 )
 
 private[compiler] object CompilerConfiguration {
@@ -64,7 +65,8 @@ private[compiler] object CompilerConfiguration {
     val simulationsDirectory = resolvePath(Paths.get(config.getString(simulationsDirectoryKey)))
     val binariesDirectory = string2option(config.getString(binariesDirectoryKey))
       .fold(GatlingHome / "target" / "test-classes")(resolvePath(_))
+    val extraScalacOptions = commandLineOverrides.extraScalacOptions.split(",").toSeq
 
-    CompilerConfiguration(encoding, simulationsDirectory, binariesDirectory)
+    CompilerConfiguration(encoding, simulationsDirectory, binariesDirectory, extraScalacOptions)
   }
 }

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/ArgsParser.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/ArgsParser.scala
@@ -22,7 +22,8 @@ import io.gatling.compiler.config.cli.CommandLineConstants._
 
 private[config] case class CommandLineOverrides(
     simulationsDirectory: String = "",
-    binariesFolder:       String = ""
+    binariesFolder:       String = "",
+    extraScalacOptions:   String = ""
 )
 
 private[config] class ArgsParser(args: Array[String]) {
@@ -42,6 +43,9 @@ private[config] class ArgsParser(args: Array[String]) {
 
     opt[String](BinariesFolder)
       .action { (binFolder, c) => c.copy(binariesFolder = binFolder) }
+
+    opt[String](ExtraScalacOptions)
+      .action { (extraScalacOpts, c) => c.copy(extraScalacOptions = extraScalacOpts) }
   }
 
   def parseArguments =

--- a/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/CommandLineConstants.scala
+++ b/gatling-compiler/src/main/scala/io/gatling/compiler/config/cli/CommandLineConstants.scala
@@ -21,4 +21,5 @@ private[cli] case class CommandLineConstant(full: String, abbr: String)
 private[cli] object CommandLineConstants {
   val SimulationsFolder = CommandLineConstant("simulations-folder", "sf")
   val BinariesFolder = CommandLineConstant("binaries-folder", "bf")
+  val ExtraScalacOptions = CommandLineConstant("extra-scalac-options", "eso")
 }


### PR DESCRIPTION
Do not merge yet: not tested

With the DSE java-driver, we need to pass `-Ybreak-cycles` to the scala compiler. Instead of hardcoding that option in `ZincCompiler`, this PR introduces a new command line parameter: `-eso` or `--extra-scalac-options` that allows arbitrary options to be passed.

A new environment variable has been added in gatling.sh: EXTRA_SCALAC_OPTIONS. If it is set, then its content is used as the value for `-eso`. I added it because I think compiler arguments should not be passed in `$@` and end up in the real Gatling invocation.

Not tested yet: for some reason, I get the following behavior on `master`.  I reproduced the problem without the patch, which makes me think there is something wrong on master.  Does anyone have the same issue?

```bash
$ ./bin/gatling.sh
GATLING_HOME is set to /tmp/gatling-charts-highcharts-bundle-3.0.0-SNAPSHOT
There is no simulation script. Please check that your scripts are in user-files/simulations
```
