### PR TITLE
Extending jms check DSL

### DIFF
--- a/gatling-jms/src/main/scala/io/gatling/jms/check/JmsBodyStringCheckMaterializer.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/check/JmsBodyStringCheckMaterializer.scala
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-package io.gatling.jms
+package io.gatling.jms.check
 
-import javax.jms.{ BytesMessage, Message, TextMessage }
-import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import io.gatling.core.check.string.BodyStringCheckType
+import io.gatling.core.check.{ CheckMaterializer, Preparer }
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.jms.JmsCheck
+import javax.jms.Message
 
-trait MockMessage extends MockitoSugar {
-  def textMessage(text: String): TextMessage = {
-    val msg = mock[TextMessage]
-    when(msg.getText) thenReturn text
-    msg
-  }
-
-  def bytesMessage(bytes: Array[Byte]): BytesMessage =
-    mock[BytesMessage](new BytesMessageAnswer(bytes))
-
-  def message: Message = mock[Message]
+object JmsBodyStringCheckMaterializer {
+  def apply(config: GatlingConfiguration): CheckMaterializer[BodyStringCheckType, JmsCheck, Message, String] =
+    new CheckMaterializer[BodyStringCheckType, JmsCheck, Message, String](identity) {
+      override protected def preparer: Preparer[Message, String] = JmsMessageBodyPreparers.jmsStringBodyPreparer(config)
+    }
 }

--- a/gatling-jms/src/main/scala/io/gatling/jms/check/JmsBodySubstringCheckMaterializer.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/check/JmsBodySubstringCheckMaterializer.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms.check
+
+import io.gatling.core.check.substring.SubstringCheckType
+import io.gatling.core.check.{ CheckMaterializer, Preparer }
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.jms.JmsCheck
+import javax.jms.Message
+
+object JmsBodySubstringCheckMaterializer {
+  def apply(config: GatlingConfiguration): CheckMaterializer[SubstringCheckType, JmsCheck, Message, String] =
+    new CheckMaterializer[SubstringCheckType, JmsCheck, Message, String](identity) {
+      override protected def preparer: Preparer[Message, String] = JmsMessageBodyPreparers.jmsStringBodyPreparer(config)
+    }
+}

--- a/gatling-jms/src/main/scala/io/gatling/jms/check/JmsCheckSupport.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/check/JmsCheckSupport.scala
@@ -16,16 +16,32 @@
 
 package io.gatling.jms.check
 
+import java.util.{ Map => JMap }
+
+import io.gatling.commons.validation.Validation
+import io.gatling.core.check.string.BodyStringCheckType
+import io.gatling.core.check.substring.SubstringCheckType
+import io.gatling.core.check.xpath.{ Dom, XPathCheckType, XmlParsers }
+import io.gatling.core.check.{
+  Check,
+  CheckBuilder,
+  CheckMaterializer,
+  CheckResult,
+  ConditionalCheck,
+  FindCheckBuilder,
+  TypedConditionalCheckWrapper,
+  UntypedConditionalCheckWrapper,
+  ValidatorCheckBuilder
+}
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.json.JsonParsers
+import io.gatling.core.session.{ Expression, Session }
+import io.gatling.jms.JmsCheck
 import javax.jms.Message
 
 import scala.annotation.implicitNotFound
 
-import io.gatling.core.check.{ CheckBuilder, CheckMaterializer, FindCheckBuilder, ValidatorCheckBuilder }
-import io.gatling.core.check.xpath.{ Dom, XPathCheckType, XmlParsers }
-import io.gatling.jms.JmsCheck
-
 trait JmsCheckSupport {
-
   def simpleCheck: JmsSimpleCheck.type = JmsSimpleCheck
 
   @implicitNotFound("Could not find a CheckMaterializer. This check might not be valid for JMS.")
@@ -46,6 +62,33 @@ trait JmsCheckSupport {
   )(implicit materializer: CheckMaterializer[A, JmsCheck, Message, P]): JmsCheck =
     findCheckBuilder.find.exists
 
+  implicit def jmsBodyStringCheckMaterializer(
+      implicit gatlingConfiguration: GatlingConfiguration
+  ): CheckMaterializer[BodyStringCheckType, JmsCheck, Message, String] =
+    JmsBodyStringCheckMaterializer(gatlingConfiguration)
+
+  implicit def jmsBodySubstringCheckMaterializer(
+      implicit gatlingConfiguration: GatlingConfiguration
+  ): CheckMaterializer[SubstringCheckType, JmsCheck, Message, String] =
+    JmsBodySubstringCheckMaterializer(gatlingConfiguration)
+
   implicit def jmsXPathmaterializer(implicit xmlParsers: XmlParsers): CheckMaterializer[XPathCheckType, JmsCheck, Message, Option[Dom]] =
     new JmsXPathCheckMaterializer(xmlParsers)
+
+  implicit def jmsJsonPathCheckMaterializer(implicit jsonParsers: JsonParsers, gatlingConfiguration: GatlingConfiguration): JmsJsonPathCheckMaterializer =
+    new JmsJsonPathCheckMaterializer(jsonParsers, gatlingConfiguration)
+
+  implicit val jmsUntypedConditionalCheckWrapper: UntypedConditionalCheckWrapper[JmsCheck] =
+    (condition: Expression[Boolean], thenCheck: JmsCheck) =>
+      new Check[Message] {
+        private val typedCondition = (_: Message, ses: Session) => condition(ses)
+
+        override def check(response: Message, session: Session, preparedCache: JMap[Any, Any]): Validation[CheckResult] =
+          ConditionalCheck(typedCondition, thenCheck).check(response, session, preparedCache)
+      }
+
+  implicit val jmsTypedConditionalCheckWrapper: TypedConditionalCheckWrapper[Message, JmsCheck] =
+    (condition: (Message, Session) => Validation[Boolean], thenCheck: JmsCheck) =>
+      (response: Message, session: Session, preparedCache: JMap[Any, Any]) => ConditionalCheck(condition, thenCheck).check(response, session, preparedCache)
+
 }

--- a/gatling-jms/src/main/scala/io/gatling/jms/check/JmsJsonPathCheckMaterializer.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/check/JmsJsonPathCheckMaterializer.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms.check
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.gatling.commons.validation._
+import io.gatling.core.check.jsonpath.JsonPathCheckType
+import io.gatling.core.check.{ CheckMaterializer, Preparer }
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.json.JsonParsers
+import io.gatling.jms.JmsCheck
+import io.gatling.jms.check.JmsMessageBodyPreparers.getBodyAsString
+import javax.jms.{ BytesMessage, Message, TextMessage }
+
+class JmsJsonPathCheckMaterializer(jsonParsers: JsonParsers, config: GatlingConfiguration)
+    extends CheckMaterializer[JsonPathCheckType, JmsCheck, Message, JsonNode](identity) {
+  override protected def preparer: Preparer[Message, JsonNode] =
+    JmsJsonPathCheckMaterializer.jsonPathPreparer(jsonParsers, config)
+}
+
+object JmsJsonPathCheckMaterializer {
+  private val ErrorMapper = "Could not parse response into a JSON: " + _
+
+  private def jsonPathPreparer(jsonParsers: JsonParsers, config: GatlingConfiguration): Preparer[Message, JsonNode] =
+    replyMessage =>
+      safely(ErrorMapper) {
+        replyMessage match {
+          case tm: TextMessage  => jsonParsers.safeParse(tm.getText)
+          case bm: BytesMessage => jsonParsers.safeParse(getBodyAsString(bm, config))
+          case _                => "Unsupported message type".failure
+        }
+      }
+}

--- a/gatling-jms/src/main/scala/io/gatling/jms/check/JmsMessageBodyPreparers.scala
+++ b/gatling-jms/src/main/scala/io/gatling/jms/check/JmsMessageBodyPreparers.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms.check
+
+import java.nio.charset.StandardCharsets
+
+import io.gatling.commons.validation._
+import io.gatling.core.check.Preparer
+import io.gatling.core.config.GatlingConfiguration
+import javax.jms.{ BytesMessage, Message, TextMessage }
+
+object JmsMessageBodyPreparers {
+
+  private def toBytes(bytesMessage: BytesMessage): Array[Byte] = {
+    val buffer = Array.ofDim[Byte](bytesMessage.getBodyLength.toInt)
+    bytesMessage.readBytes(buffer)
+    buffer
+  }
+
+  protected[check] def getBodyAsString(bytesMessage: BytesMessage, config: GatlingConfiguration): String =
+    if (config.core.charset == StandardCharsets.UTF_8)
+      bytesMessage.readUTF()
+    else
+      new String(toBytes(bytesMessage), config.core.charset)
+
+  def jmsStringBodyPreparer(config: GatlingConfiguration): Preparer[Message, String] = {
+    case tm: TextMessage  => tm.getText.success
+    case bm: BytesMessage => getBodyAsString(bm, config).success
+    case _                => "Unsupported message type".failure
+  }
+
+  def jmsBytesBodyPreparer(config: GatlingConfiguration): Preparer[Message, Array[Byte]] = {
+    case tm: TextMessage  => tm.getText.getBytes(config.core.charset).success
+    case bm: BytesMessage => toBytes(bm).success
+    case _                => "Unsupported message type".failure
+  }
+
+}

--- a/gatling-jms/src/test/java/io/gatling/jms/BytesMessageAnswer.java
+++ b/gatling-jms/src/test/java/io/gatling/jms/BytesMessageAnswer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms;
+
+import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
+import org.mockito.invocation.InvocationOnMock;
+
+class BytesMessageAnswer extends ReturnsEmptyValues {
+    private byte[] bytes;
+
+    public BytesMessageAnswer(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) {
+        switch (invocation.getMethod().getName()) {
+            case "getBodyLength":
+                return (long) bytes.length;
+            case "readBytes":
+                byte[] targetBuffer = invocation.getArgument(0);
+                System.arraycopy(bytes, 0, targetBuffer, 0, targetBuffer.length);
+                return targetBuffer.length;
+            case "readUTF":
+                return new String(bytes);
+            default:
+                return super.answer(invocation);
+        }
+    }
+}

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsConditionalCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsConditionalCheckSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms.check
+
+import java.util.{ HashMap => JHashMap }
+
+import io.gatling.commons.validation.Success
+import io.gatling.core.CoreDsl
+import io.gatling.core.check.CheckResult
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import io.gatling.jms.{ JmsCheck, MockMessage }
+import io.gatling.{ BaseSpec, ValidationValues }
+import javax.jms.Message
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class JmsConditionalCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+  override implicit def configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
+
+  private def jmap[K, V] = new JHashMap[K, V]
+
+  private val session = Session("mockSession", 0, System.currentTimeMillis())
+
+  private val testResponses = Table(
+    ("msg", "msgType"),
+    (textMessage("""[{"id":"1072920417"},"id":"1072920418"]"""), "TextMessage"),
+    (bytesMessage("""[{"id":"1072920417"},"id":"1072920418"]""".getBytes()), "BytesMessage")
+  )
+
+  forAll(testResponses) { (response: Message, msgType: String) =>
+    s"checkIf.true.succeed for $msgType" should "perform the succeed nested check" in {
+      val thenCheck: JmsCheck = substring(""""id":"""").count
+      val check: JmsCheck = checkIf((r: Message, s: Session) => Success(true))(thenCheck)
+      check.check(response, session, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
+    }
+
+    s"checkIf.true.failed for $msgType" should "perform the failed nested check" in {
+      val substringValue = """"foo":""""
+      val thenCheck: JmsCheck = substring(substringValue).findAll.exists
+      val check: JmsCheck = checkIf((r: Message, s: Session) => Success(true))(thenCheck)
+      check.check(response, session, jmap[Any, Any]).failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
+    }
+
+    s"checkIf.false.succeed for $msgType" should "not perform the succeed nested check" in {
+      val thenCheck: JmsCheck = substring(""""id":"""").count
+      val check: JmsCheck = checkIf((r: Message, s: Session) => Success(false))(thenCheck)
+      check.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(None, None)
+    }
+
+    s"checkIf.false.failed for $msgType" should "not perform the failed nested check" in {
+      val substringValue = """"foo":""""
+      val thenCheck: JmsCheck = substring(substringValue).findAll.exists
+      val check: JmsCheck = checkIf((r: Message, s: Session) => Success(false))(thenCheck)
+      check.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(None, None)
+    }
+  }
+}

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsJsonPathCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsJsonPathCheckSpec.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms.check
+
+import java.util.{ HashMap => JHashMap }
+
+import io.gatling.core.CoreDsl
+import io.gatling.core.check.CheckResult
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import io.gatling.jms.MockMessage
+import io.gatling.{ BaseSpec, ValidationValues }
+import javax.jms.Message
+import org.scalatest.matchers.{ MatchResult, Matcher }
+import org.scalatest.prop.{ TableDrivenPropertyChecks, TableFor2 }
+
+class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+  override implicit def configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
+
+  private val session = Session("mockSession", 0, System.currentTimeMillis())
+
+  private def beIn[T](seq: Seq[T]) =
+    new Matcher[T] {
+      def apply(left: T): MatchResult =
+        MatchResult(
+          seq.contains(left),
+          s"$left was not in $seq",
+          s"$left was in $seq"
+        )
+    }
+
+  private val testJson = s"""{ "store": {
+                            |    "book": "In store"
+                            |  },
+                            |  "street": {
+                            |    "book": "On the street"
+                            |  },
+                            |  "long_value": ${Long.MaxValue},
+                            |  "null_value": null,
+                            |  "not_null_value": "bar",
+                            |  "documents":[]
+                            |}""".stripMargin
+
+  val jsons: TableFor2[Message, String] = Table(
+    ("json", "messageType"),
+    (textMessage(testJson), "TextMessage"),
+    (bytesMessage(testJson.getBytes()), "BytesMessage")
+  )
+
+  forAll(jsons) { (response, messageType) =>
+    s"jsonPath.find for $messageType" should "support long values" in {
+      jsonPath("$.long_value").ofType[Long].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(Long.MaxValue),
+        None
+      )
+    }
+
+    s"jsonPath.find.exists for $messageType" should "find single result into JSON serialized form" in {
+      jsonPath("$.street").find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some("""{"book":"On the street"}"""),
+        None
+      )
+    }
+
+    it should "find single result into Map object form" in {
+      jsonPath("$.street").ofType[Map[String, Any]].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(Map("book" -> "On the street")),
+        None
+      )
+    }
+
+    it should "find a null attribute value when expected type is String" in {
+      jsonPath("$.null_value").ofType[String].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
+    }
+
+    it should "find a null attribute value when expected type is Any" in {
+      jsonPath("$.null_value").ofType[Any].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
+    }
+
+    it should "find a null attribute value when expected type is Int" in {
+      jsonPath("$.null_value").ofType[Int].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(null.asInstanceOf[Int]),
+        None
+      )
+    }
+
+    it should "find a null attribute value when expected type is Seq" in {
+      jsonPath("$.null_value").ofType[Seq[Any]].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
+    }
+
+    it should "find a null attribute value when expected type is Map" in {
+      jsonPath("$.null_value").ofType[Map[String, Any]].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(null),
+        None
+      )
+    }
+
+    it should "succeed when expecting a null value and getting a null one" in {
+      jsonPath("$.null_value").ofType[Any].find.isNull.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
+    }
+
+    it should "fail when expecting a null value and getting a non-null one" in {
+      jsonPath("$.not_null_value")
+        .ofType[Any]
+        .find
+        .isNull
+        .check(response, session, new JHashMap[Any, Any])
+        .failed shouldBe "jsonPath($.not_null_value).find.isNull, but actually found bar"
+    }
+
+    it should "succeed when expecting a non-null value and getting a non-null one" in {
+      jsonPath("$.not_null_value").ofType[Any].find.notNull.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some("bar"), None)
+    }
+
+    it should "fail when expecting a non-null value and getting a null one" in {
+      jsonPath("$.null_value")
+        .ofType[Any]
+        .find
+        .notNull
+        .check(response, session, new JHashMap[Any, Any])
+        .failed shouldBe "jsonPath($.null_value).find.notNull, but actually found null"
+    }
+
+    it should "not fail on empty array" in {
+      jsonPath("$.documents").ofType[Seq[_]].find.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(Vector.empty),
+        None
+      )
+    }
+
+    s"jsonPath.findAll.exists for $messageType" should "fetch all matches" in {
+
+      jsonPath("$..book").findAll.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(Seq("In store", "On the street")),
+        None
+      )
+    }
+
+    it should "find all by wildcard" in {
+      jsonPath("$.*.book").findAll.exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(Vector("In store", "On the street")),
+        None
+      )
+    }
+
+    s"jsonPath.findRandom.exists for $messageType" should "fetch a single random match" in {
+      jsonPath("$..book").findRandom.exists.check(response, session, new JHashMap[Any, Any]).succeeded.extractedValue.get.asInstanceOf[String] should beIn(
+        Seq("In store", "On the street")
+      )
+    }
+
+    it should "fetch at max num results" in {
+      jsonPath("$..book")
+        .findRandom(1)
+        .exists
+        .check(response, session, new JHashMap[Any, Any])
+        .succeeded
+        .extractedValue
+        .get
+        .asInstanceOf[Seq[String]] should beIn(Seq(Seq("In store"), Seq("On the street")))
+    }
+
+    it should "fetch all the matches when expected number is greater" in {
+      jsonPath("$..book").findRandom(3).exists.check(response, session, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+        Some(Seq("In store", "On the street")),
+        None
+      )
+    }
+
+    it should "fail when failIfLess is enabled and expected number is greater" in {
+      jsonPath("$..book").findRandom(3, failIfLess = true).exists.check(response, session, new JHashMap[Any, Any]).failed
+    }
+  }
+}

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsStringBodyCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsStringBodyCheckSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms.check
+
+import java.util.{ HashMap => JHashMap }
+
+import io.gatling.core.CoreDsl
+import io.gatling.core.check.CheckResult
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import io.gatling.jms.MockMessage
+import io.gatling.{ BaseSpec, ValidationValues }
+import javax.jms.Message
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class JmsStringBodyCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+  override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
+
+  private def jmap[K, V] = new JHashMap[K, V]
+
+  private val session = Session("mockSession", 0, System.currentTimeMillis())
+
+  private val testResponses = Table(
+    ("msg", "msgType"),
+    (textMessage("""[{"id":"1072920417"},"id":"1072920418"]"""), "TextMessage"),
+    (bytesMessage("""[{"id":"1072920417"},"id":"1072920418"]""".getBytes(configuration.core.charset)), "BytesMessage")
+  )
+
+  forAll(testResponses) { (response: Message, msgType: String) =>
+    s"bodyString.find.exists for $msgType" should "extract response body correctly" in {
+      bodyString.find.exists
+        .check(response, session, jmap[Any, Any])
+        .succeeded shouldBe CheckResult(Some("""[{"id":"1072920417"},"id":"1072920418"]"""), None)
+    }
+
+    s"bodyString.notNull for $msgType" should "pass when response not empty" in {
+      bodyString.find.notNull
+        .check(response, session, jmap[Any, Any])
+        .succeeded shouldBe CheckResult(Some("""[{"id":"1072920417"},"id":"1072920418"]"""), None)
+    }
+
+    s"bodyString.isNull for $msgType" should "fail when response not empty" in {
+      bodyString.isNull
+        .check(response, session, jmap[Any, Any])
+        .failed shouldBe """bodyString.find.isNull, found [{"id":"1072920417"},"id":"1072920418"]"""
+    }
+  }
+}

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsSubstringCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsSubstringCheckSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2011-2019 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.jms.check
+
+import java.util.{ HashMap => JHashMap }
+
+import io.gatling.core.CoreDsl
+import io.gatling.core.check.CheckResult
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import io.gatling.jms.MockMessage
+import io.gatling.{ BaseSpec, ValidationValues }
+import javax.jms.Message
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class JmsSubstringCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+  override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
+
+  private def jmap[K, V] = new JHashMap[K, V]
+
+  private val session = Session("mockSession", 0, System.currentTimeMillis())
+
+  private val testResponses = Table(
+    ("msg", "msgType"),
+    (textMessage("""[{"id":"1072920417"},"id":"1072920418"]"""), "TextMessage"),
+    (bytesMessage("""[{"id":"1072920417"},"id":"1072920418"]""".getBytes()), "BytesMessage")
+  )
+
+  "substring.find.exists for TextMessage" should "find single result" in {
+    val response = textMessage("""{"id":"1072920417"}""")
+    substring(""""id":"""").find.exists.check(response, session, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(1), None)
+  }
+
+  "substring.find.exists for BytesMessage" should "find single result" in {
+    val response = bytesMessage("""{"id":"1072920417"}""".getBytes())
+    substring(""""id":"""").find.exists.check(response, session, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(1), None)
+  }
+
+  forAll(testResponses) { (response: Message, msgType: String) =>
+    s"substring.find.exists for $msgType" should "find first occurrence" in {
+      substring(""""id":"""").find.exists.check(response, session, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
+    }
+
+    s"substring.findAll.exists for $msgType" should "find all occurrences" in {
+      substring(""""id":"""").findAll.exists.check(response, session, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(Seq(2, 21)), None)
+    }
+
+    it should "fail when finding nothing instead of returning an empty Seq" in {
+      val substringValue = """"foo":""""
+      substring(substringValue).findAll.exists
+        .check(response, session, jmap[Any, Any])
+        .failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
+    }
+
+    s"substring.count.exists for $msgType" should "find all occurrences" in {
+      substring(""""id":"""").count.exists.check(response, session, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
+    }
+
+    it should "return 0 when finding nothing instead of failing" in {
+      substring(""""foo":"""").count.exists.check(response, session, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(0), None)
+    }
+  }
+}

--- a/gatling-jms/src/test/scala/io/gatling/jms/compile/JmsCompileTest.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/compile/JmsCompileTest.scala
@@ -109,6 +109,13 @@ class JmsCompileTest extends Simulation {
         .textMessage("hello")
         .check(checkBodyTextCorrect)
         .check(xpath("//TEST").saveAs("name"))
+        .check(
+          bodyString.is("hello"),
+          substring("he").count.is(1),
+          checkIf(bodyString.notNull.displayActualValue) {
+            jsonPath("$").is("hello")
+          }
+        )
     )
     // extra
     .exec(

--- a/src/sphinx/jms.rst
+++ b/src/sphinx/jms.rst
@@ -109,6 +109,8 @@ There is ``simpleCheck`` that accepts just ``javax.jms.Message => Boolean`` func
 
 There is also ``xpath`` check for ``javax.jms.TextMessage`` that carries XML content.
 
+And there is ``bodyString``, ``jsonPath``, ``substring`` checks for ``java.jms.TextMessage`` that carries JSON content and ``java.jms.BytesMessage`` that carries json content in utf-8 encoding. And You may use ``checkIf`` for conditional checks.
+
 Additionally you can define your custom check that implements ``Check[javax.jms.Message]``
 
 Example


### PR DESCRIPTION
I extended checks for responses with types `TextMessage` and `BytesMessage` in jms protocol, `bodyString`, `substring`, `checkIf`, `jsonPath` were added.
Now it's possible to write some complex check like this:
``` scala
.check(
  bodyString.notNull,
  substring("jms").count.is(3),  
  checkIf(s => s.contains("specialResponseMark"))(jsonPath("$.responseCode").saveAs("RC"))
) 
```
This extension allow to check jms messages, that contains json, directly, without write functions for simpleCheck. And i think this look more natively for gatling scripts.