### PR TITLE
Recorder: Introduce config parameter 'recorder.http.useMethodAndUriAsPostfix'.

### DIFF
--- a/gatling-recorder/src/main/resources/recorder-defaults.conf
+++ b/gatling-recorder/src/main/resources/recorder-defaults.conf
@@ -16,12 +16,13 @@ recorder {
     blacklist = []              # The list of ressources patterns that are part of the Recorder's blacklist
   }
   http {
-    automaticReferer = true       # When set to false, write the referer + enable 'disableAutoReferer' in the generated simulation
-    followRedirect = true         # When set to false, write redirect requests + enable 'disableFollowRedirect' in the generated simulation
-    removeCacheHeaders = true     # When set to true, removes from the generated requests headers leading to request caching
-    inferHtmlResources = true     # When set to true, add inferred resources + set 'inferHtmlResources' with the configured blacklist/whitelist in the generated simulation
-    checkResponseBodies = false   # When set to true, save response bodies as files and add raw checks in the generated simulation
-    useSimulationAsPrefix = false # When set to true, use the simulation class name instead of 'request' as a prefix for http(s) requests
+    automaticReferer = true             # When set to false, write the referer + enable 'disableAutoReferer' in the generated simulation
+    followRedirect = true               # When set to false, write redirect requests + enable 'disableFollowRedirect' in the generated simulation
+    removeCacheHeaders = true           # When set to true, removes from the generated requests headers leading to request caching
+    inferHtmlResources = true           # When set to true, add inferred resources + set 'inferHtmlResources' with the configured blacklist/whitelist in the generated simulation
+    checkResponseBodies = false         # When set to true, save response bodies as files and add raw checks in the generated simulation
+    useSimulationAsPrefix = false       # When set to true, use the simulation class name instead of 'request' as a prefix for http(s) requests
+    useMethodAndUriAsPostfix = false    # When set to true, use the HTTP method and the URI as a postfix for http(s) requests
   }
   proxy {
     port = 8000                         # Local port used by Gatling's Proxy for HTTP/HTTPS

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/ConfigKeys.scala
@@ -44,6 +44,7 @@ private[recorder] object ConfigKeys {
     val RemoveCacheHeaders = "recorder.http.removeCacheHeaders"
     val CheckResponseBodies = "recorder.http.checkResponseBodies"
     val UseSimulationAsPrefix = "recorder.http.useSimulationAsPrefix"
+    val UseMethodAndUriAsPostfix = "recorder.http.useMethodAndUriAsPostfix"
   }
   object proxy {
     val Port = "recorder.proxy.port"

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderConfiguration.scala
@@ -145,7 +145,8 @@ private[recorder] object RecorderConfiguration extends StrictLogging {
         inferHtmlResources = config.getBoolean(http.InferHtmlResources),
         removeCacheHeaders = config.getBoolean(http.RemoveCacheHeaders),
         checkResponseBodies = config.getBoolean(http.CheckResponseBodies),
-        useSimulationAsPrefix = config.getBoolean(http.UseSimulationAsPrefix)
+        useSimulationAsPrefix = config.getBoolean(http.UseSimulationAsPrefix),
+        useMethodAndUriAsPostfix = config.getBoolean(http.UseMethodAndUriAsPostfix)
       ),
       proxy = ProxyConfiguration(
         port = config.getInt(proxy.Port),
@@ -212,7 +213,8 @@ private[recorder] final case class HttpConfiguration(
     inferHtmlResources: Boolean,
     removeCacheHeaders: Boolean,
     checkResponseBodies: Boolean,
-    useSimulationAsPrefix: Boolean
+    useSimulationAsPrefix: Boolean,
+    useMethodAndUriAsPostfix: Boolean
 )
 
 private[recorder] final case class KeyStoreConfiguration(

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/config/RecorderPropertiesBuilder.scala
@@ -121,6 +121,11 @@ class RecorderPropertiesBuilder {
     this
   }
 
+  def useMethodAndUriAsPostfix(status: Boolean): RecorderPropertiesBuilder = {
+    props += http.UseMethodAndUriAsPostfix -> status
+    this
+  }
+
   def localPort(port: Int): RecorderPropertiesBuilder = {
     props += proxy.Port -> port
     this

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
@@ -107,7 +107,8 @@ private[scenario] object RequestTemplate {
       else
         ""
     val prefix = if (config.http.useSimulationAsPrefix) simulationClass else "request"
-    s"""http("${prefix}_${request.id}")
+    val postfix = if (config.http.useMethodAndUriAsPostfix) s""":${request.method}_${request.uri}""" else ""
+    s"""http("${prefix}_${request.id}${postfix}")
 			.$renderMethod$renderHeaders$renderBodyOrParams$renderCredentials$renderResources$renderStatusCheck$renderResponseBodyCheck"""
   }
 

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
@@ -112,8 +112,8 @@ private[scenario] object RequestTemplate {
 			.$renderMethod$renderHeaders$renderBodyOrParams$renderCredentials$renderResources$renderStatusCheck$renderResponseBodyCheck"""
   }
 
-  def sanitizeRequestPostfix(name: String): String = {
-    s"""${name.replaceAll("[^-._=:/?&A-Za-z0-9]", "_")}"""
+  def sanitizeRequestPostfix(postfix: String): String = {
+    postfix.replaceAll("[^-._=:/?&A-Za-z0-9]", "_")
   }
 
   def render(simulationClass: String, request: RequestElement, extractedUri: ExtractedUris)(implicit config: RecorderConfiguration): String =

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
@@ -107,14 +107,12 @@ private[scenario] object RequestTemplate {
       else
         ""
     val prefix = if (config.http.useSimulationAsPrefix) simulationClass else "request"
-    val postfix = if (config.http.useMethodAndUriAsPostfix) s":${sanitizeRequestPostfix(s"${request.method}_${request.uri}")}" else ""
+    val postfix = if (config.http.useMethodAndUriAsPostfix) ":" + sanitizeRequestPostfix(s"${request.method}_${request.uri}") else ""
     s"""http("${prefix}_${request.id}${postfix}")
 			.$renderMethod$renderHeaders$renderBodyOrParams$renderCredentials$renderResources$renderStatusCheck$renderResponseBodyCheck"""
   }
 
-  def sanitizeRequestPostfix(postfix: String): String = {
-    postfix.replaceAll("[^-._=:/?&A-Za-z0-9]", "_")
-  }
+  def sanitizeRequestPostfix(postfix: String): String = postfix.replaceAll("[^-._=:/?&A-Za-z0-9]", "_")
 
   def render(simulationClass: String, request: RequestElement, extractedUri: ExtractedUris)(implicit config: RecorderConfiguration): String =
     s"exec(${renderRequest(simulationClass, request, extractedUri)})".toString

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/scenario/template/RequestTemplate.scala
@@ -107,9 +107,13 @@ private[scenario] object RequestTemplate {
       else
         ""
     val prefix = if (config.http.useSimulationAsPrefix) simulationClass else "request"
-    val postfix = if (config.http.useMethodAndUriAsPostfix) s""":${request.method}_${request.uri}""" else ""
+    val postfix = if (config.http.useMethodAndUriAsPostfix) s":${sanitizeRequestPostfix(s"${request.method}_${request.uri}")}" else ""
     s"""http("${prefix}_${request.id}${postfix}")
 			.$renderMethod$renderHeaders$renderBodyOrParams$renderCredentials$renderResources$renderStatusCheck$renderResponseBodyCheck"""
+  }
+
+  def sanitizeRequestPostfix(name: String): String = {
+    s"""${name.replaceAll("[^-._=:/?&A-Za-z0-9]", "_")}"""
   }
 
   def render(simulationClass: String, request: RequestElement, extractedUri: ExtractedUris)(implicit config: RecorderConfiguration): String =

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
@@ -90,6 +90,7 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontEnd)(implicit con
   private val checkResponseBodies = new CheckBox("Save & check response bodies?")
   private val automaticReferers = new CheckBox("Automatic Referers?")
   private val useSimulationAsPrefix = new CheckBox("Use Class Name as request prefix?")
+  private val useMethodAndUriAsPostfix = new CheckBox("Use HTTP method and URI as request postfix?")
 
   /* Output panel components */
   private val outputEncoding = new ComboBox[String](CharsetHelper.orderedLabelList)
@@ -222,6 +223,7 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontEnd)(implicit con
           contents += automaticReferers
           contents += removeCacheHeaders
           contents += useSimulationAsPrefix
+          contents += useMethodAndUriAsPostfix
           contents += checkResponseBodies
         }
 
@@ -529,6 +531,7 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontEnd)(implicit con
     simulationsFolderChooser.setPath(configuration.core.simulationsFolder)
     outputEncoding.selection.item = CharsetHelper.charsetNameToLabel(configuration.core.encoding)
     useSimulationAsPrefix.selected = configuration.http.useSimulationAsPrefix
+    useMethodAndUriAsPostfix.selected = configuration.http.useMethodAndUriAsPostfix
     savePreferences.selected = configuration.core.saveConfig
 
   }
@@ -603,6 +606,7 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontEnd)(implicit con
       props.simulationsFolder(simulationsFolderChooser.selection.trim)
       props.encoding(CharsetHelper.labelToCharsetName(outputEncoding.selection.item))
       props.useSimulationAsPrefix(useSimulationAsPrefix.selected)
+      props.useMethodAndUriAsPostfix(useMethodAndUriAsPostfix.selected)
       props.saveConfig(savePreferences.selected)
 
       RecorderConfiguration.reload(props.build)

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
@@ -19,8 +19,8 @@ package io.gatling.recorder.scenario.template
 import scala.collection.mutable
 
 import io.gatling.BaseSpec
-import io.gatling.recorder.config.ConfigKeys.http.UseSimulationAsPrefix
 import io.gatling.recorder.config.ConfigKeys.http.UseMethodAndUriAsPostfix
+import io.gatling.recorder.config.ConfigKeys.http.UseSimulationAsPrefix
 import io.gatling.recorder.config.RecorderConfiguration
 import io.gatling.recorder.config.RecorderConfiguration.fakeConfig
 import io.gatling.recorder.scenario.{ RequestBodyParams, RequestElement }

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
@@ -73,7 +73,7 @@ class RequestTemplateSpec extends BaseSpec {
     val mockedRequest1 = mockRequestElement("name", "short")
     implicit val config: RecorderConfiguration = fakeConfig(mutable.Map(UseMethodAndUriAsPostfix -> true))
     val res1 = RequestTemplate.render(simulationClass, mockedRequest1, new ExtractedUris(Seq(mockedRequest1)))
-    res1 should include (s"request_0:post_http://gatling.io/path1/file1")
+    res1 should include(s"request_0:post_http://gatling.io/path1/file1")
   }
 
   it should "escape bad characters in request postfix" in {

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable
 
 import io.gatling.BaseSpec
 import io.gatling.recorder.config.ConfigKeys.http.UseSimulationAsPrefix
+import io.gatling.recorder.config.ConfigKeys.http.UseMethodAndUriAsPostfix
 import io.gatling.recorder.config.RecorderConfiguration
 import io.gatling.recorder.config.RecorderConfiguration.fakeConfig
 import io.gatling.recorder.scenario.{ RequestBodyParams, RequestElement }
@@ -66,5 +67,12 @@ class RequestTemplateSpec extends BaseSpec {
     val res1 = RequestTemplate.render(simulationClass, mockedRequest1, new ExtractedUris(Seq(mockedRequest1)))
     res1 should include(s"${simulationClass}_0")
     res1 should not include ("request_0")
+  }
+
+  it should "use method and URI as postfix when requested" in {
+    val mockedRequest1 = mockRequestElement("name", "short")
+    implicit val config: RecorderConfiguration = fakeConfig(mutable.Map(UseMethodAndUriAsPostfix -> true))
+    val res1 = RequestTemplate.render(simulationClass, mockedRequest1, new ExtractedUris(Seq(mockedRequest1)))
+    res1 should include (s"request_0:post_http://gatling.io/path1/file1")
   }
 }

--- a/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
+++ b/gatling-recorder/src/test/scala/io/gatling/recorder/scenario/template/RequestTemplateSpec.scala
@@ -75,4 +75,9 @@ class RequestTemplateSpec extends BaseSpec {
     val res1 = RequestTemplate.render(simulationClass, mockedRequest1, new ExtractedUris(Seq(mockedRequest1)))
     res1 should include (s"request_0:post_http://gatling.io/path1/file1")
   }
+
+  it should "escape bad characters in request postfix" in {
+    val postfix = RequestTemplate.sanitizeRequestPostfix("POST_https://gatling.io/hello?to=\"john\\doe\"&hobbies={a,b;c\\d}")
+    postfix should equal(s"POST_https://gatling.io/hello?to=_john_doe_&hobbies=_a_b_c_d_")
+  }
 }


### PR DESCRIPTION
### Motivation
When using Gatling recorder, the produced report is not that easy to read for us, as the request names look quite alike having name `request_$ID`.

For us it is helpful, having also request method and URI in the request name; the produced reports are now quite useful to us.
 
### Content of this PR
Introduce gatling-recorder config parameter `recorder.http.useMethodAndUriAsPostfix`. When set to true, use the HTTP method and the URI as a postfix for http(s) requests name.

E.g. request name will be `request_0:post_http://gatling.io/path1/file1` (instead of simply `request_0`). This improves legibility of recorded Gatling reports.

As this implementation sticked to approach of existing parameter `recorder.http.useSimulationAsPrefix`, it was quite a no-brainer.