### PR TITLE
Update documentation sample gatling.conf

### DIFF
--- a/src/sphinx/realtime_monitoring/index.rst
+++ b/src/sphinx/realtime_monitoring/index.rst
@@ -39,14 +39,16 @@ In the ``gatling.conf`` add "graphite" to the data writers and specify the host
 of the Carbon or InfluxDB server.
 
 :: 
-  
-  data {
-    writers = [console, file, graphite]
-  }
-
-  graphite {
-    host = "192.0.2.235"  # InfluxDB or Carbon server
-    # writePeriod = 1   # Default write interval of one second
+  gatling {
+    data {
+      writers = [console, file, graphite]
+      
+      graphite {
+        host = "192.0.2.235"  # InfluxDB or Carbon server
+        port = 2003           # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
+        # writePeriod = 1     # Default write interval of one second
+      }
+    }
   }
 
 InfluxDB


### PR DESCRIPTION
I've found that "graphite" section should be inside "data". Also putting it inside "gatling" right in the example makes it less confusing at least to me.