### PR TITLE
Return exit code 1 on premature system exit, close #4005

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/Selection.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/Selection.scala
@@ -101,7 +101,7 @@ object Selection {
       def readSimulationNumber(attempts: Int): Int = {
         if (attempts > MaxReadSimulationNumberAttempts) {
           println(s"Max attempts of reading simulation number ($MaxReadSimulationNumberAttempts) reached. Aborting.")
-          sys.exit()
+          sys.exit(1)
         } else {
           println("Choose a simulation number:")
           for ((simulation, index) <- simulationClasses.zipWithIndex) {
@@ -124,7 +124,7 @@ object Selection {
 
       if (simulationClasses.isEmpty) {
         println("There is no simulation script. Please check that your scripts are in user-files/simulations")
-        sys.exit()
+        sys.exit(1)
       }
       simulationClasses(readSimulationNumber(0))
     }


### PR DESCRIPTION
This will return exit code 1 in two cases:

- absence of simulations in user-files
- too many invalid attempts at choosing the simulation in interactive shell dialog

Closes #4005 