### PR TITLE
Core: Use event loop for pace

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/action/builder/PaceBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/action/builder/PaceBuilder.scala
@@ -16,7 +16,7 @@
 
 package io.gatling.core.action.builder
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 import io.gatling.core.action.{ Action, Pace }
 import io.gatling.core.session.Expression
@@ -27,8 +27,8 @@ import io.gatling.core.structure.ScenarioContext
  *
  * Originally contributed by James Pickering.
  */
-class PaceBuilder(interval: Expression[Duration], counter: String) extends ActionBuilder {
+class PaceBuilder(interval: Expression[FiniteDuration], counter: String) extends ActionBuilder {
 
   override def build(ctx: ScenarioContext, next: Action): Action =
-    new Pace(interval, counter, ctx.coreComponents.actorSystem, ctx.coreComponents.statsEngine, ctx.coreComponents.clock, next)
+    new Pace(interval, counter, ctx.coreComponents.statsEngine, ctx.coreComponents.clock, next)
 }

--- a/gatling-core/src/test/scala/io/gatling/core/EmptySession.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/EmptySession.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package io.gatling
+package io.gatling.core
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import io.gatling.core.session.Session
 
-import io.gatling.core.EmptySession
+import org.scalatest.{ BeforeAndAfterAll, Suite }
 
-import akka.actor.ActorSystem
-import akka.testkit.{ ImplicitSender, TestKit }
+trait EmptySession extends BeforeAndAfterAll { this: Suite =>
+  val fakeEventLoop = new FakeEventLoop
+  val emptySession: Session = Session("Scenario", 0, fakeEventLoop)
 
-abstract class AkkaSpec extends TestKit(ActorSystem()) with BaseSpec with ImplicitSender with EmptySession {
-  override def afterAll(): Unit = {
-    val whenTerminated = system.terminate()
-    Await.result(whenTerminated, 2 seconds)
+  override protected def afterAll(): Unit = {
+    fakeEventLoop.shutdownGracefully()
+    super.afterAll()
   }
+
 }

--- a/gatling-core/src/test/scala/io/gatling/core/FakeEventLoop.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/FakeEventLoop.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2011-2020 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.core
+
+import java.{ util => ju }
+import java.util.{ Timer, TimerTask, concurrent => juc }
+
+import io.netty.channel.{ Channel, ChannelFuture, ChannelPromise, EventLoop, EventLoopGroup }
+import io.netty.util.concurrent.{ EventExecutor, Future => NFuture, ProgressivePromise, Promise, ScheduledFuture }
+
+class FakeEventLoop extends EventLoop {
+  private val timer = new Timer(true)
+
+  override def inEventLoop(): Boolean = true
+  override def schedule(command: Runnable, delay: Long, unit: juc.TimeUnit): ScheduledFuture[_] = {
+    timer.schedule(
+      new TimerTask {
+        override def run(): Unit = { command.run() }
+      },
+      unit.toMillis(delay)
+    )
+    null
+  }
+  override def execute(command: Runnable): Unit = command.run()
+
+  override def shutdownGracefully(): NFuture[_] = {
+    timer.cancel()
+    null
+  }
+
+  override def parent(): EventLoopGroup = throw new UnsupportedOperationException
+  override def next(): EventLoop = throw new UnsupportedOperationException
+  override def register(channel: Channel): ChannelFuture = throw new UnsupportedOperationException
+  override def register(promise: ChannelPromise): ChannelFuture = throw new UnsupportedOperationException
+  override def register(channel: Channel, promise: ChannelPromise): ChannelFuture = throw new UnsupportedOperationException
+  override def inEventLoop(thread: Thread): Boolean = throw new UnsupportedOperationException
+  override def newPromise[V](): Promise[V] = throw new UnsupportedOperationException
+  override def newProgressivePromise[V](): ProgressivePromise[V] = throw new UnsupportedOperationException
+  override def newSucceededFuture[V](result: V): NFuture[V] = throw new UnsupportedOperationException
+  override def newFailedFuture[V](cause: Throwable): NFuture[V] = throw new UnsupportedOperationException
+  override def isShuttingDown: Boolean = throw new UnsupportedOperationException
+  override def shutdownGracefully(quietPeriod: Long, timeout: Long, unit: juc.TimeUnit): NFuture[_] = throw new UnsupportedOperationException
+  override def terminationFuture(): NFuture[_] = throw new UnsupportedOperationException
+  override def shutdown(): Unit = throw new UnsupportedOperationException
+  override def shutdownNow(): ju.List[Runnable] = throw new UnsupportedOperationException
+  override def iterator(): ju.Iterator[EventExecutor] = throw new UnsupportedOperationException
+  override def submit(task: Runnable): NFuture[_] = throw new UnsupportedOperationException
+  override def submit[T](task: Runnable, result: T): NFuture[T] = throw new UnsupportedOperationException
+  override def submit[T](task: juc.Callable[T]): NFuture[T] = throw new UnsupportedOperationException
+  override def schedule[V](callable: juc.Callable[V], delay: Long, unit: juc.TimeUnit): ScheduledFuture[V] = throw new UnsupportedOperationException
+  override def scheduleAtFixedRate(command: Runnable, initialDelay: Long, period: Long, unit: juc.TimeUnit): ScheduledFuture[_] =
+    throw new UnsupportedOperationException
+  override def scheduleWithFixedDelay(command: Runnable, initialDelay: Long, delay: Long, unit: juc.TimeUnit): ScheduledFuture[_] =
+    throw new UnsupportedOperationException
+  override def isShutdown: Boolean = false
+  override def isTerminated: Boolean = throw new UnsupportedOperationException
+  override def awaitTermination(timeout: Long, unit: juc.TimeUnit): Boolean = throw new UnsupportedOperationException
+  override def invokeAll[T](tasks: ju.Collection[_ <: juc.Callable[T]]): ju.List[juc.Future[T]] = throw new UnsupportedOperationException
+  override def invokeAll[T](tasks: ju.Collection[_ <: juc.Callable[T]], timeout: Long, unit: juc.TimeUnit): ju.List[juc.Future[T]] =
+    throw new UnsupportedOperationException
+  override def invokeAny[T](tasks: ju.Collection[_ <: juc.Callable[T]]): T = throw new UnsupportedOperationException
+  override def invokeAny[T](tasks: ju.Collection[_ <: juc.Callable[T]], timeout: Long, unit: juc.TimeUnit): T = throw new UnsupportedOperationException
+}

--- a/gatling-core/src/test/scala/io/gatling/core/action/ActionSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/ActionSpec.scala
@@ -17,10 +17,10 @@
 package io.gatling.core.action
 
 import io.gatling.BaseSpec
+import io.gatling.core.EmptySession
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 
-class ActionSpec extends BaseSpec {
+class ActionSpec extends BaseSpec with EmptySession {
 
   class TestAction extends Action {
     var hasRun = false
@@ -33,7 +33,7 @@ class ActionSpec extends BaseSpec {
     val testAction = new TestAction
 
     testAction.hasRun shouldBe false
-    testAction ! EmptySession
+    testAction ! emptySession
     testAction.hasRun shouldBe true
   }
 }

--- a/gatling-core/src/test/scala/io/gatling/core/action/ChainableActionSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/ChainableActionSpec.scala
@@ -20,10 +20,10 @@ import scala.util.control.NoStackTrace
 
 import io.gatling.BaseSpec
 import io.gatling.commons.validation._
+import io.gatling.core.EmptySession
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 
-class ChainableActionSpec extends BaseSpec {
+class ChainableActionSpec extends BaseSpec with EmptySession {
 
   class ChainableTestAction(val next: Action, fail: Boolean) extends ChainableAction {
     var hasRun = false
@@ -59,7 +59,7 @@ class ChainableActionSpec extends BaseSpec {
     val testAction = new ChainableTestAction(next, fail = false)
 
     testAction.hasRun shouldBe false
-    testAction ! EmptySession
+    testAction ! emptySession
     testAction.hasRun shouldBe true
   }
 
@@ -67,8 +67,8 @@ class ChainableActionSpec extends BaseSpec {
     val next = new NextTestAction
     val testAction = new ChainableTestAction(next, fail = true)
 
-    testAction ! EmptySession
-    next.message shouldBe EmptySession.markAsFailed
+    testAction ! emptySession
+    next.message shouldBe emptySession.markAsFailed
   }
 
   "A Failable Action" should "call the execute method when receiving a Session" in {
@@ -77,7 +77,7 @@ class ChainableActionSpec extends BaseSpec {
 
     testAction.hasRun shouldBe false
 
-    testAction ! EmptySession
+    testAction ! emptySession
     testAction.hasRun shouldBe true
   }
 
@@ -85,7 +85,7 @@ class ChainableActionSpec extends BaseSpec {
     val next = new NextTestAction
     val testAction = new FailableTestAction(next, fail = true)
 
-    testAction ! EmptySession
-    next.message shouldBe EmptySession.markAsFailed
+    testAction ! emptySession
+    next.message shouldBe emptySession.markAsFailed
   }
 }

--- a/gatling-core/src/test/scala/io/gatling/core/action/ExitHereSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/ExitHereSpec.scala
@@ -19,14 +19,14 @@ package io.gatling.core.action
 import io.gatling.BaseSpec
 import io.gatling.commons.stats.KO
 import io.gatling.commons.util.Clock
+import io.gatling.core.EmptySession
 import io.gatling.core.session.{ GroupBlock, Session }
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.StatsEngine
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
-class ExitHereSpec extends BaseSpec {
+class ExitHereSpec extends BaseSpec with EmptySession {
 
   "ExitHereIfFailed" should "send the session to the next action if the session was not failed" in {
     val exit = mock[Action]
@@ -35,8 +35,8 @@ class ExitHereSpec extends BaseSpec {
     val clock = mock[Clock]
     val exitHereIfFailed = new ExitHere(ExitHere.ExitHereOnFailedCondition, exit, statsEngine, clock, next)
 
-    exitHereIfFailed ! EmptySession
-    verify(next) ! EmptySession
+    exitHereIfFailed ! emptySession
+    verify(next) ! emptySession
     verify(exit, never) ! any[Session]
   }
 
@@ -47,7 +47,7 @@ class ExitHereSpec extends BaseSpec {
     val clock = mock[Clock]
     val exitHereIfFailed = new ExitHere(ExitHere.ExitHereOnFailedCondition, exit, statsEngine, clock, next)
 
-    val sessionWithTryMax = EmptySession.enterTryMax("loop", next).markAsFailed
+    val sessionWithTryMax = emptySession.enterTryMax("loop", next).markAsFailed
 
     exitHereIfFailed ! sessionWithTryMax
 
@@ -63,7 +63,7 @@ class ExitHereSpec extends BaseSpec {
     when(clock.nowMillis).thenReturn(1)
     val exitHereIfFailed = new ExitHere(ExitHere.ExitHereOnFailedCondition, exit, statsEngine, clock, next)
 
-    val sessionWithGroup = EmptySession.enterGroup("group", 0).markAsFailed
+    val sessionWithGroup = emptySession.enterGroup("group", 0).markAsFailed
 
     exitHereIfFailed ! sessionWithGroup
 

--- a/gatling-core/src/test/scala/io/gatling/core/action/ExitSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/ExitSpec.scala
@@ -18,7 +18,6 @@ package io.gatling.core.action
 
 import io.gatling.AkkaSpec
 import io.gatling.commons.util.DefaultClock
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.writer.UserEndMessage
 
 class ExitSpec extends AkkaSpec {
@@ -30,7 +29,7 @@ class ExitSpec extends AkkaSpec {
 
     var hasTerminated = false
 
-    val session = EmptySession.copy(onExit = _ => hasTerminated = true)
+    val session = emptySession.copy(onExit = _ => hasTerminated = true)
     exit ! session
 
     hasTerminated shouldBe true

--- a/gatling-core/src/test/scala/io/gatling/core/action/FeedActorSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/FeedActorSpec.scala
@@ -20,7 +20,6 @@ import io.gatling.AkkaSpec
 import io.gatling.core.controller.ControllerCommand.Crash
 import io.gatling.core.feeder.Feeder
 import io.gatling.core.session._
-import io.gatling.core.session.SessionSpec.EmptySession
 
 import akka.testkit._
 
@@ -33,10 +32,10 @@ class FeedActorSpec extends AkkaSpec {
     val controller = TestProbe()
     val feedActor = createFeedActor(Iterator.continually(Map("foo" -> "bar")), controller)
 
-    feedActor ! FeedMessage(EmptySession, 0, new ActorDelegatingAction("next", self))
+    feedActor ! FeedMessage(emptySession, 0, new ActorDelegatingAction("next", self))
     controller.expectMsgType[Crash]
 
-    feedActor ! FeedMessage(EmptySession, -1, new ActorDelegatingAction("next", self))
+    feedActor ! FeedMessage(emptySession, -1, new ActorDelegatingAction("next", self))
     controller.expectMsgType[Crash]
   }
 
@@ -44,7 +43,7 @@ class FeedActorSpec extends AkkaSpec {
     val controller = TestProbe()
     val feedActor = createFeedActor(Iterator.empty, controller)
 
-    feedActor ! FeedMessage(EmptySession, 1, new ActorDelegatingAction("next", self))
+    feedActor ! FeedMessage(emptySession, 1, new ActorDelegatingAction("next", self))
     controller.expectMsgType[Crash]
   }
 
@@ -52,7 +51,7 @@ class FeedActorSpec extends AkkaSpec {
     val controller = TestProbe()
     val feedActor = createFeedActor(Iterator.continually(Map("foo" -> "bar")), controller)
 
-    feedActor ! FeedMessage(EmptySession, 1, new ActorDelegatingAction("next", self))
+    feedActor ! FeedMessage(emptySession, 1, new ActorDelegatingAction("next", self))
 
     val newSession = expectMsgType[Session]
     newSession.contains("foo") shouldBe true
@@ -63,7 +62,7 @@ class FeedActorSpec extends AkkaSpec {
     val controller = TestProbe()
     val feedActor = createFeedActor(Iterator.continually(Map("foo" -> "bar")), controller)
 
-    feedActor ! FeedMessage(EmptySession, 2, new ActorDelegatingAction("next", self))
+    feedActor ! FeedMessage(emptySession, 2, new ActorDelegatingAction("next", self))
 
     val newSession = expectMsgType[Session]
     newSession.contains("foo1") shouldBe true

--- a/gatling-core/src/test/scala/io/gatling/core/action/FeedSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/FeedSpec.scala
@@ -19,7 +19,6 @@ package io.gatling.core.action
 import io.gatling.AkkaSpec
 import io.gatling.commons.util.DefaultClock
 import io.gatling.core.session._
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.StatsEngine
 
 import akka.testkit._
@@ -35,10 +34,10 @@ class FeedSpec extends AkkaSpec with MockitoSugar {
 
     val feed = new Feed(feedActor.ref, 1.expressionSuccess, mock[StatsEngine], clock, next)
 
-    feed ! EmptySession
+    feed ! emptySession
 
     val feedMessage = feedActor.expectMsgType[FeedMessage]
-    feedMessage.session shouldBe EmptySession
+    feedMessage.session shouldBe emptySession
     feedMessage.next shouldBe next
   }
 }

--- a/gatling-core/src/test/scala/io/gatling/core/action/GroupEndSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/GroupEndSpec.scala
@@ -17,8 +17,8 @@
 package io.gatling.core.action
 
 import io.gatling.commons.util.DefaultClock
+import io.gatling.core.EmptySession
 import io.gatling.core.session.{ GroupBlock, Session }
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.StatsEngine
 
 import org.mockito.{ ArgumentCaptor, ArgumentMatchers }
@@ -28,7 +28,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-class GroupEndSpec extends AnyFlatSpec with Matchers with MockitoSugar with GivenWhenThen {
+class GroupEndSpec extends AnyFlatSpec with Matchers with MockitoSugar with GivenWhenThen with EmptySession {
 
   private val clock = new DefaultClock
 
@@ -40,7 +40,7 @@ class GroupEndSpec extends AnyFlatSpec with Matchers with MockitoSugar with Give
     val groupEnd = new GroupEnd(statsEngine, clock, next)
 
     When("being sent a Session that has one single group")
-    val session = EmptySession.enterGroup("group", clock.nowMillis)
+    val session = emptySession.enterGroup("group", clock.nowMillis)
     groupEnd ! session
 
     Then("next Action should receive a Session with an empty blockStack")

--- a/gatling-core/src/test/scala/io/gatling/core/action/GroupStartSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/GroupStartSpec.scala
@@ -17,8 +17,8 @@
 package io.gatling.core.action
 
 import io.gatling.commons.util.DefaultClock
+import io.gatling.core.EmptySession
 import io.gatling.core.session.{ GroupBlock, Session }
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.session.el.El
 import io.gatling.core.stats.StatsEngine
 
@@ -29,7 +29,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-class GroupStartSpec extends AnyFlatSpec with Matchers with MockitoSugar with GivenWhenThen {
+class GroupStartSpec extends AnyFlatSpec with Matchers with MockitoSugar with GivenWhenThen with EmptySession {
 
   private val clock = new DefaultClock
 
@@ -40,7 +40,7 @@ class GroupStartSpec extends AnyFlatSpec with Matchers with MockitoSugar with Gi
     val groupStart = new GroupStart("${theGroupName}".el[String], mock[StatsEngine], clock, next)
 
     When("being sent a Session that resolves the group name")
-    val session = EmptySession.copy(attributes = Map("theGroupName" -> "foo"))
+    val session = emptySession.copy(attributes = Map("theGroupName" -> "foo"))
     groupStart ! session
 
     Then("next Action should receive a Session")

--- a/gatling-core/src/test/scala/io/gatling/core/action/IfSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/IfSpec.scala
@@ -17,7 +17,7 @@
 package io.gatling.core.action
 
 import io.gatling.commons.util.DefaultClock
-import io.gatling.core.session.SessionSpec.EmptySession
+import io.gatling.core.EmptySession
 import io.gatling.core.session.el.El
 import io.gatling.core.stats.StatsEngine
 
@@ -26,7 +26,7 @@ import org.scalatest.GivenWhenThen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
 
-class IfSpec extends AnyFlatSpec with MockitoSugar with GivenWhenThen {
+class IfSpec extends AnyFlatSpec with MockitoSugar with GivenWhenThen with EmptySession {
 
   private val clock = new DefaultClock
   private val condition = "${condition}".el[Boolean]
@@ -39,7 +39,7 @@ class IfSpec extends AnyFlatSpec with MockitoSugar with GivenWhenThen {
     val ifAction = new If(condition, thenNext, elseNext, mock[StatsEngine], clock, mock[Action])
 
     When("being sent a Session that causes condition to be evaluated as true")
-    val session = EmptySession.set("condition", true)
+    val session = emptySession.set("condition", true)
     ifAction ! session
 
     Then("Session should be propagated to thenNext")
@@ -57,7 +57,7 @@ class IfSpec extends AnyFlatSpec with MockitoSugar with GivenWhenThen {
     val ifAction = new If(condition, thenNext, elseNext, mock[StatsEngine], clock, mock[Action])
 
     When("being sent a Session that causes condition to be evaluated as false")
-    val session = EmptySession.set("condition", false)
+    val session = emptySession.set("condition", false)
     ifAction ! session
 
     Then("Session should be propagated to elseNext")

--- a/gatling-core/src/test/scala/io/gatling/core/action/PaceSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/PaceSpec.scala
@@ -34,7 +34,7 @@ class PaceSpec extends AkkaSpec {
   private val counterName = "paceCounter"
 
   "pace" should "run actions with a minimum wait time" in {
-    val instance = new Pace(interval, counterName, system, mock[StatsEngine], clock, new ActorDelegatingAction("next", self))
+    val instance = new Pace(interval, counterName, mock[StatsEngine], clock, new ActorDelegatingAction("next", self))
 
     // Send session, expect response near-instantly
     instance ! EmptySession
@@ -51,7 +51,7 @@ class PaceSpec extends AkkaSpec {
 
   it should "run actions immediately if the minimum time has expired" in {
     val overrunTime = 1 second
-    val instance = new Pace(interval, counterName, system, mock[StatsEngine], clock, new ActorDelegatingAction("next", self))
+    val instance = new Pace(interval, counterName, mock[StatsEngine], clock, new ActorDelegatingAction("next", self))
 
     // Send session, expect response near-instantly
     instance ! EmptySession

--- a/gatling-core/src/test/scala/io/gatling/core/action/PaceSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/PaceSpec.scala
@@ -21,7 +21,6 @@ import scala.concurrent.duration._
 import io.gatling.AkkaSpec
 import io.gatling.commons.util.DefaultClock
 import io.gatling.core.Predef._
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.StatsEngine
 
 import akka.testkit._
@@ -37,7 +36,7 @@ class PaceSpec extends AkkaSpec {
     val instance = new Pace(interval, counterName, mock[StatsEngine], clock, new ActorDelegatingAction("next", self))
 
     // Send session, expect response near-instantly
-    instance ! EmptySession
+    instance ! emptySession
     val session1 = expectMsgClass(1 second, classOf[Session])
 
     // Send second session, expect nothing for ~3 seconds, then a response
@@ -54,7 +53,7 @@ class PaceSpec extends AkkaSpec {
     val instance = new Pace(interval, counterName, mock[StatsEngine], clock, new ActorDelegatingAction("next", self))
 
     // Send session, expect response near-instantly
-    instance ! EmptySession
+    instance ! emptySession
     val session1 = expectMsgClass(1 second, classOf[Session])
 
     // Wait 4 seconds - simulate overrunning action

--- a/gatling-core/src/test/scala/io/gatling/core/action/RendezVousSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/action/RendezVousSpec.scala
@@ -18,7 +18,7 @@ package io.gatling.core.action
 
 import io.gatling.AkkaSpec
 import io.gatling.commons.util.DefaultClock
-import io.gatling.core.session.SessionSpec.EmptySession
+import io.gatling.core.EmptySession
 import io.gatling.core.stats.StatsEngine
 
 class RendezVousSpec extends AkkaSpec {
@@ -28,16 +28,16 @@ class RendezVousSpec extends AkkaSpec {
   "RendezVous" should "block the specified number of sessions until they have all reached it" in {
     val rendezVous = RendezVous(3, system, mock[StatsEngine], clock, new ActorDelegatingAction("next", self))
 
-    rendezVous ! EmptySession
+    rendezVous ! emptySession
     expectNoMessage(remainingOrDefault)
 
-    rendezVous ! EmptySession
+    rendezVous ! emptySession
     expectNoMessage(remainingOrDefault)
 
-    rendezVous ! EmptySession
-    expectMsgAllOf(EmptySession, EmptySession, EmptySession)
+    rendezVous ! emptySession
+    expectMsgAllOf(emptySession, emptySession, emptySession)
 
-    rendezVous ! EmptySession
-    expectMsg(EmptySession)
+    rendezVous ! emptySession
+    expectMsg(emptySession)
   }
 }

--- a/gatling-core/src/test/scala/io/gatling/core/body/PebbleFileBodySpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/body/PebbleFileBodySpec.scala
@@ -17,16 +17,16 @@
 package io.gatling.core.body
 
 import io.gatling.{ BaseSpec, ValidationValues }
+import io.gatling.core.EmptySession
 import io.gatling.core.config.{ GatlingConfiguration, GatlingFiles }
 import io.gatling.core.session._
-import io.gatling.core.session.SessionSpec.EmptySession
 
-class PebbleFileBodySpec extends BaseSpec with ValidationValues {
+class PebbleFileBodySpec extends BaseSpec with ValidationValues with EmptySession {
 
   private val pebbleFileBodies: PebbleFileBodies = new PebbleFileBodies(GatlingFiles.resourcesDirectory(GatlingConfiguration.loadForTest()), Long.MaxValue)
 
   "PebbleFileBody" should "support templates inheritance" in {
-    val session = EmptySession.set("name", "Mitchell")
+    val session = emptySession.set("name", "Mitchell")
     val body = PebbleFileBody("pebble/home.html".expressionSuccess, pebbleFileBodies)
     body(session).succeeded shouldBe """<html>
                                        |<head>

--- a/gatling-core/src/test/scala/io/gatling/core/body/PebbleStringBodySpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/body/PebbleStringBodySpec.scala
@@ -17,57 +17,57 @@
 package io.gatling.core.body
 
 import io.gatling.{ BaseSpec, ValidationValues }
+import io.gatling.core.EmptySession
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 
-class PebbleStringBodySpec extends BaseSpec with ValidationValues {
+class PebbleStringBodySpec extends BaseSpec with ValidationValues with EmptySession {
 
   private implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   "Static String" should "return itself" in {
-    val session = EmptySession
+    val session = emptySession
     val body = PebbleStringBody("bar")
     body(session).succeeded shouldBe "bar"
   }
 
   it should "return empty when empty" in {
-    val session = EmptySession
+    val session = emptySession
     val body = PebbleStringBody("")
     body(session).succeeded shouldBe ""
   }
 
   "One monovalued Expression" should "return expected result when the variable is the whole string" in {
-    val session = EmptySession.set("bar", "BAR")
+    val session = emptySession.set("bar", "BAR")
     val body = PebbleStringBody("{{bar}}")
     body(session).succeeded shouldBe "BAR"
   }
 
   it should "return expected result when the variable is at the end of the string" in {
-    val session = EmptySession.set("bar", "BAR")
+    val session = emptySession.set("bar", "BAR")
     val body = PebbleStringBody("foo{{bar}}")
     body(session).succeeded shouldBe "fooBAR"
   }
 
   it should "return expected result when the variable is at the beginning of the string" in {
-    val session = EmptySession.set("bar", "BAR")
+    val session = emptySession.set("bar", "BAR")
     val body = PebbleStringBody("{{bar}}foo")
     body(session).succeeded shouldBe "BARfoo"
   }
 
   it should "return expected result when the variable is in the middle of the string" in {
-    val session = EmptySession.set("bar", "BAR")
+    val session = emptySession.set("bar", "BAR")
     val body = PebbleStringBody("foo{{bar}}foo")
     body(session).succeeded shouldBe "fooBARfoo"
   }
 
   it should "handle when an attribute is missing" in {
-    val session = EmptySession.set("foo", "FOO")
+    val session = emptySession.set("foo", "FOO")
     val body = PebbleStringBody("foo{{bar}}")
     body(session).succeeded shouldBe "foo"
   }
 
   it should "properly handle multiline JSON template" in {
-    val session = EmptySession.set("foo", "FOO")
+    val session = emptySession.set("foo", "FOO")
     val body = PebbleStringBody("""{
         "foo": {{foo}},
         "bar": 1
@@ -79,43 +79,43 @@ class PebbleStringBodySpec extends BaseSpec with ValidationValues {
   }
 
   it should "properly handle if" in {
-    val session = EmptySession.setAll("barTrue" -> "BARTRUE", "barFalse" -> "BARFALSE", "true" -> true, "false" -> false)
+    val session = emptySession.setAll("barTrue" -> "BARTRUE", "barFalse" -> "BARFALSE", "true" -> true, "false" -> false)
     val body = PebbleStringBody("{%if true %}{{barTrue}}{%endif%}{%if false %}{{barFalse}}{% endif %}")
     body(session).succeeded shouldBe "BARTRUE"
   }
 
   it should "handle gracefully when an exception is thrown" in {
-    val session = EmptySession
+    val session = emptySession
     val body = PebbleStringBody("{{ 0 / 0 }}")
     body(session).failed
   }
 
   "Multivalued Expression" should "return expected result with 2 monovalued expressions" in {
-    val session = EmptySession.setAll("foo" -> "FOO", "bar" -> "BAR")
+    val session = emptySession.setAll("foo" -> "FOO", "bar" -> "BAR")
     val body = PebbleStringBody("{{foo}} {{bar}}")
     body(session).succeeded shouldBe "FOO BAR"
   }
 
   it should "properly handle for loop" in {
-    val session = EmptySession.set("list", List("hello", "bonjour", 42))
+    val session = emptySession.set("list", List("hello", "bonjour", 42))
     val body = PebbleStringBody("{% for value in list %}{{value }}{% endfor %}")
     body(session).succeeded shouldBe "hellobonjour42"
   }
 
   it should "support index access for Scala Seq" in {
-    val session = EmptySession.set("list", Seq(1, 2, 3))
+    val session = emptySession.set("list", Seq(1, 2, 3))
     val body = PebbleStringBody("{{list[0]}}")
     body(session).succeeded shouldBe "1"
   }
 
   it should "handle Maps" in {
-    val session = EmptySession.set("map", Map("foo" -> "bar"))
+    val session = emptySession.set("map", Map("foo" -> "bar"))
     val body = PebbleStringBody("{{map.foo}}")
     body(session).succeeded shouldBe "bar"
   }
 
   it should "handle deep objects" in {
-    val session = EmptySession.set("map", List(Map("key" -> "key1", "value" -> "value1"), Map("key" -> "key2", "value" -> "value2")))
+    val session = emptySession.set("map", List(Map("key" -> "key1", "value" -> "value1"), Map("key" -> "key2", "value" -> "value2")))
 
     val template =
       """{% for element in map %}
@@ -139,7 +139,7 @@ class PebbleStringBodySpec extends BaseSpec with ValidationValues {
   }
 
   it should "return expected result when using filters" in {
-    val session = EmptySession.set("bar", "bar")
+    val session = emptySession.set("bar", "bar")
     val body = PebbleStringBody("{{ bar | capitalize }}{% filter upper %}hello{% endfilter %}")
     body(session).succeeded shouldBe "BarHELLO"
   }

--- a/gatling-core/src/test/scala/io/gatling/core/session/BlockSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/session/BlockSpec.scala
@@ -19,10 +19,10 @@ package io.gatling.core.session
 import io.gatling.BaseSpec
 import io.gatling.commons.stats.OK
 import io.gatling.commons.validation._
+import io.gatling.core.EmptySession
 import io.gatling.core.action.Action
-import io.gatling.core.session.SessionSpec.EmptySession
 
-class BlockSpec extends BaseSpec {
+class BlockSpec extends BaseSpec with EmptySession {
 
   "LoopBlock.unapply" should "return the block's counter name if it is a instance of LoopBlock" in {
     LoopBlock.unapply(ExitAsapLoopBlock("counter", true.expressionSuccess, mock[Action])) shouldBe Some("counter")
@@ -34,12 +34,12 @@ class BlockSpec extends BaseSpec {
   }
 
   "LoopBlock.continue" should "return true if the condition evaluation succeeds and evaluates to true" in {
-    val session = EmptySession.set("foo", 1)
+    val session = emptySession.set("foo", 1)
     LoopBlock.continue(session => (session("foo").as[Int] == 1).success, session) shouldBe true
   }
 
   it should "return false if the condition evaluation succeeds and evaluates to false or if it failed" in {
-    val session = EmptySession.set("foo", 1)
+    val session = emptySession.set("foo", 1)
     LoopBlock.continue(session => (session("foo").as[Int] == 0).success, session) shouldBe false
 
     LoopBlock.continue(_ => "failed".failure, session) shouldBe false

--- a/gatling-core/src/test/scala/io/gatling/core/session/ExpressionUtilsSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/session/ExpressionUtilsSpec.scala
@@ -18,25 +18,25 @@ package io.gatling.core.session
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.commons.validation._
-import io.gatling.core.session.SessionSpec.EmptySession
+import io.gatling.core.EmptySession
 import io.gatling.core.session.el._
 
-class ExpressionUtilsSpec extends BaseSpec with ValidationValues {
+class ExpressionUtilsSpec extends BaseSpec with ValidationValues with EmptySession {
 
   "resolveOptionalExpression" should "return NoneSuccess if the expression was None" in {
-    resolveOptionalExpression(None, EmptySession) shouldBe NoneSuccess
+    resolveOptionalExpression(None, emptySession) shouldBe NoneSuccess
   }
 
   it should "return the expression's result wrapped in a Success if the expression wasn't None" in {
-    val session = EmptySession.set("foo", "bar")
+    val session = emptySession.set("foo", "bar")
     val expr = Some("${foo}".el[String])
     resolveOptionalExpression(expr, session) shouldBe Success(Some("bar"))
   }
 
   "ExpressionWrapper" should "correctly map the underlying validation" in {
     val expr = "foo".el[String]
-    expr(EmptySession).succeeded shouldBe "foo"
+    expr(emptySession).succeeded shouldBe "foo"
     val newExpr = expr.map(_.toUpperCase)
-    newExpr(EmptySession).succeeded shouldBe "FOO"
+    newExpr(emptySession).succeeded shouldBe "FOO"
   }
 }

--- a/gatling-core/src/test/scala/io/gatling/core/session/SessionSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/session/SessionSpec.scala
@@ -17,7 +17,7 @@
 package io.gatling.core.session
 
 import java.{ util => ju }
-import java.util.{ concurrent => juc }
+import java.util.{ Timer, TimerTask, concurrent => juc }
 
 import io.gatling.BaseSpec
 import io.gatling.commons.stats.{ KO, OK }
@@ -28,10 +28,17 @@ import io.netty.channel.{ Channel, ChannelFuture, ChannelPromise, EventLoop, Eve
 import io.netty.util.concurrent.{ EventExecutor, Future => NFuture, ProgressivePromise, Promise, ScheduledFuture }
 
 object SessionSpec {
+  private val timer = new Timer
+
   private val FakeEventLoop: EventLoop = new EventLoop {
     override def inEventLoop(): Boolean = true
     override def schedule(command: Runnable, delay: Long, unit: juc.TimeUnit): ScheduledFuture[_] = {
-      command.run()
+      timer.schedule(
+        new TimerTask {
+          override def run(): Unit = { command.run() }
+        },
+        unit.toMillis(delay)
+      )
       null
     }
     override def execute(command: Runnable): Unit = command.run()

--- a/gatling-core/src/test/scala/io/gatling/core/session/SessionSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/session/SessionSpec.scala
@@ -16,79 +16,17 @@
 
 package io.gatling.core.session
 
-import java.{ util => ju }
-import java.util.{ Timer, TimerTask, concurrent => juc }
-
 import io.gatling.BaseSpec
 import io.gatling.commons.stats.{ KO, OK }
 import io.gatling.commons.validation.{ Failure, Success }
+import io.gatling.core.EmptySession
 import io.gatling.core.action.Action
 
-import io.netty.channel.{ Channel, ChannelFuture, ChannelPromise, EventLoop, EventLoopGroup }
-import io.netty.util.concurrent.{ EventExecutor, Future => NFuture, ProgressivePromise, Promise, ScheduledFuture }
-
-object SessionSpec {
-  private val timer = new Timer
-
-  private val FakeEventLoop: EventLoop = new EventLoop {
-    override def inEventLoop(): Boolean = true
-    override def schedule(command: Runnable, delay: Long, unit: juc.TimeUnit): ScheduledFuture[_] = {
-      timer.schedule(
-        new TimerTask {
-          override def run(): Unit = { command.run() }
-        },
-        unit.toMillis(delay)
-      )
-      null
-    }
-    override def execute(command: Runnable): Unit = command.run()
-
-    override def parent(): EventLoopGroup = throw new UnsupportedOperationException
-    override def next(): EventLoop = throw new UnsupportedOperationException
-    override def register(channel: Channel): ChannelFuture = throw new UnsupportedOperationException
-    override def register(promise: ChannelPromise): ChannelFuture = throw new UnsupportedOperationException
-    override def register(channel: Channel, promise: ChannelPromise): ChannelFuture = throw new UnsupportedOperationException
-    override def inEventLoop(thread: Thread): Boolean = throw new UnsupportedOperationException
-    override def newPromise[V](): Promise[V] = throw new UnsupportedOperationException
-    override def newProgressivePromise[V](): ProgressivePromise[V] = throw new UnsupportedOperationException
-    override def newSucceededFuture[V](result: V): NFuture[V] = throw new UnsupportedOperationException
-    override def newFailedFuture[V](cause: Throwable): NFuture[V] = throw new UnsupportedOperationException
-    override def isShuttingDown: Boolean = throw new UnsupportedOperationException
-    override def shutdownGracefully(): NFuture[_] = throw new UnsupportedOperationException
-    override def shutdownGracefully(quietPeriod: Long, timeout: Long, unit: juc.TimeUnit): NFuture[_] = throw new UnsupportedOperationException
-    override def terminationFuture(): NFuture[_] = throw new UnsupportedOperationException
-    override def shutdown(): Unit = throw new UnsupportedOperationException
-    override def shutdownNow(): ju.List[Runnable] = throw new UnsupportedOperationException
-    override def iterator(): ju.Iterator[EventExecutor] = throw new UnsupportedOperationException
-    override def submit(task: Runnable): NFuture[_] = throw new UnsupportedOperationException
-    override def submit[T](task: Runnable, result: T): NFuture[T] = throw new UnsupportedOperationException
-    override def submit[T](task: juc.Callable[T]): NFuture[T] = throw new UnsupportedOperationException
-    override def schedule[V](callable: juc.Callable[V], delay: Long, unit: juc.TimeUnit): ScheduledFuture[V] = throw new UnsupportedOperationException
-    override def scheduleAtFixedRate(command: Runnable, initialDelay: Long, period: Long, unit: juc.TimeUnit): ScheduledFuture[_] =
-      throw new UnsupportedOperationException
-    override def scheduleWithFixedDelay(command: Runnable, initialDelay: Long, delay: Long, unit: juc.TimeUnit): ScheduledFuture[_] =
-      throw new UnsupportedOperationException
-    override def isShutdown: Boolean = false
-    override def isTerminated: Boolean = throw new UnsupportedOperationException
-    override def awaitTermination(timeout: Long, unit: juc.TimeUnit): Boolean = throw new UnsupportedOperationException
-    override def invokeAll[T](tasks: ju.Collection[_ <: juc.Callable[T]]): ju.List[juc.Future[T]] = throw new UnsupportedOperationException
-    override def invokeAll[T](tasks: ju.Collection[_ <: juc.Callable[T]], timeout: Long, unit: juc.TimeUnit): ju.List[juc.Future[T]] =
-      throw new UnsupportedOperationException
-    override def invokeAny[T](tasks: ju.Collection[_ <: juc.Callable[T]]): T = throw new UnsupportedOperationException
-    override def invokeAny[T](tasks: ju.Collection[_ <: juc.Callable[T]], timeout: Long, unit: juc.TimeUnit): T = throw new UnsupportedOperationException
-  }
-
-  val EmptySession: Session = Session("Scenario", 0, SessionSpec.FakeEventLoop)
-}
-
-class SessionSpec extends BaseSpec {
-
-  import SessionSpec._
-
+class SessionSpec extends BaseSpec with EmptySession {
   private val nextAction = mock[Action]
 
   "setAll" should "set all give key/values pairs in session" in {
-    val session = EmptySession.setAll("key" -> 1, "otherKey" -> 2)
+    val session = emptySession.setAll("key" -> 1, "otherKey" -> 2)
     session.attributes.contains("key") shouldBe true
     session.attributes.contains("otherKey") shouldBe true
     session.attributes("key") shouldBe 1
@@ -97,7 +35,7 @@ class SessionSpec extends BaseSpec {
 
   "reset" should "remove all non private attributes from the session" in {
     val privateAttribute = SessionPrivateAttributes.PrivateAttributePrefix + "foo"
-    val session = EmptySession
+    val session = emptySession
       .setAll("key" -> 1, "otherKey" -> 2, privateAttribute -> 5)
       .reset
 
@@ -105,7 +43,7 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "preserve loop counter" in {
-    val session = EmptySession
+    val session = emptySession
       .set("bar", 5)
       .enterLoop(counterName = "foo", condition = _ => Success(true), exitAction = null, exitASAP = false)
       .reset
@@ -115,7 +53,7 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "preserve loop timestamp" in {
-    val session = EmptySession
+    val session = emptySession
       .set("bar", 5)
       .enterTimeBasedLoop(counterName = "foo", condition = _ => Success(true), exitAction = null, exitASAP = false, nowMillis = 1000)
       .reset
@@ -126,50 +64,50 @@ class SessionSpec extends BaseSpec {
   }
 
   "remove" should "remove an attribute from the session if present" in {
-    val session = EmptySession.set("key", "value").remove("key")
+    val session = emptySession.set("key", "value").remove("key")
     session.attributes.contains("key") shouldBe false
   }
 
   it should "return the current session if the attribute is not in session" in {
-    val session = EmptySession.set("key", "value")
+    val session = emptySession.set("key", "value")
     val unmodifiedSession = session.remove("otherKey")
     session should be theSameInstanceAs unmodifiedSession
   }
 
   "removeAll" should "remove all specified attributes from the session if present" in {
-    val session = EmptySession.set("key", "value").set("otherKey", "otherValue").removeAll("key", "otherKey")
+    val session = emptySession.set("key", "value").set("otherKey", "otherValue").removeAll("key", "otherKey")
     session.attributes.contains("key") shouldBe false
     session.attributes.contains("otherKey") shouldBe false
   }
 
   it should "return the current session if the specified attributes are not in the session" in {
-    val session = EmptySession.set("key", "value").set("otherKey", "otherValue")
+    val session = emptySession.set("key", "value").set("otherKey", "otherValue")
     val unmodifiedSession = session.removeAll("unknownKey", "otherUnknownKey")
     session should be theSameInstanceAs unmodifiedSession
   }
 
   "contains" should "return true if the attribute is in the session" in {
-    val session = EmptySession.set("key", "value")
+    val session = emptySession.set("key", "value")
     session.contains("key") shouldBe true
   }
 
   it should "return false if the attribute is not in the session" in {
-    EmptySession.contains("foo") shouldBe false
+    emptySession.contains("foo") shouldBe false
   }
 
   "loopCounterValue" should "return a counter stored in the session as an Int" in {
-    val session = EmptySession.set("counter", 1)
+    val session = emptySession.set("counter", 1)
     session.loopCounterValue("counter") shouldBe 1
   }
 
   "loopTimestampValue" should "return a counter stored in the session as an Int" in {
     val timestamp = System.currentTimeMillis()
-    val session = EmptySession.set("timestamp.foo", timestamp)
+    val session = emptySession.set("timestamp.foo", timestamp)
     session.loopTimestampValue("foo") shouldBe timestamp
   }
 
   "enterGroup" should "add a 'root' group block is there is no group in the stack" in {
-    val session = EmptySession
+    val session = emptySession
     val sessionWithGroup = session.enterGroup("root group", System.currentTimeMillis())
     val lastBlock = sessionWithGroup.blockStack.head
     lastBlock shouldBe a[GroupBlock]
@@ -177,7 +115,7 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "add a group block with its hierarchy is there are groups in the stack" in {
-    val session = EmptySession.enterGroup("root group", System.currentTimeMillis()).enterGroup("child group", System.currentTimeMillis())
+    val session = emptySession.enterGroup("root group", System.currentTimeMillis()).enterGroup("child group", System.currentTimeMillis())
     val sessionWithThreeGroups = session.enterGroup("last group", System.currentTimeMillis())
     val lastBlock = sessionWithThreeGroups.blockStack.head
     lastBlock shouldBe a[GroupBlock]
@@ -185,13 +123,13 @@ class SessionSpec extends BaseSpec {
   }
 
   "exitGroup" should "remove the GroupBlock from the stack if it's on top of the stack" in {
-    val session = EmptySession.enterGroup("root group", System.currentTimeMillis())
+    val session = emptySession.enterGroup("root group", System.currentTimeMillis())
     val sessionWithoutGroup = session.exitGroup(session.blockStack.tail)
     sessionWithoutGroup.blockStack shouldBe empty
   }
 
   "logGroupRequestTimings" should "update stats in all parent groups" in {
-    val session = EmptySession
+    val session = emptySession
       .enterGroup("root group", System.currentTimeMillis())
       .enterGroup("child group", System.currentTimeMillis())
       .enterTryMax("tryMax", nextAction)
@@ -204,14 +142,14 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "leave the session unmodified if there is no groups in the stack" in {
-    val session = EmptySession
+    val session = emptySession
     val unModifiedSession = session.logGroupRequestTimings(1, 2)
 
     session should be theSameInstanceAs unModifiedSession
   }
 
   "groupHierarchy" should "return the group hierarchy if there is one" in {
-    val session = EmptySession
+    val session = emptySession
     session.groups shouldBe empty
 
     val sessionWithGroup = session
@@ -221,21 +159,21 @@ class SessionSpec extends BaseSpec {
   }
 
   "enterTryMax" should "add a TryMaxBlock on top of the stack and init a counter" in {
-    val session = EmptySession.enterTryMax("tryMax", nextAction)
+    val session = emptySession.enterTryMax("tryMax", nextAction)
 
     session.blockStack.head shouldBe a[TryMaxBlock]
     session.contains("tryMax") shouldBe true
   }
 
   "exitTryMax" should "simply exit the closest TryMaxBlock and remove its associated counter if it has not failed" in {
-    val session = EmptySession.enterTryMax("tryMax", nextAction).exitTryMax
+    val session = emptySession.enterTryMax("tryMax", nextAction).exitTryMax
 
     session.blockStack shouldBe empty
     session.contains("tryMax") shouldBe false
   }
 
   it should "simply exit the TryMaxBlock and remove its associated counter if it has failed but with no other TryMaxBlock in the stack" in {
-    val session = EmptySession
+    val session = emptySession
       .enterGroup("root group", System.currentTimeMillis())
       .enterTryMax("tryMax", nextAction)
       .markAsFailed
@@ -246,7 +184,7 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "exit the TryMaxBlock, remove its associated counter and set the closest TryMaxBlock in the stack's status to KO if it has failed" in {
-    val session = EmptySession
+    val session = emptySession
       .enterTryMax("tryMax1", nextAction)
       .enterGroup("root group", System.currentTimeMillis())
       .enterTryMax("tryMax2", nextAction)
@@ -260,14 +198,14 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "leave the session unmodified if there is no TryMaxBlock on top of the stack" in {
-    val session = EmptySession
+    val session = emptySession
     val unmodifiedSession = session.exitTryMax
 
     session should be theSameInstanceAs unmodifiedSession
   }
 
   it should "propagate the failure to the baseStatus" in {
-    val session = EmptySession
+    val session = emptySession
       .enterTryMax("tryMax1", nextAction)
       .markAsFailed
       .exitTryMax
@@ -276,37 +214,37 @@ class SessionSpec extends BaseSpec {
   }
 
   "isFailed" should "return true if baseStatus is KO and there is no failed TryMaxBlock in the stack" in {
-    val session = EmptySession.copy(baseStatus = KO)
+    val session = emptySession.copy(baseStatus = KO)
 
     session.isFailed shouldBe true
   }
 
   it should "return true if baseStatus is OK and there is a failed TryMaxBlock in the stack" in {
-    val session = EmptySession.copy(blockStack = List(TryMaxBlock("tryMax", nextAction, KO)))
+    val session = emptySession.copy(blockStack = List(TryMaxBlock("tryMax", nextAction, KO)))
 
     session.isFailed shouldBe true
   }
 
   it should "return false if baseStatus is OK and there is no TryMaxBlock in the stack" in {
-    EmptySession.isFailed shouldBe false
+    emptySession.isFailed shouldBe false
   }
 
   it should "return false if baseStatus is OK and there is no failed TryMaxBlock in the stack" in {
-    val session = EmptySession.copy(blockStack = List(TryMaxBlock("tryMax", nextAction, OK)))
+    val session = emptySession.copy(blockStack = List(TryMaxBlock("tryMax", nextAction, OK)))
 
     session.isFailed shouldBe false
   }
 
   "status" should "be OK if the session is not failed" in {
-    EmptySession.status shouldBe OK
+    emptySession.status shouldBe OK
   }
 
   it should "be KO if the session is failed" in {
-    EmptySession.copy(baseStatus = KO).status shouldBe KO
+    emptySession.copy(baseStatus = KO).status shouldBe KO
   }
 
   "markAsSucceeded" should "only set the baseStatus to OK if it was originally KO and there is no TryMaxBlock in the stack" in {
-    val session = EmptySession.copy(baseStatus = KO)
+    val session = emptySession.copy(baseStatus = KO)
     val failedSession = session.markAsSucceeded
 
     failedSession should not be theSameInstanceAs(session)
@@ -314,14 +252,14 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "leave the session unmodified if baseStatus is already OK and there is no TryMaxBlock in the stack" in {
-    val session = EmptySession
+    val session = emptySession
     val failedSession = session.markAsSucceeded
 
     failedSession should be theSameInstanceAs session
   }
 
   it should "set the TryMaxBlock's status to OK if there is a TryMaxBlock in the stack, but leave the baseStatus unmodified" in {
-    val session = EmptySession
+    val session = emptySession
       .copy(baseStatus = KO)
       .enterGroup("root group", System.currentTimeMillis())
       .enterTryMax("tryMax", nextAction)
@@ -332,7 +270,7 @@ class SessionSpec extends BaseSpec {
   }
 
   "markAsFailed" should "only set the baseStatus to KO if it was not set and there is no TryMaxBlock in the stack" in {
-    val session = EmptySession
+    val session = emptySession
     val failedSession = session.markAsFailed
 
     failedSession should not be theSameInstanceAs(session)
@@ -340,14 +278,14 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "leave the session unmodified if baseStatus is already KO and the stack is empty" in {
-    val session = EmptySession.copy(baseStatus = KO)
+    val session = emptySession.copy(baseStatus = KO)
     val failedSession = session.markAsFailed
 
     failedSession should be theSameInstanceAs session
   }
 
   it should "set the TryMaxBlock's status to KO if there is a TryMaxBlock in the stack, but leave the baseStatus unmodified" in {
-    val session = EmptySession
+    val session = emptySession
       .enterGroup("root group", System.currentTimeMillis())
       .enterTryMax("tryMax", nextAction)
     val failedSession = session.markAsFailed
@@ -357,7 +295,7 @@ class SessionSpec extends BaseSpec {
   }
 
   "enterLoop" should "add an ExitASAPLoopBlock on top of the stack and init a counter when exitASAP = true" in {
-    val session = EmptySession
+    val session = emptySession
       .enterLoop("loop", true.expressionSuccess, nextAction, exitASAP = true)
 
     session.blockStack.head shouldBe a[ExitAsapLoopBlock]
@@ -366,7 +304,7 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "add an ExitOnCompleteLoopBlock on top of the stack and init a counter when exitASAP = false" in {
-    val session = EmptySession
+    val session = emptySession
       .enterLoop("loop", true.expressionSuccess, nextAction, exitASAP = false)
 
     session.blockStack.head shouldBe a[ExitOnCompleteLoopBlock]
@@ -375,7 +313,7 @@ class SessionSpec extends BaseSpec {
   }
 
   "exitLoop" should "remove the LoopBlock from the top of the stack and its associated counter" in {
-    val session = EmptySession
+    val session = emptySession
       .enterLoop("loop", true.expressionSuccess, nextAction, exitASAP = false)
     val sessionOutOfLoop = session.exitLoop
 
@@ -384,13 +322,13 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "leave the stack unmodified if there's no LoopBlock on top of the stack" in {
-    val session = EmptySession
+    val session = emptySession
     val unModifiedSession = session.exitLoop
     session should be theSameInstanceAs unModifiedSession
   }
 
   "enterTimeBasedLoop" should "add a counter, initialized to 0, and a timestamp for the counter creation in the session" in {
-    val session = EmptySession.enterTimeBasedLoop("counter", _ => Success(true), null, exitASAP = false, System.currentTimeMillis())
+    val session = emptySession.enterTimeBasedLoop("counter", _ => Success(true), null, exitASAP = false, System.currentTimeMillis())
 
     session.contains("counter") shouldBe true
     session.attributes("counter") shouldBe 0
@@ -398,20 +336,20 @@ class SessionSpec extends BaseSpec {
   }
 
   "incrementCounter" should "increment a counter in session" in {
-    val session = EmptySession.enterLoop("counter", _ => Success(true), null, exitASAP = false)
+    val session = emptySession.enterLoop("counter", _ => Success(true), null, exitASAP = false)
     val sessionWithUpdatedCounter = session.incrementCounter("counter")
 
     sessionWithUpdatedCounter.attributes("counter") shouldBe 1
   }
 
   it should "should leave the session unmodified if there was no counter created with the specified name" in {
-    val session = EmptySession
+    val session = emptySession
     val unModifiedSession = session.incrementCounter("counter")
     session should be theSameInstanceAs unModifiedSession
   }
 
   "removeCounter" should "remove a counter and its associated timestamp from the session" in {
-    val session = EmptySession.enterTimeBasedLoop("counter", _ => Success(true), null, exitASAP = false, System.currentTimeMillis())
+    val session = emptySession.enterTimeBasedLoop("counter", _ => Success(true), null, exitASAP = false, System.currentTimeMillis())
     val sessionWithRemovedCounter = session.removeCounter("counter")
 
     sessionWithRemovedCounter.contains("counter") shouldBe false
@@ -419,100 +357,100 @@ class SessionSpec extends BaseSpec {
   }
 
   it should "should leave the session unmodified if there was no counter created with the specified name" in {
-    val session = EmptySession
+    val session = emptySession
     val unModifiedSession = session.removeCounter("counter")
     session should be theSameInstanceAs unModifiedSession
   }
 
   "terminate" should "call the userEnd function" in {
     var i = 0
-    val session = EmptySession.copy(onExit = _ => i += 1)
+    val session = emptySession.copy(onExit = _ => i += 1)
     session.exit()
 
     i shouldBe 1
   }
 
   "MarkAsFailedUpdate function" should "mark as failed the session passed as parameter" in {
-    val failedSession = Session.MarkAsFailedUpdate(EmptySession)
+    val failedSession = Session.MarkAsFailedUpdate(emptySession)
     failedSession.isFailed shouldBe true
   }
 
   "Identity function" should "return the same session instance" in {
-    val session = EmptySession
+    val session = emptySession
     val unModifiedSession = Session.Identity(session)
     session should be theSameInstanceAs unModifiedSession
   }
 
   "as[T]" should "return the value when key is defined and value of the expected type" in {
-    val session = EmptySession.set("foo", "bar")
+    val session = emptySession.set("foo", "bar")
     session("foo").as[String] shouldBe "bar"
   }
 
   it should "support parsing a valid String into an Int" in {
-    val session = EmptySession.set("foo", "200")
+    val session = emptySession.set("foo", "200")
     session("foo").as[String] shouldBe "200"
     session("foo").as[Int] shouldBe 200
   }
 
   it should "throw an exception when key isn't defined" in {
-    val session = EmptySession
+    val session = emptySession
     a[java.util.NoSuchElementException] shouldBe thrownBy(session("foo").as[String])
   }
 
   it should "throw a NumberFormatException when the String value can't be parsed" in {
-    val session = EmptySession.set("foo", "bar")
+    val session = emptySession.set("foo", "bar")
     a[NumberFormatException] shouldBe thrownBy(session("foo").as[Int])
   }
 
   it should "throw a ClassCastException when the value can't be turned into the expected type" in {
-    val session = EmptySession.set("foo", true)
+    val session = emptySession.set("foo", true)
     a[ClassCastException] shouldBe thrownBy(session("foo").as[Int])
   }
 
   "asOption[T]" should "return a Some(value) when key is defined and value of the expected type" in {
-    val session = EmptySession.set("foo", "bar")
+    val session = emptySession.set("foo", "bar")
     session("foo").asOption[String] shouldBe Some("bar")
   }
 
   it should "support parsing a valid String into an Int" in {
-    val session = EmptySession.set("foo", "200")
+    val session = emptySession.set("foo", "200")
     session("foo").asOption[String] shouldBe Some("200")
     session("foo").asOption[Int] shouldBe Some(200)
   }
 
   it should "return None when key isn't defined" in {
-    val session = EmptySession
+    val session = emptySession
     session("foo").asOption[String] shouldBe None
   }
 
   it should "throw a NumberFormatException when the String value can't be parsed" in {
-    val session = EmptySession.set("foo", "bar")
+    val session = emptySession.set("foo", "bar")
     a[NumberFormatException] shouldBe thrownBy(session("foo").asOption[Int])
   }
 
   it should "throw a ClassCastException when the value isn't of the expected type" in {
-    val session = EmptySession.set("foo", true)
+    val session = emptySession.set("foo", true)
     a[ClassCastException] shouldBe thrownBy(session("foo").asOption[Int])
   }
 
   "validate[T]" should "return a Validation(value) when key is defined and value of the expected type" in {
-    val session = EmptySession.set("foo", "bar")
+    val session = emptySession.set("foo", "bar")
     session("foo").validate[String] shouldBe Success("bar")
   }
 
   it should "support parsing a valid String into an Int" in {
-    val session = EmptySession.set("foo", "200")
+    val session = emptySession.set("foo", "200")
     session("foo").validate[String] shouldBe Success("200")
     session("foo").validate[Int] shouldBe Success(200)
   }
 
   it should "return a Failure when key isn't defined" in {
-    val session = EmptySession
+    val session = emptySession
     session("foo").validate[String] shouldBe a[Failure]
   }
 
   it should "return a Failure when the value isn't of the expected type" in {
-    val session = EmptySession.set("foo", "bar")
+    val session = emptySession.set("foo", "bar")
     session("foo").validate[Int] shouldBe a[Failure]
   }
 }

--- a/gatling-core/src/test/scala/io/gatling/core/session/el/ElSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/session/el/ElSpec.scala
@@ -19,16 +19,16 @@ package io.gatling.core.session.el
 import java.{ util => ju }
 
 import io.gatling.{ BaseSpec, ValidationValues }
+import io.gatling.core.EmptySession
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.session.el
 
-class ElSpec extends BaseSpec with ValidationValues {
+class ElSpec extends BaseSpec with ValidationValues with EmptySession {
 
   private implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   private def newSession(attributes: Map[String, Any]) =
-    EmptySession.copy(attributes = attributes)
+    emptySession.copy(attributes = attributes)
 
   "Static String" should "return itself" in {
     val session = newSession(Map.empty)

--- a/gatling-core/src/test/scala/io/gatling/core/structure/ChainBuilderSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/structure/ChainBuilderSpec.scala
@@ -20,12 +20,12 @@ import io.gatling.BaseSpec
 import io.gatling.commons.stats._
 import io.gatling.commons.validation._
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.test._
 
-class ChainBuilderSpec extends BaseSpec with CoreDsl with ScenarioTestFixture {
+class ChainBuilderSpec extends BaseSpec with CoreDsl with ScenarioTestFixture with EmptySession {
 
   implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
@@ -51,7 +51,7 @@ class ChainBuilderSpec extends BaseSpec with CoreDsl with ScenarioTestFixture {
         }
       }
 
-      chain ! EmptySession
+      chain ! emptySession
 
       expectMsg(message1)
       expectMsg(message2)
@@ -71,7 +71,7 @@ class ChainBuilderSpec extends BaseSpec with CoreDsl with ScenarioTestFixture {
         }
       }
 
-      chain ! EmptySession
+      chain ! emptySession
 
       expectMsgPF { case session: Session =>
         session.status shouldBe KO
@@ -121,7 +121,7 @@ class ChainBuilderSpec extends BaseSpec with CoreDsl with ScenarioTestFixture {
         }
       }
 
-      chain ! EmptySession
+      chain ! emptySession
       expectMsg(message(1, 0, 0))
       expectMsgPF { case LogGroupEnd(_, group, _) =>
         group.groups shouldBe List(outerGroup, innerGroup)

--- a/gatling-core/src/test/scala/io/gatling/core/util/cache/SessionCacheHandlerSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/util/cache/SessionCacheHandlerSpec.scala
@@ -17,38 +17,38 @@
 package io.gatling.core.util.cache
 
 import io.gatling.BaseSpec
-import io.gatling.core.session.SessionSpec.EmptySession
+import io.gatling.core.EmptySession
 
 import org.scalatest.OptionValues
 
-class SessionCacheHandlerSpec extends BaseSpec with OptionValues {
+class SessionCacheHandlerSpec extends BaseSpec with OptionValues with EmptySession {
 
   private val sessionCacheHandler = new SessionCacheHandler[String, String]("stringCache", 1)
 
   "getCache" should "return None if the cache does not exist" in {
-    sessionCacheHandler.getCache(EmptySession) shouldBe empty
+    sessionCacheHandler.getCache(emptySession) shouldBe empty
   }
 
   it should "return the cache if it exists" in {
     val newCache = Cache.newImmutableCache[String, String](2)
-    val sessionWithCache = EmptySession.set("stringCache", newCache)
+    val sessionWithCache = emptySession.set("stringCache", newCache)
     sessionCacheHandler.getCache(sessionWithCache) should not be empty
     sessionCacheHandler.getCache(sessionWithCache).value should be theSameInstanceAs newCache
   }
 
   "getOrCreateCache" should "return the cache if it exists" in {
     val newCache = Cache.newImmutableCache[String, String](2)
-    val sessionWithCache = EmptySession.set("stringCache", newCache)
+    val sessionWithCache = emptySession.set("stringCache", newCache)
     sessionCacheHandler.getOrCreateCache(sessionWithCache) should be theSameInstanceAs newCache
   }
 
   it should "create a new cache if it didn't exists" in {
-    EmptySession.contains("stringCache") shouldBe false
-    sessionCacheHandler.getOrCreateCache(EmptySession) shouldBe a[Cache[_, _]] // TODO : Can this test be improved ?
+    emptySession.contains("stringCache") shouldBe false
+    sessionCacheHandler.getOrCreateCache(emptySession) shouldBe a[Cache[_, _]] // TODO : Can this test be improved ?
   }
 
   "addEntry" should "add a new entry to the cache" in {
-    val sessionWithNewEntry = sessionCacheHandler.addEntry(EmptySession, "foo", "bar")
+    val sessionWithNewEntry = sessionCacheHandler.addEntry(emptySession, "foo", "bar")
     val entry = sessionCacheHandler.getOrCreateCache(sessionWithNewEntry).get("foo")
 
     entry should not be empty
@@ -56,16 +56,16 @@ class SessionCacheHandlerSpec extends BaseSpec with OptionValues {
   }
 
   "getEntry" should "return None if the cache does not exists" in {
-    sessionCacheHandler.getEntry(EmptySession, "foo") shouldBe empty
+    sessionCacheHandler.getEntry(emptySession, "foo") shouldBe empty
   }
 
   it should "return None if the entry does not exists" in {
-    val sessionWithCache = sessionCacheHandler.addEntry(EmptySession, "foo", "bar")
+    val sessionWithCache = sessionCacheHandler.addEntry(emptySession, "foo", "bar")
     sessionCacheHandler.getEntry(sessionWithCache, "quz") shouldBe empty
   }
 
   it should "return the value if the cache and entry exists" in {
-    val sessionWithCache = sessionCacheHandler.addEntry(EmptySession, "foo", "bar")
+    val sessionWithCache = sessionCacheHandler.addEntry(emptySession, "foo", "bar")
     val entry = sessionCacheHandler.getEntry(sessionWithCache, "foo")
 
     entry should not be empty
@@ -73,11 +73,11 @@ class SessionCacheHandlerSpec extends BaseSpec with OptionValues {
   }
 
   "removeEntry" should "left the session untouched if the cache doesn't exist" in {
-    sessionCacheHandler.removeEntry(EmptySession, "foo") should be theSameInstanceAs EmptySession
+    sessionCacheHandler.removeEntry(emptySession, "foo") should be theSameInstanceAs emptySession
   }
 
   it should "remove the key from the cache if it exists" in {
-    val sessionWithEntry = sessionCacheHandler.addEntry(EmptySession, "foo", "bar")
+    val sessionWithEntry = sessionCacheHandler.addEntry(emptySession, "foo", "bar")
     val sessionWithoutEntry = sessionCacheHandler.removeEntry(sessionWithEntry, "foo")
 
     sessionCacheHandler.getEntry(sessionWithoutEntry, "foo") shouldBe empty

--- a/gatling-http/src/test/scala/io/gatling/http/HttpSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/HttpSpec.scala
@@ -33,7 +33,6 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.pause.Constant
 import io.gatling.core.protocol.{ Protocol, ProtocolComponentsRegistries }
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.structure.{ ScenarioBuilder, ScenarioContext }
 import io.gatling.http.protocol.HttpProtocolBuilder
@@ -75,7 +74,7 @@ abstract class HttpSpec extends AkkaSpec with BeforeAndAfter {
     val protocolComponentsRegistry = new ProtocolComponentsRegistries(coreComponents, protocols).scenarioRegistry(Map.empty)
     val next = new ActorDelegatingAction("next", self)
     val action = sb.build(new ScenarioContext(coreComponents, protocolComponentsRegistry, Constant, throttled = false), next)
-    action ! EmptySession
+    action ! emptySession
     expectMsgClass(timeout, classOf[Session])
   }
 

--- a/gatling-http/src/test/scala/io/gatling/http/cache/CacheSupportSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/cache/CacheSupportSpec.scala
@@ -19,9 +19,9 @@ package io.gatling.http.cache
 import io.gatling.BaseSpec
 import io.gatling.commons.util.DefaultClock
 import io.gatling.core.CoreComponents
+import io.gatling.core.EmptySession
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.client.{ Request, RequestBuilder }
 import io.gatling.http.client.uri.Uri
 import io.gatling.http.engine.HttpEngine
@@ -33,7 +33,7 @@ import io.netty.handler.codec.http.{ DefaultHttpHeaders, HttpHeaderNames, HttpHe
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 
-class CacheSupportSpec extends BaseSpec {
+class CacheSupportSpec extends BaseSpec with EmptySession {
 
   private val configuration = GatlingConfiguration.loadForTest()
   private val coreComponents = new CoreComponents(null, null, null, null, null, new DefaultClock, null, configuration)
@@ -102,7 +102,7 @@ class CacheSupportSpec extends BaseSpec {
   }
 
   class RedirectContext {
-    var session: Session = EmptySession
+    var session: Session = emptySession
 
     def addRedirect(from: String, to: String): Unit = {
       val request = new RequestBuilder(HttpMethod.GET, Uri.create(from), null)

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/ConditionalCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/ConditionalCheckSpec.scala
@@ -19,15 +19,15 @@ package io.gatling.http.check.body
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.commons.validation.Success
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckResult }
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.response.Response
 
-class ConditionalCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class ConditionalCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
@@ -35,7 +35,7 @@ class ConditionalCheckSpec extends BaseSpec with ValidationValues with CoreDsl w
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
     val thenCheck: HttpCheck = substring(""""id":"""").count
     val check: HttpCheck = checkIf((_: Response, _: Session) => Success(true))(thenCheck)
-    check.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
+    check.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
   }
 
   "checkIf.true.failed" should "perform the failed nested check" in {
@@ -43,14 +43,14 @@ class ConditionalCheckSpec extends BaseSpec with ValidationValues with CoreDsl w
     val substringValue = """"foo":""""
     val thenCheck: HttpCheck = substring(substringValue).findAll.exists
     val check: HttpCheck = checkIf((_: Response, _: Session) => Success(true))(thenCheck)
-    check.check(response, EmptySession, Check.newPreparedCache).failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
+    check.check(response, emptySession, Check.newPreparedCache).failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
   }
 
   "checkIf.false.succeed" should "not perform the succeed nested check" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
     val thenCheck: HttpCheck = substring(""""id":"""").count
     val check: HttpCheck = checkIf((_: Response, _: Session) => Success(false))(thenCheck)
-    check.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(None, None)
+    check.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(None, None)
   }
 
   "checkIf.false.failed" should "not perform the failed nested check" in {
@@ -58,7 +58,7 @@ class ConditionalCheckSpec extends BaseSpec with ValidationValues with CoreDsl w
     val substringValue = """"foo":""""
     val thenCheck: HttpCheck = substring(substringValue).findAll.exists
     val check: HttpCheck = checkIf((_: Response, _: Session) => Success(false))(thenCheck)
-    check.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(None, None)
+    check.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(None, None)
   }
 
 }

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyBytesCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyBytesCheckSpec.scala
@@ -20,15 +20,15 @@ import java.nio.charset.StandardCharsets._
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckMaterializer, CheckResult }
 import io.gatling.core.check.bytes.BodyBytesCheckType
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.response.Response
 
-class HttpBodyBytesCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class HttpBodyBytesCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
   private implicit val materializer: CheckMaterializer[BodyBytesCheckType, HttpCheck, Response, Array[Byte]] = HttpBodyBytesCheckMaterializer.Instance
@@ -37,13 +37,13 @@ class HttpBodyBytesCheckSpec extends BaseSpec with ValidationValues with CoreDsl
     val string = "Hello World"
     val responseBytes = string.getBytes(UTF_8)
     val response = mockResponse(responseBytes)
-    bodyBytes.find.is(string.getBytes(UTF_8)).check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(responseBytes), None)
+    bodyBytes.find.is(string.getBytes(UTF_8)).check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(responseBytes), None)
   }
 
   it should "fail when byte arrays are different" in {
     val string = "Hello World"
     val responseBytes = string.getBytes(UTF_8)
     val response = mockResponse(responseBytes)
-    bodyBytes.find.is("HELLO WORLD".getBytes(UTF_8)).check(response, EmptySession, Check.newPreparedCache).failed shouldBe a[String]
+    bodyBytes.find.is("HELLO WORLD".getBytes(UTF_8)).check(response, emptySession, Check.newPreparedCache).failed shouldBe a[String]
   }
 }

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyJmesPathCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyJmesPathCheckSpec.scala
@@ -19,18 +19,18 @@ package io.gatling.http.check.body
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.commons.validation.Failure
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckMaterializer, CheckResult }
 import io.gatling.core.check.jmespath.JmesPathCheckType
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.json.JsonParsers
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.response.Response
 
 import com.fasterxml.jackson.databind.JsonNode
 
-class HttpBodyJmesPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class HttpBodyJmesPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
   private implicit val materializer: CheckMaterializer[JmesPathCheckType, HttpCheck, Response, JsonNode] =
@@ -46,12 +46,12 @@ class HttpBodyJmesPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   "jmesPath.find" should "support long values" in {
     val response = mockResponse(s"""{"value": ${Long.MaxValue}}""")
-    jmesPath("value").ofType[Long].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(Long.MaxValue), None)
+    jmesPath("value").ofType[Long].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(Long.MaxValue), None)
   }
 
   "jmesPath.find.exists" should "find single result into JSON serialized form" in {
     val response = mockResponse(storeJson)
-    jmesPath("street").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jmesPath("street").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some("""{"book":"On the street"}"""),
       None
     )
@@ -59,17 +59,17 @@ class HttpBodyJmesPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "fail when the path doesn't match" in {
     val response = mockResponse(storeJson)
-    jmesPath("foo").find.exists.check(response, EmptySession, Check.newPreparedCache) shouldBe a[Failure]
+    jmesPath("foo").find.exists.check(response, emptySession, Check.newPreparedCache) shouldBe a[Failure]
   }
 
   it should "fail when the attribute value is null" in {
     val response = mockResponse("""{"foo": null}""")
-    jmesPath("foo").ofType[String].find.exists.check(response, EmptySession, Check.newPreparedCache) shouldBe a[Failure]
+    jmesPath("foo").ofType[String].find.exists.check(response, emptySession, Check.newPreparedCache) shouldBe a[Failure]
   }
 
   it should "find single result into Map object form" in {
     val response = mockResponse(storeJson)
-    jmesPath("street").ofType[Map[String, Any]].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jmesPath("street").ofType[Map[String, Any]].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Map("book" -> "On the street")),
       None
     )
@@ -77,18 +77,18 @@ class HttpBodyJmesPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "succeed when expecting a non-null value and getting a non-null one" in {
     val response = mockResponse("""{"foo": "bar"}""")
-    jmesPath("foo").ofType[Any].find.notNull.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("bar"), None)
+    jmesPath("foo").ofType[Any].find.notNull.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("bar"), None)
   }
 
   it should "fail when expecting a non-null value and getting a null one" in {
     val response = mockResponse("""{"foo": null}""")
     jmesPath("foo").find
-      .check(response, EmptySession, Check.newPreparedCache) shouldBe a[Failure]
+      .check(response, emptySession, Check.newPreparedCache) shouldBe a[Failure]
   }
 
   it should "not fail on empty array" in {
     val response = mockResponse("""{"documents":[]}""")
-    jmesPath("documents").ofType[Seq[_]].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jmesPath("documents").ofType[Seq[_]].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Vector.empty),
       None
     )

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyJsonPathCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyJsonPathCheckSpec.scala
@@ -18,11 +18,11 @@ package io.gatling.http.check.body
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckMaterializer, CheckResult }
 import io.gatling.core.check.jsonpath.JsonPathCheckType
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.json.JsonParsers
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.response.Response
@@ -30,7 +30,7 @@ import io.gatling.http.response.Response
 import com.fasterxml.jackson.databind.JsonNode
 import org.scalatest.matchers.{ MatchResult, Matcher }
 
-class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
   private implicit val materializer: CheckMaterializer[JsonPathCheckType, HttpCheck, Response, JsonNode] =
@@ -46,12 +46,12 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   "jsonPath.find" should "support long values" in {
     val response = mockResponse(s"""{"value": ${Long.MaxValue}}""")
-    jsonPath("$.value").ofType[Long].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(Long.MaxValue), None)
+    jsonPath("$.value").ofType[Long].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(Long.MaxValue), None)
   }
 
   "jsonPath.find.exists" should "find single result into JSON serialized form" in {
     val response = mockResponse(storeJson)
-    jsonPath("$.street").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$.street").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some("""{"book":"On the street"}"""),
       None
     )
@@ -59,7 +59,7 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "find single result into Map object form" in {
     val response = mockResponse(storeJson)
-    jsonPath("$.street").ofType[Map[String, Any]].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$.street").ofType[Map[String, Any]].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Map("book" -> "On the street")),
       None
     )
@@ -67,17 +67,17 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "find a null attribute value when expected type is String" in {
     val response = mockResponse("""{"foo": null}""")
-    jsonPath("$.foo").ofType[String].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
+    jsonPath("$.foo").ofType[String].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
   }
 
   it should "find a null attribute value when expected type is Any" in {
     val response = mockResponse("""{"foo": null}""")
-    jsonPath("$.foo").ofType[Any].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
+    jsonPath("$.foo").ofType[Any].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
   }
 
   it should "find a null attribute value when expected type is Int" in {
     val response = mockResponse("""{"foo": null}""")
-    jsonPath("$.foo").ofType[Int].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$.foo").ofType[Int].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(null.asInstanceOf[Int]),
       None
     )
@@ -85,12 +85,12 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "find a null attribute value when expected type is Seq" in {
     val response = mockResponse("""{"foo": null}""")
-    jsonPath("$.foo").ofType[Seq[Any]].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
+    jsonPath("$.foo").ofType[Seq[Any]].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
   }
 
   it should "find a null attribute value when expected type is Map" in {
     val response = mockResponse("""{"foo": null}""")
-    jsonPath("$.foo").ofType[Map[String, Any]].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$.foo").ofType[Map[String, Any]].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(null),
       None
     )
@@ -98,7 +98,7 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "succeed when expecting a null value and getting a null one" in {
     val response = mockResponse("""{"foo": null}""")
-    jsonPath("$.foo").ofType[Any].find.isNull.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
+    jsonPath("$.foo").ofType[Any].find.isNull.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(null), None)
   }
 
   it should "fail when expecting a null value and getting a non-null one" in {
@@ -107,13 +107,13 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
       .ofType[Any]
       .find
       .isNull
-      .check(response, EmptySession, Check.newPreparedCache)
+      .check(response, emptySession, Check.newPreparedCache)
       .failed shouldBe "jsonPath($.foo).find.isNull, but actually found bar"
   }
 
   it should "succeed when expecting a non-null value and getting a non-null one" in {
     val response = mockResponse("""{"foo": "bar"}""")
-    jsonPath("$.foo").ofType[Any].find.notNull.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("bar"), None)
+    jsonPath("$.foo").ofType[Any].find.notNull.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("bar"), None)
   }
 
   it should "fail when expecting a non-null value and getting a null one" in {
@@ -122,13 +122,13 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
       .ofType[Any]
       .find
       .notNull
-      .check(response, EmptySession, Check.newPreparedCache)
+      .check(response, emptySession, Check.newPreparedCache)
       .failed shouldBe "jsonPath($.foo).find.notNull, but actually found null"
   }
 
   it should "not fail on empty array" in {
     val response = mockResponse("""{"documents":[]}""")
-    jsonPath("$.documents").ofType[Seq[_]].find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$.documents").ofType[Seq[_]].find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Vector.empty),
       None
     )
@@ -136,7 +136,7 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   "jsonPath.findAll.exists" should "fetch all matches" in {
     val response = mockResponse(storeJson)
-    jsonPath("$..book").findAll.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$..book").findAll.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Seq("In store", "On the street")),
       None
     )
@@ -144,7 +144,7 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "find all by wildcard" in {
     val response = mockResponse(storeJson)
-    jsonPath("$.*.book").findAll.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$.*.book").findAll.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Vector("In store", "On the street")),
       None
     )
@@ -160,7 +160,7 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   "jsonPath.findRandom.exists" should "fetch a single random match" in {
     val response = mockResponse(storeJson)
-    jsonPath("$..book").findRandom.exists.check(response, EmptySession, Check.newPreparedCache).succeeded.extractedValue.get.asInstanceOf[String] should beIn(
+    jsonPath("$..book").findRandom.exists.check(response, emptySession, Check.newPreparedCache).succeeded.extractedValue.get.asInstanceOf[String] should beIn(
       Seq("In store", "On the street")
     )
   }
@@ -170,7 +170,7 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
     jsonPath("$..book")
       .findRandom(1)
       .exists
-      .check(response, EmptySession, Check.newPreparedCache)
+      .check(response, emptySession, Check.newPreparedCache)
       .succeeded
       .extractedValue
       .get
@@ -179,7 +179,7 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "fetch all the matches when expected number is greater" in {
     val response = mockResponse(storeJson)
-    jsonPath("$..book").findRandom(3).exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonPath("$..book").findRandom(3).exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Seq("In store", "On the street")),
       None
     )
@@ -187,6 +187,6 @@ class HttpBodyJsonPathCheckSpec extends BaseSpec with ValidationValues with Core
 
   it should "fail when failIfLess is enabled and expected number is greater" in {
     val response = mockResponse(storeJson)
-    jsonPath("$..book").findRandom(3, failIfLess = true).exists.check(response, EmptySession, Check.newPreparedCache).failed
+    jsonPath("$..book").findRandom(3, failIfLess = true).exists.check(response, emptySession, Check.newPreparedCache).failed
   }
 }

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyJsonpJsonPathCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyJsonpJsonPathCheckSpec.scala
@@ -18,18 +18,18 @@ package io.gatling.http.check.body
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckMaterializer, CheckResult }
 import io.gatling.core.check.jsonpath.JsonPathCheckType
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.json.JsonParsers
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.response.Response
 
 import com.fasterxml.jackson.databind.JsonNode
 
-class HttpBodyJsonpJsonPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class HttpBodyJsonpJsonPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
   implicit val materializer: CheckMaterializer[JsonPathCheckType, HttpCheck, Response, JsonNode] =
@@ -45,7 +45,7 @@ class HttpBodyJsonpJsonPathCheckSpec extends BaseSpec with ValidationValues with
 
   "jsonpJsonPath.find.exists" should "find single result into JSON serialized form" in {
     val response = mockResponse(storeJson)
-    jsonpJsonPath("$.street").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    jsonpJsonPath("$.street").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some("""{"book":"On the street"}"""),
       None
     )

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyRegexCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyRegexCheckSpec.scala
@@ -18,15 +18,15 @@ package io.gatling.http.check.body
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckMaterializer, CheckResult }
 import io.gatling.core.check.regex.RegexCheckType
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.{ HttpCheck, HttpCheckSupport }
 import io.gatling.http.response.Response
 
-class HttpBodyRegexCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class HttpBodyRegexCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   object RegexSupport extends HttpCheckSupport
 
@@ -38,17 +38,17 @@ class HttpBodyRegexCheckSpec extends BaseSpec with ValidationValues with CoreDsl
 
   "regex.find.exists" should "find single result" in {
     val response = mockResponse("""{"id":"1072920417"}""")
-    regexCheck(""""id":"(.+?)"""").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
+    regexCheck(""""id":"(.+?)"""").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
   }
 
   it should "find first occurrence" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
-    regexCheck(""""id":"(.+?)"""").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
+    regexCheck(""""id":"(.+?)"""").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
   }
 
   "regex.findAll.exists" should "find all occurrences" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
-    regexCheck(""""id":"(.+?)"""").findAll.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    regexCheck(""""id":"(.+?)"""").findAll.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Seq("1072920417", "1072920418")),
       None
     )
@@ -58,7 +58,7 @@ class HttpBodyRegexCheckSpec extends BaseSpec with ValidationValues with CoreDsl
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
     val regexValue = """"foo":"(.+?)""""
     regexCheck(regexValue).findAll.exists
-      .check(response, EmptySession, Check.newPreparedCache)
+      .check(response, emptySession, Check.newPreparedCache)
       .failed shouldBe s"regex($regexValue).findAll.exists, found nothing"
   }
 
@@ -68,18 +68,18 @@ class HttpBodyRegexCheckSpec extends BaseSpec with ValidationValues with CoreDsl
     regexCheck(regexValue).findAll
       .transform(_.map(_ + "foo"))
       .exists
-      .check(response, EmptySession, Check.newPreparedCache)
+      .check(response, emptySession, Check.newPreparedCache)
       .failed shouldBe s"regex($regexValue).findAll.transform.exists, found nothing"
   }
 
   "regex.count.exists" should "find all occurrences" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
-    regexCheck(""""id":"(.+?)"""").count.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
+    regexCheck(""""id":"(.+?)"""").count.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
   }
 
   it should "return 0 when finding nothing instead of failing" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
     val regexValue = """"foo":"(.+?)""""
-    regexCheck(regexValue).count.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(0), None)
+    regexCheck(regexValue).count.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(0), None)
   }
 }

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodySubstringCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodySubstringCheckSpec.scala
@@ -18,15 +18,15 @@ package io.gatling.http.check.body
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckMaterializer, CheckResult }
 import io.gatling.core.check.substring.SubstringCheckType
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.response.Response
 
-class HttpBodySubstringCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class HttpBodySubstringCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
   private implicit val materializer: CheckMaterializer[SubstringCheckType, HttpCheck, Response, String] =
@@ -34,34 +34,34 @@ class HttpBodySubstringCheckSpec extends BaseSpec with ValidationValues with Cor
 
   "substring.find.exists" should "find single result" in {
     val response = mockResponse("""{"id":"1072920417"}""")
-    substring(""""id":"""").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(1), None)
+    substring(""""id":"""").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(1), None)
   }
 
   it should "find first occurrence" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
-    substring(""""id":"""").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
+    substring(""""id":"""").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
   }
 
   "substring.findAll.exists" should "find all occurrences" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
-    substring(""""id":"""").findAll.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(Seq(2, 21)), None)
+    substring(""""id":"""").findAll.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(Seq(2, 21)), None)
   }
 
   it should "fail when finding nothing instead of returning an empty Seq" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
     val substringValue = """"foo":""""
     substring(substringValue).findAll.exists
-      .check(response, EmptySession, Check.newPreparedCache)
+      .check(response, emptySession, Check.newPreparedCache)
       .failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
   }
 
   "substring.count.exists" should "find all occurrences" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
-    substring(""""id":"""").count.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
+    substring(""""id":"""").count.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
   }
 
   it should "return 0 when finding nothing instead of failing" in {
     val response = mockResponse("""[{"id":"1072920417"},"id":"1072920418"]""")
-    substring(""""foo":"""").count.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(0), None)
+    substring(""""foo":"""").count.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(0), None)
   }
 }

--- a/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyXPathCheckSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/check/body/HttpBodyXPathCheckSpec.scala
@@ -18,17 +18,17 @@ package io.gatling.http.check.body
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.{ Check, CheckMaterializer, CheckResult }
 import io.gatling.core.check.xpath.XPathCheckType
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.http.HttpDsl
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.response.Response
 
 import net.sf.saxon.s9api.XdmNode
 
-class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl {
+class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl with HttpDsl with EmptySession {
 
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
   private implicit val materializer: CheckMaterializer[XPathCheckType, HttpCheck, Response, Option[XdmNode]] =
@@ -38,7 +38,7 @@ class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl
 
     val response = mockResponse(<id>1072920417</id>)
 
-    xpath("/id").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
+    xpath("/id").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
   }
 
   it should "find first occurrence" in {
@@ -48,7 +48,7 @@ class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl
                                   <id>1072920418</id>
                                 </root>)
 
-    xpath("//id").find.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
+    xpath("//id").find.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some("1072920417"), None)
   }
 
   "xpath.findAll.exists" should "find all occurrences" in {
@@ -58,7 +58,7 @@ class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl
                                   <id>1072920418</id>
                                 </root>)
 
-    xpath("//id").findAll.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
+    xpath("//id").findAll.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(
       Some(Seq("1072920417", "1072920418")),
       None
     )
@@ -71,7 +71,7 @@ class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl
                                   <id>1072920418</id>
                                 </root>)
 
-    xpath("//foo").findAll.exists.check(response, EmptySession, Check.newPreparedCache).failed shouldBe "xpath((//foo,Map())).findAll.exists, found nothing"
+    xpath("//foo").findAll.exists.check(response, emptySession, Check.newPreparedCache).failed shouldBe "xpath((//foo,Map())).findAll.exists, found nothing"
   }
 
   "xpath.count.exists" should "find all occurrences" in {
@@ -81,7 +81,7 @@ class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl
                                   <id>1072920418</id>
                                 </root>)
 
-    xpath("//id").count.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
+    xpath("//id").count.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(2), None)
   }
 
   it should "return 0 when finding nothing instead of failing" in {
@@ -91,6 +91,6 @@ class HttpBodyXPathCheckSpec extends BaseSpec with ValidationValues with CoreDsl
                                   <id>1072920418</id>
                                 </root>)
 
-    xpath("//foo").count.exists.check(response, EmptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(0), None)
+    xpath("//foo").count.exists.check(response, emptySession, Check.newPreparedCache).succeeded shouldBe CheckResult(Some(0), None)
   }
 }

--- a/gatling-http/src/test/scala/io/gatling/http/cookie/CookieHandlingSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/cookie/CookieHandlingSpec.scala
@@ -17,12 +17,12 @@
 package io.gatling.http.cookie
 
 import io.gatling.BaseSpec
-import io.gatling.core.session.SessionSpec.EmptySession
+import io.gatling.core.EmptySession
 import io.gatling.http.client.uri.Uri
 
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder.LAX.decode
 
-class CookieHandlingSpec extends BaseSpec {
+class CookieHandlingSpec extends BaseSpec with EmptySession {
 
   private val uri = Uri.create("https://docs.foo.com/accounts")
 
@@ -31,19 +31,19 @@ class CookieHandlingSpec extends BaseSpec {
     val originalDomain = "docs.foo.com"
     val originalCookieJar = new CookieJar(Map(CookieKey("ALPHA", originalDomain, "/") -> StoredCookie(originalCookie, hostOnly = true, persistent = true, 0L)))
     val originalSession =
-      EmptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
+      emptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
     CookieSupport.getStoredCookies(originalSession, uri).map(x => x.value) shouldBe List("VALUE1")
   }
 
   it should "be called with an empty session" in {
-    CookieSupport.getStoredCookies(EmptySession, uri) shouldBe empty
+    CookieSupport.getStoredCookies(emptySession, uri) shouldBe empty
   }
 
   "storeCookies" should "be able to store a cookie in an empty session" in {
     val newCookie = decode("ALPHA=VALUE1; Domain=docs.foo.com; Path=/accounts; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; HttpOnly")
-    CookieSupport.storeCookies(EmptySession, uri, List(newCookie), System.currentTimeMillis())
+    CookieSupport.storeCookies(emptySession, uri, List(newCookie), System.currentTimeMillis())
 
-    CookieSupport.getStoredCookies(EmptySession, uri) shouldBe empty
+    CookieSupport.getStoredCookies(emptySession, uri) shouldBe empty
   }
 
   "getSecureStoredCookies" should "be able to get a secure cookie from session" in {
@@ -51,7 +51,7 @@ class CookieHandlingSpec extends BaseSpec {
     val originalDomain = "docs.foo.com"
     val originalCookieJar = new CookieJar(Map(CookieKey("ALPHA", originalDomain, "/") -> StoredCookie(originalCookie, hostOnly = true, persistent = true, 0L)))
     val originalSession =
-      EmptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
+      emptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
     CookieSupport.getStoredCookies(originalSession, uri).map(x => x.value) shouldBe List("VALUE1")
     CookieSupport.getStoredCookies(originalSession, uri).map(x => x.isSecure) shouldBe List(true)
   }
@@ -61,7 +61,7 @@ class CookieHandlingSpec extends BaseSpec {
     val originalDomain = "docs.foo.com"
     val originalCookieJar = new CookieJar(Map(CookieKey("ALPHA", originalDomain, "/") -> StoredCookie(originalCookie, hostOnly = true, persistent = true, 0L)))
     val originalSession =
-      EmptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
+      emptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
     CookieSupport.getStoredCookies(originalSession, uri).map(x => x.value) shouldBe List("VALUE6")
     CookieSupport.getStoredCookies(originalSession, uri).map(x => x.isSecure) shouldBe List(false)
   }
@@ -71,7 +71,7 @@ class CookieHandlingSpec extends BaseSpec {
     val originalDomain = "docs.foo.com"
     val originalCookieJar = new CookieJar(Map(CookieKey("ALPHA", originalDomain, "/") -> StoredCookie(originalCookie, hostOnly = true, persistent = true, 0L)))
     val originalSession =
-      EmptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
+      emptySession.copy(attributes = Map(CookieSupport.CookieJarAttributeName -> originalCookieJar))
     CookieSupport.getStoredCookies(originalSession, uri.withNewScheme("http")).size shouldBe 0
   }
 }

--- a/gatling-http/src/test/scala/io/gatling/http/request/builder/HttpRequestBuilderSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/request/builder/HttpRequestBuilderSpec.scala
@@ -21,10 +21,10 @@ import scala.jdk.CollectionConverters._
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.commons.util.DefaultClock
 import io.gatling.core.CoreComponents
+import io.gatling.core.EmptySession
 import io.gatling.core.Predef._
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session._
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.session.el._
 import io.gatling.http.Predef._
 import io.gatling.http.cache.DnsCacheSupport
@@ -39,14 +39,14 @@ import io.gatling.http.protocol.HttpProtocol
 
 import io.netty.handler.codec.http.HttpMethod
 
-class HttpRequestBuilderSpec extends BaseSpec with ValidationValues {
+class HttpRequestBuilderSpec extends BaseSpec with ValidationValues with EmptySession {
 
   // Default config
   private val configuration = GatlingConfiguration.loadForTest()
   private val clock = new DefaultClock
   private val coreComponents = new CoreComponents(null, null, null, null, null, clock, null, configuration)
   private val httpCaches = new HttpCaches(coreComponents)
-  private val sessionBase = EmptySession.set(DnsCacheSupport.DnsNameResolverAttributeName, InetAddressNameResolver.JAVA_RESOLVER)
+  private val sessionBase = emptySession.set(DnsCacheSupport.DnsNameResolverAttributeName, InetAddressNameResolver.JAVA_RESOLVER)
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   private def httpRequestDef(f: HttpRequestBuilder => HttpRequestBuilder, httpProtocol: HttpProtocol = HttpProtocol(configuration)) = {

--- a/gatling-jms/src/test/scala/io/gatling/jms/action/TrackerSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/action/TrackerSpec.scala
@@ -23,7 +23,6 @@ import io.gatling.core.CoreDsl
 import io.gatling.core.action.ActorDelegatingAction
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.writer.ResponseMessage
 import io.gatling.jms._
 import io.gatling.jms.check.JmsSimpleCheck
@@ -41,13 +40,13 @@ class TrackerSpec extends AkkaSpec with CoreDsl with JmsDsl with MockMessage {
     val statsEngine = new MockStatsEngine
     val tracker = TestActorRef(Tracker.props(statsEngine, clock, configuration))
 
-    tracker ! MessageSent("1", 15, 0, Nil, EmptySession, new ActorDelegatingAction("next", testActor), "success")
+    tracker ! MessageSent("1", 15, 0, Nil, emptySession, new ActorDelegatingAction("next", testActor), "success")
     tracker ! MessageReceived("1", 30, textMessage("test"))
 
     val nextSession = expectMsgType[Session]
 
-    nextSession shouldBe EmptySession
-    val expected = ResponseMessage(EmptySession.scenario, Nil, "success", 15, 30, OK, None, None)
+    nextSession shouldBe emptySession
+    val expected = ResponseMessage(emptySession.scenario, Nil, "success", 15, 30, OK, None, None)
     statsEngine.dataWriterMsg should contain(expected)
   }
 
@@ -56,13 +55,13 @@ class TrackerSpec extends AkkaSpec with CoreDsl with JmsDsl with MockMessage {
     val statsEngine = new MockStatsEngine
     val tracker = TestActorRef(Tracker.props(statsEngine, clock, configuration))
 
-    tracker ! MessageSent("1", 15, 0, List(failedCheck), EmptySession, new ActorDelegatingAction("next", testActor), "failure")
+    tracker ! MessageSent("1", 15, 0, List(failedCheck), emptySession, new ActorDelegatingAction("next", testActor), "failure")
     tracker ! MessageReceived("1", 30, textMessage("test"))
 
     val nextSession = expectMsgType[Session]
 
-    nextSession shouldBe EmptySession.markAsFailed
-    val expected = ResponseMessage(EmptySession.scenario, Nil, "failure", 15, 30, KO, None, Some("JMS check failed"))
+    nextSession shouldBe emptySession.markAsFailed
+    val expected = ResponseMessage(emptySession.scenario, Nil, "failure", 15, 30, KO, None, Some("JMS check failed"))
     statsEngine.dataWriterMsg should contain(expected)
   }
 
@@ -71,13 +70,13 @@ class TrackerSpec extends AkkaSpec with CoreDsl with JmsDsl with MockMessage {
     val statsEngine = new MockStatsEngine
     val tracker = TestActorRef(Tracker.props(statsEngine, clock, configuration))
 
-    tracker ! MessageSent("1", 15, 0, List(check), EmptySession, new ActorDelegatingAction("next", testActor), "updated")
+    tracker ! MessageSent("1", 15, 0, List(check), emptySession, new ActorDelegatingAction("next", testActor), "updated")
     tracker ! MessageReceived("1", 30, textMessage("<id>5</id>"))
 
     val nextSession = expectMsgType[Session]
 
-    nextSession shouldBe EmptySession.set("id", "5")
-    val expected = ResponseMessage(EmptySession.scenario, Nil, "updated", 15, 30, OK, None, None)
+    nextSession shouldBe emptySession.set("id", "5")
+    val expected = ResponseMessage(emptySession.scenario, Nil, "updated", 15, 30, OK, None, None)
     statsEngine.dataWriterMsg should contain(expected)
   }
 
@@ -85,7 +84,7 @@ class TrackerSpec extends AkkaSpec with CoreDsl with JmsDsl with MockMessage {
     val statsEngine = new MockStatsEngine
     val tracker = TestActorRef(Tracker.props(statsEngine, clock, configuration))
 
-    val groupSession = EmptySession.enterGroup("group", clock.nowMillis)
+    val groupSession = emptySession.enterGroup("group", clock.nowMillis)
     tracker ! MessageSent("1", 15, 0, Nil, groupSession, new ActorDelegatingAction("next", testActor), "logGroupResponse")
     tracker ! MessageReceived("1", 30, textMessage("group"))
 

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsConditionalCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsConditionalCheckSpec.scala
@@ -22,15 +22,22 @@ import javax.jms.Message
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.commons.validation.Success
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.CheckResult
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Session
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.jms.{ JmsCheck, MockMessage }
 
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-class JmsConditionalCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+class JmsConditionalCheckSpec
+    extends BaseSpec
+    with ValidationValues
+    with MockMessage
+    with CoreDsl
+    with JmsCheckSupport
+    with TableDrivenPropertyChecks
+    with EmptySession {
   override implicit def configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   private def jmap[K, V] = new JHashMap[K, V]
@@ -45,27 +52,27 @@ class JmsConditionalCheckSpec extends BaseSpec with ValidationValues with MockMe
     s"checkIf.true.succeed for $msgType" should "perform the succeed nested check" in {
       val thenCheck: JmsCheck = substring(""""id":"""").count
       val check: JmsCheck = checkIf((_: Message, _: Session) => Success(true))(thenCheck)
-      check.check(response, EmptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
+      check.check(response, emptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
     }
 
     s"checkIf.true.failed for $msgType" should "perform the failed nested check" in {
       val substringValue = """"foo":""""
       val thenCheck: JmsCheck = substring(substringValue).findAll.exists
       val check: JmsCheck = checkIf((_: Message, _: Session) => Success(true))(thenCheck)
-      check.check(response, EmptySession, jmap[Any, Any]).failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
+      check.check(response, emptySession, jmap[Any, Any]).failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
     }
 
     s"checkIf.false.succeed for $msgType" should "not perform the succeed nested check" in {
       val thenCheck: JmsCheck = substring(""""id":"""").count
       val check: JmsCheck = checkIf((_: Message, _: Session) => Success(false))(thenCheck)
-      check.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(None, None)
+      check.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(None, None)
     }
 
     s"checkIf.false.failed for $msgType" should "not perform the failed nested check" in {
       val substringValue = """"foo":""""
       val thenCheck: JmsCheck = substring(substringValue).findAll.exists
       val check: JmsCheck = checkIf((_: Message, _: Session) => Success(false))(thenCheck)
-      check.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(None, None)
+      check.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(None, None)
     }
   }
 }

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsJsonPathCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsJsonPathCheckSpec.scala
@@ -21,15 +21,22 @@ import javax.jms.Message
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.CheckResult
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.jms.MockMessage
 
 import org.scalatest.matchers.{ MatchResult, Matcher }
 import org.scalatest.prop.{ TableDrivenPropertyChecks, TableFor2 }
 
-class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+class JmsJsonPathCheckSpec
+    extends BaseSpec
+    with ValidationValues
+    with MockMessage
+    with CoreDsl
+    with JmsCheckSupport
+    with TableDrivenPropertyChecks
+    with EmptySession {
   override implicit def configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   private def beIn[T](seq: Seq[T]) =
@@ -62,57 +69,57 @@ class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessa
 
   forAll(jsons) { (response, messageType) =>
     s"jsonPath.find for $messageType" should "support long values" in {
-      jsonPath("$.long_value").ofType[Long].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.long_value").ofType[Long].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(Long.MaxValue),
         None
       )
     }
 
     s"jsonPath.find.exists for $messageType" should "find single result into JSON serialized form" in {
-      jsonPath("$.street").find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.street").find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some("""{"book":"On the street"}"""),
         None
       )
     }
 
     it should "find single result into Map object form" in {
-      jsonPath("$.street").ofType[Map[String, Any]].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.street").ofType[Map[String, Any]].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(Map("book" -> "On the street")),
         None
       )
     }
 
     it should "find a null attribute value when expected type is String" in {
-      jsonPath("$.null_value").ofType[String].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
+      jsonPath("$.null_value").ofType[String].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
     }
 
     it should "find a null attribute value when expected type is Any" in {
-      jsonPath("$.null_value").ofType[Any].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
+      jsonPath("$.null_value").ofType[Any].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
     }
 
     it should "find a null attribute value when expected type is Int" in {
-      jsonPath("$.null_value").ofType[Int].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.null_value").ofType[Int].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(null.asInstanceOf[Int]),
         None
       )
     }
 
     it should "find a null attribute value when expected type is Seq" in {
-      jsonPath("$.null_value").ofType[Seq[Any]].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.null_value").ofType[Seq[Any]].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(null),
         None
       )
     }
 
     it should "find a null attribute value when expected type is Map" in {
-      jsonPath("$.null_value").ofType[Map[String, Any]].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.null_value").ofType[Map[String, Any]].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(null),
         None
       )
     }
 
     it should "succeed when expecting a null value and getting a null one" in {
-      jsonPath("$.null_value").ofType[Any].find.isNull.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
+      jsonPath("$.null_value").ofType[Any].find.isNull.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(Some(null), None)
     }
 
     it should "fail when expecting a null value and getting a non-null one" in {
@@ -120,12 +127,12 @@ class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessa
         .ofType[Any]
         .find
         .isNull
-        .check(response, EmptySession, new JHashMap[Any, Any])
+        .check(response, emptySession, new JHashMap[Any, Any])
         .failed shouldBe "jsonPath($.not_null_value).find.isNull, but actually found bar"
     }
 
     it should "succeed when expecting a non-null value and getting a non-null one" in {
-      jsonPath("$.not_null_value").ofType[Any].find.notNull.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.not_null_value").ofType[Any].find.notNull.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some("bar"),
         None
       )
@@ -136,12 +143,12 @@ class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessa
         .ofType[Any]
         .find
         .notNull
-        .check(response, EmptySession, new JHashMap[Any, Any])
+        .check(response, emptySession, new JHashMap[Any, Any])
         .failed shouldBe "jsonPath($.null_value).find.notNull, but actually found null"
     }
 
     it should "not fail on empty array" in {
-      jsonPath("$.documents").ofType[Seq[_]].find.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.documents").ofType[Seq[_]].find.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(Vector.empty),
         None
       )
@@ -149,21 +156,21 @@ class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessa
 
     s"jsonPath.findAll.exists for $messageType" should "fetch all matches" in {
 
-      jsonPath("$..book").findAll.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$..book").findAll.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(Seq("In store", "On the street")),
         None
       )
     }
 
     it should "find all by wildcard" in {
-      jsonPath("$.*.book").findAll.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$.*.book").findAll.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(Vector("In store", "On the street")),
         None
       )
     }
 
     s"jsonPath.findRandom.exists for $messageType" should "fetch a single random match" in {
-      jsonPath("$..book").findRandom.exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded.extractedValue.get.asInstanceOf[String] should beIn(
+      jsonPath("$..book").findRandom.exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded.extractedValue.get.asInstanceOf[String] should beIn(
         Seq("In store", "On the street")
       )
     }
@@ -172,7 +179,7 @@ class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessa
       jsonPath("$..book")
         .findRandom(1)
         .exists
-        .check(response, EmptySession, new JHashMap[Any, Any])
+        .check(response, emptySession, new JHashMap[Any, Any])
         .succeeded
         .extractedValue
         .get
@@ -180,14 +187,14 @@ class JmsJsonPathCheckSpec extends BaseSpec with ValidationValues with MockMessa
     }
 
     it should "fetch all the matches when expected number is greater" in {
-      jsonPath("$..book").findRandom(3).exists.check(response, EmptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
+      jsonPath("$..book").findRandom(3).exists.check(response, emptySession, new JHashMap[Any, Any]).succeeded shouldBe CheckResult(
         Some(Seq("In store", "On the street")),
         None
       )
     }
 
     it should "fail when failIfLess is enabled and expected number is greater" in {
-      jsonPath("$..book").findRandom(3, failIfLess = true).exists.check(response, EmptySession, new JHashMap[Any, Any]).failed
+      jsonPath("$..book").findRandom(3, failIfLess = true).exists.check(response, emptySession, new JHashMap[Any, Any]).failed
     }
   }
 }

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsSimpleCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsSimpleCheckSpec.scala
@@ -21,10 +21,10 @@ import javax.jms._
 
 import io.gatling.BaseSpec
 import io.gatling.commons.validation._
-import io.gatling.core.session.SessionSpec.EmptySession
+import io.gatling.core.EmptySession
 import io.gatling.jms._
 
-class JmsSimpleCheckSpec extends BaseSpec with JmsDsl with MockMessage {
+class JmsSimpleCheckSpec extends BaseSpec with JmsDsl with MockMessage with EmptySession {
 
   private val check = simpleCheck {
     case tm: TextMessage => tm.getText == "OK"
@@ -32,14 +32,14 @@ class JmsSimpleCheckSpec extends BaseSpec with JmsDsl with MockMessage {
   }
 
   "simple check" should "return success if condition is true" in {
-    check.check(textMessage("OK"), EmptySession, new JHashMap[Any, Any]) shouldBe a[Success[_]]
+    check.check(textMessage("OK"), emptySession, new JHashMap[Any, Any]) shouldBe a[Success[_]]
   }
 
   it should "return failure if condition is false" in {
-    check.check(textMessage("KO"), EmptySession, new JHashMap[Any, Any]) shouldBe a[Failure]
+    check.check(textMessage("KO"), emptySession, new JHashMap[Any, Any]) shouldBe a[Failure]
   }
 
   it should "return failure if message is not TextMessage" in {
-    check.check(message, EmptySession, new JHashMap[Any, Any]) shouldBe a[Failure]
+    check.check(message, emptySession, new JHashMap[Any, Any]) shouldBe a[Failure]
   }
 }

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsStringBodyCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsStringBodyCheckSpec.scala
@@ -21,14 +21,21 @@ import javax.jms.Message
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.CheckResult
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.jms.MockMessage
 
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-class JmsStringBodyCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+class JmsStringBodyCheckSpec
+    extends BaseSpec
+    with ValidationValues
+    with MockMessage
+    with CoreDsl
+    with JmsCheckSupport
+    with TableDrivenPropertyChecks
+    with EmptySession {
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   private def jmap[K, V] = new JHashMap[K, V]
@@ -42,19 +49,19 @@ class JmsStringBodyCheckSpec extends BaseSpec with ValidationValues with MockMes
   forAll(testResponses) { (response: Message, msgType: String) =>
     s"bodyString.find.exists for $msgType" should "extract response body correctly" in {
       bodyString.find.exists
-        .check(response, EmptySession, jmap[Any, Any])
+        .check(response, emptySession, jmap[Any, Any])
         .succeeded shouldBe CheckResult(Some("""[{"id":"1072920417"},"id":"1072920418"]"""), None)
     }
 
     s"bodyString.notNull for $msgType" should "pass when response not empty" in {
       bodyString.find.notNull
-        .check(response, EmptySession, jmap[Any, Any])
+        .check(response, emptySession, jmap[Any, Any])
         .succeeded shouldBe CheckResult(Some("""[{"id":"1072920417"},"id":"1072920418"]"""), None)
     }
 
     s"bodyString.isNull for $msgType" should "fail when response not empty" in {
       bodyString.isNull
-        .check(response, EmptySession, jmap[Any, Any])
+        .check(response, emptySession, jmap[Any, Any])
         .failed shouldBe """bodyString.find.isNull, found [{"id":"1072920417"},"id":"1072920418"]"""
     }
   }

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsSubstringCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsSubstringCheckSpec.scala
@@ -21,14 +21,21 @@ import javax.jms.Message
 
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.check.CheckResult
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.jms.MockMessage
 
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-class JmsSubstringCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with TableDrivenPropertyChecks {
+class JmsSubstringCheckSpec
+    extends BaseSpec
+    with ValidationValues
+    with MockMessage
+    with CoreDsl
+    with JmsCheckSupport
+    with TableDrivenPropertyChecks
+    with EmptySession {
   override implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   private def jmap[K, V] = new JHashMap[K, V]
@@ -41,36 +48,36 @@ class JmsSubstringCheckSpec extends BaseSpec with ValidationValues with MockMess
 
   "substring.find.exists for TextMessage" should "find single result" in {
     val response = textMessage("""{"id":"1072920417"}""")
-    substring(""""id":"""").find.exists.check(response, EmptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(1), None)
+    substring(""""id":"""").find.exists.check(response, emptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(1), None)
   }
 
   "substring.find.exists for BytesMessage" should "find single result" in {
     val response = bytesMessage("""{"id":"1072920417"}""".getBytes())
-    substring(""""id":"""").find.exists.check(response, EmptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(1), None)
+    substring(""""id":"""").find.exists.check(response, emptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(1), None)
   }
 
   forAll(testResponses) { (response: Message, msgType: String) =>
     s"substring.find.exists for $msgType" should "find first occurrence" in {
-      substring(""""id":"""").find.exists.check(response, EmptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
+      substring(""""id":"""").find.exists.check(response, emptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
     }
 
     s"substring.findAll.exists for $msgType" should "find all occurrences" in {
-      substring(""""id":"""").findAll.exists.check(response, EmptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(Seq(2, 21)), None)
+      substring(""""id":"""").findAll.exists.check(response, emptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(Seq(2, 21)), None)
     }
 
     it should "fail when finding nothing instead of returning an empty Seq" in {
       val substringValue = """"foo":""""
       substring(substringValue).findAll.exists
-        .check(response, EmptySession, jmap[Any, Any])
+        .check(response, emptySession, jmap[Any, Any])
         .failed shouldBe s"substring($substringValue).findAll.exists, found nothing"
     }
 
     s"substring.count.exists for $msgType" should "find all occurrences" in {
-      substring(""""id":"""").count.exists.check(response, EmptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
+      substring(""""id":"""").count.exists.check(response, emptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(2), None)
     }
 
     it should "return 0 when finding nothing instead of failing" in {
-      substring(""""foo":"""").count.exists.check(response, EmptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(0), None)
+      substring(""""foo":"""").count.exists.check(response, emptySession, jmap[Any, Any]).succeeded shouldBe CheckResult(Some(0), None)
     }
   }
 }

--- a/gatling-jms/src/test/scala/io/gatling/jms/check/JmsXPathCheckSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/check/JmsXPathCheckSpec.scala
@@ -21,25 +21,25 @@ import java.util.{ HashMap => JHashMap }
 import io.gatling.{ BaseSpec, ValidationValues }
 import io.gatling.commons.validation._
 import io.gatling.core.CoreDsl
+import io.gatling.core.EmptySession
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.jms.{ JmsCheck, MockMessage }
 
-class JmsXPathCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport {
+class JmsXPathCheckSpec extends BaseSpec with ValidationValues with MockMessage with CoreDsl with JmsCheckSupport with EmptySession {
 
   override val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   private val check: JmsCheck = xpath("/ok").find
 
   "xpath check" should "return success if condition is true" in {
-    check.check(textMessage("<ok></ok>"), EmptySession, new JHashMap[Any, Any]) shouldBe a[Success[_]]
+    check.check(textMessage("<ok></ok>"), emptySession, new JHashMap[Any, Any]) shouldBe a[Success[_]]
   }
 
   it should "return failure if condition is false" in {
-    check.check(textMessage("<ko></ko>"), EmptySession, new JHashMap[Any, Any]) shouldBe a[Failure]
+    check.check(textMessage("<ko></ko>"), emptySession, new JHashMap[Any, Any]) shouldBe a[Failure]
   }
 
   it should "return failure if message is not TextMessage" in {
-    check.check(message, EmptySession, new JHashMap[Any, Any]).failed.message should include("Unsupported message type")
+    check.check(message, emptySession, new JHashMap[Any, Any]).failed.message should include("Unsupported message type")
   }
 }

--- a/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsSpec.scala
@@ -28,7 +28,6 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.pause.Constant
 import io.gatling.core.protocol.{ Protocol, ProtocolComponentsRegistries, Protocols }
 import io.gatling.core.session.{ Session, StaticValueExpression }
-import io.gatling.core.session.SessionSpec.EmptySession
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.structure.{ ScenarioBuilder, ScenarioContext }
 import io.gatling.jms._
@@ -120,7 +119,7 @@ trait JmsSpec extends AkkaSpec with JmsDsl {
     val next = new ActorDelegatingAction("next", self)
     val protocolComponentsRegistry = new ProtocolComponentsRegistries(coreComponents, protocols).scenarioRegistry(Map.empty)
     val actor = sb.build(new ScenarioContext(coreComponents, protocolComponentsRegistry, Constant, throttled = false), next)
-    actor ! EmptySession
+    actor ! emptySession
     val session = expectMsgClass(timeout, classOf[Session])
 
     session


### PR DESCRIPTION
Motivation:

With the virtual user <-> event loop affinity,
scheduling delays with the session event loop should be more performant.

Modifications:

`Pace`, like `Pause`, uses event loop for delay.
`SessionSpec.FakeEventLoop` uses a `java.util.Timer` to handle delays.

Result:

`Pace` does not depend on `ActorSystem`.