### PR TITLE
Recorder: Save resource files with correct file extension

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/ScenarioExporter.scala
@@ -58,13 +58,13 @@ private[recorder] object ScenarioExporter extends StrictLogging {
   }
 
   private def requestBodyFileName(request: RequestElement) =
-    s"${request.id.leftPad(4, '0')}_request.txt"
+    s"${request.id.leftPad(4, '0')}_request.${request.fileExtension}"
 
   def requestBodyRelativeFilePath(request: RequestElement)(implicit config: RecorderConfiguration) =
     packageAsFolderPath("/") + "/" + config.core.className + "/" + requestBodyFileName(request)
 
   private def responseBodyFileName(request: RequestElement) =
-    s"${request.id.leftPad(4, '0')}_response.txt"
+    s"${request.id.leftPad(4, '0')}_response.${request.responseFileExtension}"
 
   def responseBodyRelativeFilePath(request: RequestElement)(implicit config: RecorderConfiguration) =
     packageAsFolderPath("/") + "/" + config.core.className + "/" + responseBodyFileName(request)


### PR DESCRIPTION
Implemented changes that set correct file extension to resource files so it's not always `.txt`. This makes opening them a lot easier. Mime type is extracted from `Content-Type` header. There's a map for a dozen most common mime types and for the rest `jodd.net.MimeTypes.findExtensionsByMimeTypes()` is used (it's based on Apache's `mime.types` file). This is because `jodd.net.MimeTypes` is not optimized for looking up extension from mime type but vice-versa (looked at the source code, they have a `HashMap` from extension to mime type).

(Changes done here are based on changes already done in #3707, i.e. commit pmalic@378778dc84cf73dcd5642ce3c2039c468e7a3f03)