### PR TITLE
Fixed typo, warmpUp -> warmUp

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/engine/HttpEngine.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/engine/HttpEngine.scala
@@ -60,7 +60,7 @@ class HttpEngine(
 
   private[this] var warmedUp = false
 
-  def warmpUp(httpComponents: HttpComponents): Unit =
+  def warmUp(httpComponents: HttpComponents): Unit =
     if (!warmedUp) {
       logger.info("Start warm up")
       warmedUp = true

--- a/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
@@ -65,7 +65,7 @@ object HttpProtocol extends StrictLogging {
           new HttpTxExecutor(coreComponents, httpEngine, httpCaches, defaultStatsProcessor, httpProtocol)
         )
 
-        httpEngine.warmpUp(httpComponents)
+        httpEngine.warmUp(httpComponents)
         httpComponents
       }
     }


### PR DESCRIPTION
I noticed a typo in `io.gatling.http.engine.HttpEngine`, so I fixed it.