### PR TITLE
Charts: Remove background color for .head

### DIFF
--- a/gatling-charts/src/main/resources/io/gatling/charts/assets/style/style.css
+++ b/gatling-charts/src/main/resources/io/gatling/charts/assets/style/style.css
@@ -78,7 +78,6 @@ h1 span {
 	height: 100px;
 	width: 600px;
 	padding: 10px 0 0 120px;
-	background-color: #f0f5fb;
 	position: absolute;
 	top: 0;
 	left: 0;


### PR DESCRIPTION
The previous way this was written causes the output to look quite ugly if the simulation results directory is quite long.

## Before the change (w/ Gatling 3.0.2)

As can be seen, the Gatling frontline infomercial overlays the results directory.

![image](https://user-images.githubusercontent.com/630613/80691922-8c9f2e00-8ad9-11ea-9de9-c80665fe5997.png)

## After the change

(tested by flipping the CSS property as indicated)

![image](https://user-images.githubusercontent.com/630613/80692288-0afbd000-8ada-11ea-962f-f6819a68fef8.png)
