### PR TITLE
Update simulation_setup.rst, link outdated.

### DIFF
--- a/src/sphinx/general/simulation_setup.rst
+++ b/src/sphinx/general/simulation_setup.rst
@@ -43,7 +43,7 @@ If you're using a closed workload model in your load tests while your system act
 In such case, when system under test starts to has some trouble, response time will increase, journey time will become longer, so number of concurrent users will increase
 and injector will slow down to match the imaginary cap you've set.
 
-You can read more about open and closed models `here <http://repository.cmu.edu/cgi/viewcontent.cgi?article=1872&context=compsci>`_.
+You can read more about open and closed models `here <https://gatling.io/2018/10/04/gatling-3-closed-workload-model-support>`_.
 
 .. warning::
 

--- a/src/sphinx/general/simulation_setup.rst
+++ b/src/sphinx/general/simulation_setup.rst
@@ -43,7 +43,7 @@ If you're using a closed workload model in your load tests while your system act
 In such case, when system under test starts to has some trouble, response time will increase, journey time will become longer, so number of concurrent users will increase
 and injector will slow down to match the imaginary cap you've set.
 
-You can read more about open and closed models `here <https://gatling.io/2018/10/04/gatling-3-closed-workload-model-support>`_.
+You can read more about open and closed models `here <https://kilthub.cmu.edu/articles/Open_Versus_Closed_A_Cautionary_Tale/6608078>`_.
 
 .. warning::
 


### PR DESCRIPTION
the link here is outdated, and I found another article in your gatling.io blog site, is it ok to replace it with this link? 
https://gatling.io/2018/10/04/gatling-3-closed-workload-model-support