### PR TITLE
Removed incorrect log message when logging provider is log4j2

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Gatling.scala
@@ -21,11 +21,10 @@ import java.nio.file.FileSystems
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
-
 import io.gatling.app.cli.ArgsParser
 import io.gatling.core.config.GatlingConfiguration
-
 import akka.actor.ActorSystem
+import ch.qos.logback.classic.LoggerContext
 import com.typesafe.scalalogging.StrictLogging
 import org.slf4j.LoggerFactory
 
@@ -80,12 +79,10 @@ object Gatling extends StrictLogging {
         }
       RunResultProcessor(configuration).processRunResult(runResult).code
     } finally {
-      val factory = LoggerFactory.getILoggerFactory
       try {
-        factory.getClass.getMethod("stop").invoke(factory)
+        LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext].stop()
       } catch {
-        case NonFatal(e) =>
-          logger.warn("The LoggerFactory of your logging framework does not have a stop method. In case you run into buffering issues consider switching to logback or log4j2 which support flushing the buffer before shutdown.", e)
+        case e: Throwable => //Log nothing. Fail silently if a provider other than LogBack is used.
       }
     }
 }


### PR DESCRIPTION
- Fail silently when stop method isn't invoked correctly