### PR TITLE
Use LongRef for ThreadLocal

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/action/Loop.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/action/Loop.scala
@@ -16,6 +16,8 @@
 
 package io.gatling.core.action
 
+import scala.runtime.LongRef
+
 import io.gatling.commons.util.Clock
 import io.gatling.core.session.{ Expression, LoopBlock, Session }
 import io.gatling.core.stats.StatsEngine
@@ -62,12 +64,13 @@ class InnerLoop(
     val next: Action
 ) extends ChainableAction {
 
-  private[this] val lastUserIdThreadLocal = new ThreadLocal[Long]
+  private[this] val lastUserIdThreadLocal = ThreadLocal.withInitial(() => LongRef.zero())
 
   private[this] def getAndSetLastUserId(session: Session): Long = {
-    val lastUserId = lastUserIdThreadLocal.get()
-    lastUserIdThreadLocal.set(session.userId)
-    lastUserId
+    val lastUserIdRef = lastUserIdThreadLocal.get()
+    val prev = lastUserIdRef.elem
+    lastUserIdRef.elem = session.userId
+    prev
   }
 
   /**


### PR DESCRIPTION
This is barely a micro-optimization (more like nano-optimization).
But minor cost like this can add up.

I have done a JMH test and confirmed a measurable speedup.