### PR TITLE
registerJmesPathFunctions always results in UnsupportedOperationExcep…

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/check/jmespath/JmesPaths.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/check/jmespath/JmesPaths.scala
@@ -30,7 +30,7 @@ private[gatling] object JmesPathFunctions {
   private[jmespath] var functions: Seq[JmesPathFunction] = Nil
 
   def register(functions: Seq[JmesPathFunction]): Unit = {
-    if (functions.nonEmpty) {
+    if (this.functions.nonEmpty) {
       throw new UnsupportedOperationException("JmesPath functions have already been registered")
     }
     this.functions = functions


### PR DESCRIPTION
The check to see if `registerJmesPathFunctions` has already been called, incorrectly referred to a method parameter instead of an object variable and therefore did not allow registering new JmesPath functions even once.