### PR TITLE
Fix Brotli4j MacOS dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   private val nettyHttp2                     = netty.organization                     % "netty-codec-http2"               % netty.revision
   private val nettyBoringSsl                 = netty.organization                     % "netty-tcnative-boringssl-static" % "2.0.35.Final"
   private val brotli4j                       = "com.aayushatharva.brotli4j"           % "brotli4j"                        % "1.2.1"
-  private val brotli4jMacOs                  = brotli4j.withName("native-linux_x86-64")
+  private val brotli4jMacOs                  = brotli4j.withName("native-macos_x86-64")
   private val brotli4jLinux                  = brotli4j.withName("native-linux_x86-64")
   private val brotli4jWindows                = brotli4j.withName("native-windows_x86-64")
   private val akka                           = "com.typesafe.akka"                   %% "akka-actor"                      % "2.6.10"


### PR DESCRIPTION
Dependency for `brotli4jMacOs` should be `native-macos_x86-64` instead of `native-linux_x86-64`.