### PR TITLE
add type anntation for better documentation

### DIFF
--- a/src/sphinx/code/AdvancedTutorialSample.scala
+++ b/src/sphinx/code/AdvancedTutorialSample.scala
@@ -25,7 +25,7 @@ class AdvancedTutorial extends Simulation {
   //#isolate-processes
   object Search {
 
-    val search = exec(http("Home") // let's give proper names, as they are displayed in the reports
+    val search: ChainBuilder = exec(http("Home") // let's give proper names, as they are displayed in the reports
       .get("/"))
       .pause(7)
       .exec(http("Search")


### PR DESCRIPTION
Since this is used in https://gatling.io/docs/current/advanced_tutorial/#step-01-isolate-processes it would be better to label the type of the value, so that people would have a easier time to get it to compile.