### PR TITLE
Make parentheses-vs-curly-braces more explicit

### DIFF
--- a/src/sphinx/general/scenario.rst
+++ b/src/sphinx/general/scenario.rst
@@ -325,6 +325,8 @@ Similar to ``doSwitch``, but with a fallback if no switch is selected.
 ``randomSwitch`` can be used to emulate simple Markov chains.
 Simple means cyclic graphs are not currently supported.
 
+.. warning:: Beware: you have to use parentheses when using these switch methods, curly braces will change the semantic and will not work as expected.
+
 .. includecode:: code/ScenarioSample.scala#randomSwitch
 
 Percentages sum can't exceed 100%.


### PR DESCRIPTION
In documentation the warnings about curly braces not working for randomSwitch methods are put in comments, which are practically invisible in most cases. I suggest to add a more explicit warning about that to avoid a confusion, as using braces does compile and breaks during runtime only.