### PR TITLE
Change config priority

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingConfiguration.scala
@@ -98,7 +98,7 @@ object GatlingConfiguration extends StrictLogging {
     val customConfig = ConfigFactory.parseResources(classLoader, customConfigFile)
     val propertiesConfig = ConfigFactory.parseMap(props.asJava)
 
-    val config = configChain(ConfigFactory.systemProperties, customConfig, propertiesConfig, defaultsConfig)
+    val config = configChain(ConfigFactory.systemProperties, propertiesConfig, customConfig, defaultsConfig)
 
     warnAboutRemovedProperties(config)
 


### PR DESCRIPTION
Would it make sense to have properties passed in taking priority over the properties file? My rationale is that one might use the file as sane defaults that can be overridden with code.