### PR TITLE
Use the correct request name in the assertion documentation

### DIFF
--- a/src/sphinx/general/assertions.rst
+++ b/src/sphinx/general/assertions.rst
@@ -35,7 +35,7 @@ An assertion can test a statistic calculated from all requests or only a part.
 
 * ``details(path)``: use statistics calculated from a group or a request. The path is defined like a Unix filesystem path.
 
-For example, to perform an assertion on the request ``Search``, use:
+For example, to perform an assertion on the request ``Index``, use:
 
 .. includecode:: code/AssertionSample.scala#details
 

--- a/src/sphinx/general/assertions.rst
+++ b/src/sphinx/general/assertions.rst
@@ -35,7 +35,7 @@ An assertion can test a statistic calculated from all requests or only a part.
 
 * ``details(path)``: use statistics calculated from a group or a request. The path is defined like a Unix filesystem path.
 
-For example, to perform an assertion on the request ``Index``, use:
+For example, to perform an assertion on the request ``Home``, use:
 
 .. includecode:: code/AssertionSample.scala#details
 

--- a/src/sphinx/general/code/AssertionSample.scala
+++ b/src/sphinx/general/code/AssertionSample.scala
@@ -28,7 +28,7 @@ class AssertionSample extends Simulation {
   //#setUp
 
   //#details
-  details("Index")
+  details("Home")
   //#details
 
   //#details-group
@@ -46,7 +46,7 @@ class AssertionSample extends Simulation {
   // is exactly 0 %
   setUp(scn).assertions(details("Search" / "Index").failedRequests.percent.is(0))
 
-  // Assert that the rate of requests per seconds for the group "Search"
-  setUp(scn).assertions(details("Search").requestsPerSec.between(100, 1000))
+  // Assert that the rate of requests per seconds for the request "Home"
+  setUp(scn).assertions(details("Home").requestsPerSec.between(100, 1000))
   //#examples
 }


### PR DESCRIPTION
Just a minor documentation fix for a part of the docs which I contributed a couple of weeks ago.

See: https://gatling.io/docs/current/general/assertions
The request name in the text does not match the code example