### PR TITLE
use https to download build plugins from bintray

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += Resolver.url("gatling", url("http://dl.bintray.com/content/gatling/sbt-plugins/"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("gatling", url("https://dl.bintray.com/content/gatling/sbt-plugins/"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.jcenterRepo
 
 addSbtPlugin("io.gatling" % "gatling-build-plugin" % "2.2.2")


### PR DESCRIPTION
I noticed this because I am behind a proxy that blocks http connections. For a motivation to use https also see this article: https://medium.com/bugbountywriteup/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb.