### PR TITLE
Support $${} for escaping in EL

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/session/el/ElCompiler.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/session/el/ElCompiler.scala
@@ -265,25 +265,38 @@ class ElCompiler extends RegexParsers {
 
   private def multivaluedExpr: Parser[List[Part[Any]]] = (elExpr | staticPart) *
 
-  private val staticPartPattern = new Parser[String] {
+  private val staticPartPattern: Parser[List[String]] = new Parser[String] {
     override def apply(in: Input): ParseResult[String] = {
       val source = in.source
       val offset = in.offset
       val end = source.length
 
       def success(i: Int) = Success(source.subSequence(offset, i).toString, in.drop(i - offset))
-      def failure = Failure("Not a static part", in)
 
       source.indexOf(DynamicPartStart, offset) match {
-        case -1 if offset == end => failure
-        case -1                  => success(end)
-        case n if n == offset    => failure
-        case n                   => success(n)
+        case -1 => success(end)
+        case n =>
+          val extra$Count = (n - 1).to(offset, step = -1).takeWhile(source.charAt(_) == '$').size
+          val halfCount = extra$Count / 2
+          val throughEscaped$ = success(n - halfCount)
+          if (extra$Count % 2 == 0) {
+            throughEscaped$.copy(next = throughEscaped$.next.drop(halfCount))
+          } else { // should escape
+            throughEscaped$.copy(
+              result = throughEscaped$.result + "{",
+              next = throughEscaped$.next.drop(halfCount + 2)
+            )
+          }
       }
     }
+  } >> {
+    case "" => success(Nil)
+    case s  => staticPartPattern ^^ (s :: _)
   }
 
-  private def staticPart: Parser[StaticPart] = staticPartPattern ^^ { staticStr => StaticPart(staticStr) }
+  private def staticPart: Parser[StaticPart] = staticPartPattern ^? ({
+    case staticStr if staticStr.nonEmpty => StaticPart(staticStr.mkString)
+  }, _ => "Not a static part")
 
   private def elExpr: Parser[Part[Any]] = "${" ~> sessionObject <~ "}"
 

--- a/gatling-core/src/test/scala/io/gatling/core/session/el/ElSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/session/el/ElSpec.scala
@@ -558,4 +558,24 @@ class ElSpec extends BaseSpec with ValidationValues {
     val failedJsonStringifyExpression = "${foo.bar.jsonStringify()}".el[String]
     failedJsonStringifyExpression(session).failed shouldBe failedKeyAccessExpression(session).failed
   }
+
+  "Escaping" should "turn $${ into ${" in {
+    val session = newSession(Map("foo" -> "FOO"))
+    val expression = "$${foo}".el[String]
+    expression(session).succeeded shouldBe "${foo}"
+  }
+
+  it should "keep one $ in $$${" in {
+    val session = newSession(Map("foo" -> "FOO"))
+    val expression = "$$${foo}".el[String]
+    expression(session).succeeded shouldBe "$FOO"
+  }
+
+  it should "handle multiple escape sequences correctly" in {
+    val session = newSession(Map("foo" -> "FOO"))
+
+    "$${foo$${foo}".el[String].apply(session).succeeded shouldBe "${foo${foo}"
+    "bar$$$$${foo}$${foo}".el[String].apply(session).succeeded shouldBe "bar$$FOO${foo}"
+    "$$$${foo}$${foo}$${foo}$$${foo}".el[String].apply(session).succeeded shouldBe "$${foo}${foo}${foo}$FOO"
+  }
 }

--- a/src/sphinx/session/expression_el.rst
+++ b/src/sphinx/session/expression_el.rst
@@ -41,7 +41,7 @@ Gatling EL supports the following indexed collections: java.util.List, Seq and A
 
 .. warning::
   This Expression Language only works on String values being passed to Gatling DSL methods.
-  Such Strings are parsed only once, when the Gatling simulation is being instanciated.
+  Such Strings are parsed only once, when the Gatling simulation is being instantiated.
 
   For example ``queryParam("latitude", session => "${latitude}")`` wouldn't work because the parameter is not a String, but a function that returns a String.
 
@@ -55,6 +55,18 @@ Gatling EL supports the following indexed collections: java.util.List, Seq and A
   By default, IntelliJ will automatically prepend your String with an ``s`` as soon as you start typing ``${``
   because it thinks you want to use `Scala's String interpolation <https://docs.scala-lang.org/overviews/core/string-interpolation.html>`_.
   You need to remove this ``s`` to use Gatling EL.
+
+Escaping ``${``
+---------------
+
+To prevent ``"${"`` from being interpreted by the EL compiler, add a ``$`` before it. ``"$${foo}"`` will be turned into ``"${foo}"``.
+
+If you want a ``$`` before the placeholder, add another ``$``.
+Assuming the session attribute ``foo`` holds ``"FOO"``, ``"$$${foo}"`` will be turned into ``"$FOO"``.
+
+This can go on and on. In general, if there are 2n-1 ``$`` characters before ``${`` -- an even number of ``$`` characters totally --
+there will be n ``$`` before ``{`` in the final string;
+if there are 2n ``$`` before ``${`` -- an odd number totally -- there will be n ``$`` before the placeholder.
 
 .. _expression:
 


### PR DESCRIPTION
Completes https://github.com/gatling/gatling/issues/2769.

> `$${foo}` would be turned into `${foo}` instead of trying to resolve foo as a session attribute.