### PR TITLE
Update documentation to point to correct plugin (gatling-maven-plugin)

### DIFF
--- a/src/sphinx/extensions/maven_plugin.rst
+++ b/src/sphinx/extensions/maven_plugin.rst
@@ -38,7 +38,7 @@ In your ``pom.xml``, add::
 Demo sample
 ===========
 
-You can find a `sample project demoing the gatling-sbt-plugin <https://github.com/gatling/gatling-sbt-plugin-demo>`_ in Gatling's Github organization.
+You can find a `sample project demoing the gatling-maven-plugin <https://github.com/gatling/gatling-maven-plugin-demo>`_ in Gatling's Github organization.
 
 You can also use the :ref:`gatling-highcharts-maven-archetype <maven-archetype>` to bootstrap your project.
 


### PR DESCRIPTION
This is a small update to the gatling maven plugin documentation to point to the correct demo project.

Currently the maven plugin documentation references the sbt plugin demo rather than the maven plugin demo.