### PR TITLE
Remove hard dependency on logback

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
@@ -26,9 +26,10 @@ import io.gatling.app.cli.ArgsParser
 import io.gatling.core.config.GatlingConfiguration
 
 import akka.actor.ActorSystem
-import ch.qos.logback.classic.LoggerContext
 import com.typesafe.scalalogging.StrictLogging
 import org.slf4j.LoggerFactory
+
+import scala.util.{ Failure, Try }
 
 /**
  * Object containing entry point of application
@@ -81,6 +82,11 @@ object Gatling extends StrictLogging {
         }
       RunResultProcessor(configuration).processRunResult(runResult).code
     } finally {
-      LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext].stop()
+      val factoryClass = LoggerFactory.getILoggerFactory.getClass
+      Try(factoryClass.getMethod("stop").invoke(factoryClass)).recoverWith {
+        case e: Throwable =>
+          logger.warn("The LoggerFactory of your logging framework does not have a stop method. In case you run into buffering issues consider switching to logback or log4j2 which support flushing the buffer before shutdown.")
+          Failure(e)
+      }
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
 
   // format: ON
 
-  private val loggingDeps = Seq(slf4jApi, scalaLogging, logback)
+  private val loggingDeps = Seq(slf4jApi, scalaLogging)
   private val testDeps = Seq(scalaTest, scalaCheck, akkaTestKit, mockitoCore)
   private val parserDeps = Seq(jsonpath, jackson, joddJson, saxon, joddLagarto)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
 
   // format: ON
 
-  private val loggingDeps = Seq(slf4jApi, scalaLogging)
+  private val loggingDeps = Seq(slf4jApi, scalaLogging, logback)
   private val testDeps = Seq(scalaTest, scalaCheck, akkaTestKit, mockitoCore)
   private val parserDeps = Seq(jsonpath, jackson, joddJson, saxon, joddLagarto)
 


### PR DESCRIPTION
This will allow to choosing other logging frameworks especially when using the Gatling SBT plugin as part of an existing project.

Solves https://github.com/gatling/gatling/issues/3340