### PR TITLE
Recorder: dump resources to a subfolder named after package

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
@@ -62,7 +62,7 @@ private[scenario] object RequestTemplate {
 
     def renderBodyOrParams: Fastring = request.body.map {
       case _: RequestBodyBytes => fast"""
-			.body(RawFileBody("${ScenarioExporter.requestBodyFileName(request)}"))"""
+			.body(RawFileBody("${ScenarioExporter.requestBodyRelativeFilePath(request)}"))"""
       case RequestBodyParams(params) => params.map {
         case (key, value) => fast"""
 			.formParam(${protectWithTripleQuotes(key)}, ${renderLongString(value)})"""
@@ -84,7 +84,7 @@ private[scenario] object RequestTemplate {
     def renderResponseBodyCheck: Fastring =
       if (request.responseBody.isDefined && config.http.checkResponseBodies)
         fast"""
-			.check(bodyBytes.is(RawFileBody("${ScenarioExporter.responseBodyFileName(request)}")))"""
+			.check(bodyBytes.is(RawFileBody("${ScenarioExporter.responseBodyRelativeFilePath(request)}")))"""
       else
         EmptyFastring
 


### PR DESCRIPTION
Implemention for issue #3706.

master couldn't compile (using OpenJDK 11.0.2), had to change JdkXmlParsers.scala first (commit pmalic@96d6929).

Also changed string interpolators for `requestBodyFileName`/`responseBodyFileName` to `s`, it was `f` although there were no printf-style format strings.