### PR TITLE
Fix LogFileReader to not print to stdout

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/stats/LogFileReader.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/stats/LogFileReader.scala
@@ -47,7 +47,7 @@ class LogFileReader(runUuid: String)(implicit configuration: GatlingConfiguratio
 
   import LogFileReader._
 
-  println("Parsing log file(s)...")
+  logger.debug("Parsing log file(s)...")
 
   private val inputFiles = simulationLogDirectory(runUuid, create = false, configuration).files
     .collect { case file if file.filename.matches(SimulationFilesNamePattern) => file.path }
@@ -176,7 +176,7 @@ class LogFileReader(runUuid: String)(implicit configuration: GatlingConfiguratio
 
   private val resultsHolder = parseInputFiles(secondPass)
 
-  println("Parsing log file(s) done")
+  logger.debug("Parsing log file(s) done")
 
   override val statsPaths: List[StatsPath] =
     resultsHolder.groupAndRequestsNameBuffer.map.toList


### PR DESCRIPTION
I noted this while (ab)using the `LogFileReader` for a project of ours where I am converting the Gatling-generated `.log` file into a JSON format more suitable for subsequent processing. My initial idea was to redirect `stdout` from my console application to a `.json` file but these `println()` calls obviously made that harder.

The log level here can be discussed and I'm fine to change it to e.g. `logger.info()` calls if it's considered appropriate. My main concern is to get rid of the code that prints to stdout, since it's much easier for "machine-consumption" if we change these to be log statements instead.

Having that said, I _do_ realize that this might make things inconvenient for "standard" users of Gatling, where these stdout messages might be of use. To properly cater for both scenarios, one option would be to make `LogFileReader` take a stream as parameter, and print the messages to that stream instead. That way, it's still useful from both kinds of scenarios. If you'd like me to take this route, please let me know and give as much information as possible about the suggested implementation since I'm not particularly versed in Scala and "the Scala way" of doing things. 

Thanks in advance, and thanks again for a great load testing tool! :+1: 