### PR TITLE
Fix workaround for servers that requires HTTP header content-length:0…

### DIFF
--- a/gatling-http-client/src/main/java/io/gatling/http/client/impl/request/WritableRequestBuilder.java
+++ b/gatling-http-client/src/main/java/io/gatling/http/client/impl/request/WritableRequestBuilder.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpMethod.*;
+import static java.util.Arrays.asList;
 
 public class WritableRequestBuilder {
 
@@ -41,7 +42,7 @@ public class WritableRequestBuilder {
                                                          HttpHeaders headers) {
 
     // force content-length to 0 when method usually takes a body, some servers might break otherwise
-    if (!headers.contains(CONTENT_LENGTH) && (method == POST || method == PUT || method == PATCH)) {
+    if (!headers.contains(CONTENT_LENGTH) && asList(POST, PUT, PATCH).contains(method)) {
       headers.set(CONTENT_LENGTH, 0);
     }
 

--- a/gatling-http-client/src/main/java/io/gatling/http/client/impl/request/WritableRequestBuilder.java
+++ b/gatling-http-client/src/main/java/io/gatling/http/client/impl/request/WritableRequestBuilder.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpMethod.*;
-import static java.util.Arrays.asList;
 
 public class WritableRequestBuilder {
 
@@ -42,7 +41,7 @@ public class WritableRequestBuilder {
                                                          HttpHeaders headers) {
 
     // force content-length to 0 when method usually takes a body, some servers might break otherwise
-    if (!headers.contains(CONTENT_LENGTH) && asList(POST, PUT, PATCH).contains(method)) {
+    if (!headers.contains(CONTENT_LENGTH) && (POST.equals(method) || PUT.equals(method) || PATCH.equals(method))) {
       headers.set(CONTENT_LENGTH, 0);
     }
 

--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/Http.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/Http.scala
@@ -34,7 +34,7 @@ case class Http(requestName: Expression[String]) {
   def head(url: Expression[String]): HttpRequestBuilder = httpRequest(HttpMethod.HEAD, url)
   def delete(url: Expression[String]): HttpRequestBuilder = httpRequest(HttpMethod.DELETE, url)
   def options(url: Expression[String]): HttpRequestBuilder = httpRequest(HttpMethod.OPTIONS, url)
-  def httpRequest(method: String, url: Expression[String]): HttpRequestBuilder = httpRequest(new HttpMethod(method), Left(url))
+  def httpRequest(method: String, url: Expression[String]): HttpRequestBuilder = httpRequest(HttpMethod.valueOf(method), Left(url))
   def httpRequest(method: HttpMethod, url: Expression[String]): HttpRequestBuilder = httpRequest(method, Left(url))
   def httpRequest(method: HttpMethod, urlOrURI: Either[Expression[String], Uri]): HttpRequestBuilder = new HttpRequestBuilder(CommonAttributes(requestName, method, urlOrURI), HttpAttributes())
 }


### PR DESCRIPTION
… for POST,PUT,PATCH methods when no body is send. Closes gatling/gatling#3648

Motivation:

Some POST requests without body results with HTTP 411 Length Required
 error on Microsoft Azure cloud servers

Modification:

- httpRequest() passes now existing HttpMethod object instead of creating a new one
- In buildRequestWithoutBody() replace object reference comparison with equals() from comparable HttpMethod class

Result:

HTTP request header 'content-length: 0'  is set as intended for POST,PUT,PATCH methods when no body is send