### PR TITLE
Add HTML abbreviation tag to "cnt/s"

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTableComponent.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTableComponent.scala
@@ -58,7 +58,7 @@ private[charts] class StatisticsTableComponent(implicit configuration: GatlingCo
                                         <th id="col-3" class="header sortable"><span>OK</span></th>
                                         <th id="col-4" class="header sortable"><span>KO</span></th>
                                         <th id="col-5" class="header sortable"><span>% KO</span></th>
-                                        <th id="col-6" class="header sortable"><span>Cnt/s</span></th>
+                                        <th id="col-6" class="header sortable"><span><abbr title="Count of events per second">Cnt/s</abbr></span></th>
                                         ${responseTimeFields.zipWithIndex
       .map { case (header, i) => s"""<th id="col-${i + 7}" class="header sortable"><span>$header</span></th>""" }
       .mkString(Eol)}

--- a/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTextComponent.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/component/StatisticsTextComponent.scala
@@ -75,7 +75,7 @@ private[charts] class StatisticsTextComponent(implicit configuration: GatlingCon
                                                 <td id="numberOfRequestsKO" class="ko"></td>
                                             </tr>
                                             <tr>
-                                                <td class="title">Mean cnt/s</td>
+                                                <td class="title">Mean <abbr title="Count of events per second">cnt/s</abbr></td>
                                                 <td id="meanNumberOfRequestsPerSecond" class="total"></td>
                                                 <td id="meanNumberOfRequestsPerSecondOK" class="ok"></td>
                                                 <td id="meanNumberOfRequestsPerSecondKO" class="ko"></td>


### PR DESCRIPTION
It isn't immediately obvious what it means, having recently updated the Gatling version.

Relates to https://github.com/gatling/gatling/issues/3741

Appears like:
![Screenshot 2020-01-29 at 11 44 54](https://user-images.githubusercontent.com/7168740/73354162-f286da00-428c-11ea-90f0-bbb54cb88070.png)
