### PR TITLE
Doc: data and bodies are now in resources dir

### DIFF
--- a/src/sphinx/general/bundle_structure.rst
+++ b/src/sphinx/general/bundle_structure.rst
@@ -10,7 +10,6 @@ The bundle structure is as following:
 * ``user-files``:
 
   * ``simulations`` contains your Simulations scala files. Please respect package folder hierarchy.
-  * ``data`` contains feeder files.
-  * ``bodies`` contains templates for request bodies.
+  * ``resources`` contains feeder files and templates for request bodies.
 
 * ``results`` contains ``simulation.log`` and reports generated in a sub directory.


### PR DESCRIPTION
According to https://gatling.io/docs/current/migration_guides/2.3-to-3.0/
and https://gatling.io/docs/current/session/feeder/