### PR TITLE
Switch order of multipart form parameters

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestExpressionBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/request/builder/HttpRequestExpressionBuilder.scala
@@ -51,7 +51,7 @@ class HttpRequestExpressionBuilder(
       params <- httpAttributes.formParams.mergeWithFormIntoParamJList(httpAttributes.form, session)
       stringParts = params.asScala.map(param => new StringPart(param.getName, param.getValue, charset, null, null, null, null, null))
       parts <- Validation.sequence(bodyParts.map(_.toMultiPart(session)))
-    } yield requestBuilder.setBodyBuilder(new MultipartFormDataRequestBodyBuilder((parts ++ stringParts).asJava))
+    } yield requestBuilder.setBodyBuilder(new MultipartFormDataRequestBodyBuilder((stringParts ++ parts).asJava))
 
   private def setBody(session: Session, requestBuilder: AhcRequestBuilder, body: Body): Validation[AhcRequestBuilder] =
     body match {


### PR DESCRIPTION
Uploading file to AWS S3 requires sending auth form fields before actual file contents. This quick fix ensures this behaviour. 

For details see here:
https://groups.google.com/forum/#!topic/gatling/Iil3hiGNo-U
and here:
https://github.com/gatling/gatling/issues/3728