### PR TITLE
Minor: update misleading typographical error on session documentation

### DIFF
--- a/src/sphinx/session/session_api.rst
+++ b/src/sphinx/session/session_api.rst
@@ -110,28 +110,28 @@ You can then access methods to retrieve the actual value in several ways:
 
 * returns a ``Int``,
 * throws a ``NoSuchElementException`` if the *foo* attribute is undefined,
-* throws a ``NumberFormatException`` if the value is a String and can't be parsed into a String,
-* throws a ``ClassCastException`` if the value is not an Int
+* throws a ``NumberFormatException`` if the value is a String and can't be parsed into an Int,
+* throws a ``ClassCastException`` otherwise.
 
 ``session("foo").asOption[Int]``:
 
-* returns an ``Option[Int]``
+* returns an ``Option[Int]``,
 * which is ``None`` if the *foo* attribute is undefined,
-* which is ``Some(value)`` otherwise and *value* is an Int, or is a String that can be parsed into a String,
-* throws a ``NumberFormatException`` if the value is a String and can't be parsed into a String,
-* throws a ``ClassCastException`` otherwise
+* which is ``Some(value)`` otherwise and *value* is an Int, or is a String that can be parsed into an Int,
+* throws a ``NumberFormatException`` if the value is a String and can't be parsed into an Int,
+* throws a ``ClassCastException`` otherwise.
 
 ``session("foo").validate[Int]``:
 
-* returns an ``Validation[Int]``
-* which is ``Success(value)`` if the *foo* attribute is defined and *value* is an Int or is a String that can be parsed into a String,
-* which is ``Failure(errorMessage)`` otherwise
+* returns a ``Validation[Int]``,
+* which is ``Success(value)`` if the *foo* attribute is defined and *value* is an Int or is a String that can be parsed into an Int,
+* which is ``Failure(errorMessage)`` otherwise.
 
 .. note::
   Trying to get a ``[String]`` actually performs a ``toString`` conversion and thus, always works as long as the entry is defined.
 
 .. note::
-if the value a ``[String]``, Gatling will try to parse it into a value of the expected type.
+  If the value is a ``[String]``, Gatling will try to parse it into a value of the expected type.
 
 .. note::
 


### PR DESCRIPTION
Minor change on session documentation.

1. Typo `String and can't be parsed into a String` become `String and can't be parsed into an Int`
2. Typo `an "Validation[Int]"` become `a "Validation[Int]"`
3. Third exception description of `session("foo").as[Int]` is now describe as "otherwise", matching others descriptions.

Also add missing commas and  dots.