### PR TITLE
Improved assertion doc for websockets

### DIFF
--- a/src/sphinx/general/assertions.rst
+++ b/src/sphinx/general/assertions.rst
@@ -35,9 +35,15 @@ An assertion can test a statistic calculated from all requests or only a part.
 
 * ``details(path)``: use statistics calculated from a group or a request. The path is defined like a Unix filesystem path.
 
-For example, to perform an assertion on the request ``Index`` in the group ``Search``, use:
+For example, to perform an assertion on the request ``Search``, use:
 
 .. includecode:: code/AssertionSample.scala#details
+
+and to perform an assertion on the request ``Index`` in the group ``Search``, use:
+
+.. includecode:: code/AssertionSample.scala#details-group
+
+For WebSockets it takes the name of the check and not the name of the request. ``ws.checkTextMessage("use this name")``
 
 .. note::
 

--- a/src/sphinx/general/code/AssertionSample.scala
+++ b/src/sphinx/general/code/AssertionSample.scala
@@ -28,8 +28,12 @@ class AssertionSample extends Simulation {
   //#setUp
 
   //#details
-  details("Search" / "Index")
+  details("Index")
   //#details
+
+  //#details-group
+  details("Search" / "Index")
+  //#details-group
 
   //#examples
   // Assert that the max response time of all requests is less than 100 ms


### PR DESCRIPTION
Make clear that check name should be used when performing the `details` assertion for Websockets