### PR TITLE
make graphite data writer flush one last time when simulation stops

### DIFF
--- a/gatling-graphite/src/main/scala/io/gatling/graphite/GraphiteDataWriter.scala
+++ b/gatling-graphite/src/main/scala/io/gatling/graphite/GraphiteDataWriter.scala
@@ -97,7 +97,10 @@ private[gatling] class GraphiteDataWriter(clock: Clock, configuration: GatlingCo
 
   override def onCrash(cause: String, data: GraphiteData): Unit = {}
 
-  def onStop(data: GraphiteData): Unit = cancelTimer(flushTimerName)
+  def onStop(data: GraphiteData): Unit = {
+    cancelTimer(flushTimerName)
+    onFlush(data)
+  }
 
   private def sendMetricsToGraphite(
     data:            GraphiteData,


### PR DESCRIPTION
The `GraphiteDataWriter` collects metrics and flushes them in a configurable interval. When the simulation is finished, there might be some data left over that is not flushed, especially if the interval is set to a value longer then the default of one second. This PR should make sure that the remaining data is flushed, similar to what the `ConsoleDataWriter` does.