### PR TITLE
Remove duplicated checks in TypeCaster for primitives.

### DIFF
--- a/gatling-commons/src/main/scala/io/gatling/commons/util/TypeHelper.scala
+++ b/gatling-commons/src/main/scala/io/gatling/commons/util/TypeHelper.scala
@@ -95,18 +95,16 @@ object TypeCaster extends LowPriorityTypeCaster {
     @throws[ClassCastException]
     override def cast(key: String, value: Any): Boolean =
       value match {
-        case v: Boolean           => v
-        case v: java.lang.Boolean => v.booleanValue
-        case s: String            => tryParse(key, s, classOf[Boolean])(_.toBoolean)
-        case _                    => throw new ClassCastException(cceMessage(key, value, classOf[Boolean]))
+        case v: Boolean => v
+        case s: String  => tryParse(key, s, classOf[Boolean])(_.toBoolean)
+        case _          => throw new ClassCastException(cceMessage(key, value, classOf[Boolean]))
       }
 
     override def validate(key: String, value: Any): Validation[Boolean] =
       value match {
-        case true | java.lang.Boolean.TRUE   => TrueSuccess
-        case false | java.lang.Boolean.FALSE => FalseSuccess
-        case s: String                       => tryParseV(key, s, classOf[Boolean])(_.toBoolean)
-        case _                               => cceMessage(key, value, classOf[Boolean]).failure
+        case v: Boolean => if (v) TrueSuccess else FalseSuccess
+        case s: String  => tryParseV(key, s, classOf[Boolean])(_.toBoolean)
+        case _          => cceMessage(key, value, classOf[Boolean]).failure
       }
   }
 
@@ -115,18 +113,16 @@ object TypeCaster extends LowPriorityTypeCaster {
     @throws[ClassCastException]
     override def cast(key: String, value: Any): Byte =
       value match {
-        case v: Byte           => v
-        case v: java.lang.Byte => v.byteValue
-        case s: String         => tryParse(key, s, classOf[Byte])(_.toByte)
-        case _                 => throw new ClassCastException(cceMessage(key, value, classOf[Byte]))
+        case v: Byte   => v
+        case s: String => tryParse(key, s, classOf[Byte])(_.toByte)
+        case _         => throw new ClassCastException(cceMessage(key, value, classOf[Byte]))
       }
 
     override def validate(key: String, value: Any): Validation[Byte] =
       value match {
-        case v: Byte           => v.success
-        case v: java.lang.Byte => v.byteValue.success
-        case s: String         => tryParseV(key, s, classOf[Byte])(_.toByte)
-        case _                 => cceMessage(key, value, classOf[Byte]).failure
+        case v: Byte   => v.success
+        case s: String => tryParseV(key, s, classOf[Byte])(_.toByte)
+        case _         => cceMessage(key, value, classOf[Byte]).failure
       }
   }
 
@@ -134,18 +130,16 @@ object TypeCaster extends LowPriorityTypeCaster {
     @throws[ClassCastException]
     override def cast(key: String, value: Any): Short =
       value match {
-        case v: Short           => v
-        case v: java.lang.Short => v.shortValue
-        case s: String          => tryParse(key, s, classOf[Short])(_.toShort)
-        case _                  => throw new ClassCastException(cceMessage(key, value, classOf[Short]))
+        case v: Short  => v
+        case s: String => tryParse(key, s, classOf[Short])(_.toShort)
+        case _         => throw new ClassCastException(cceMessage(key, value, classOf[Short]))
       }
 
     override def validate(key: String, value: Any): Validation[Short] =
       value match {
-        case v: Short           => v.success
-        case v: java.lang.Short => v.shortValue.success
-        case s: String          => tryParseV(key, s, classOf[Short])(_.toShort)
-        case _                  => cceMessage(key, value, classOf[Short]).failure
+        case v: Short  => v.success
+        case s: String => tryParseV(key, s, classOf[Short])(_.toShort)
+        case _         => cceMessage(key, value, classOf[Short]).failure
       }
   }
 
@@ -153,18 +147,16 @@ object TypeCaster extends LowPriorityTypeCaster {
     @throws[ClassCastException]
     override def cast(key: String, value: Any): Int =
       value match {
-        case v: Int               => v
-        case v: java.lang.Integer => v.intValue
-        case s: String            => tryParse(key, s, classOf[Int])(_.toInt)
-        case _                    => throw new ClassCastException(cceMessage(key, value, classOf[Int]))
+        case v: Int    => v
+        case s: String => tryParse(key, s, classOf[Int])(_.toInt)
+        case _         => throw new ClassCastException(cceMessage(key, value, classOf[Int]))
       }
 
     override def validate(key: String, value: Any): Validation[Int] =
       value match {
-        case v: Int               => v.success
-        case v: java.lang.Integer => v.intValue.success
-        case s: String            => tryParseV(key, s, classOf[Int])(_.toInt)
-        case _                    => cceMessage(key, value, classOf[Int]).failure
+        case v: Int    => v.success
+        case s: String => tryParseV(key, s, classOf[Int])(_.toInt)
+        case _         => cceMessage(key, value, classOf[Int]).failure
       }
   }
 
@@ -172,18 +164,16 @@ object TypeCaster extends LowPriorityTypeCaster {
     @throws[ClassCastException]
     override def cast(key: String, value: Any): Long =
       value match {
-        case v: Long           => v
-        case v: java.lang.Long => v.longValue
-        case s: String         => tryParse(key, s, classOf[Long])(_.toLong)
-        case _                 => throw new ClassCastException(cceMessage(key, value, classOf[Long]))
+        case v: Long   => v
+        case s: String => tryParse(key, s, classOf[Long])(_.toLong)
+        case _         => throw new ClassCastException(cceMessage(key, value, classOf[Long]))
       }
 
     override def validate(key: String, value: Any): Validation[Long] =
       value match {
-        case v: Long           => v.success
-        case v: java.lang.Long => v.longValue.success
-        case s: String         => tryParseV(key, s, classOf[Long])(_.toLong)
-        case _                 => cceMessage(key, value, classOf[Long]).failure
+        case v: Long   => v.success
+        case s: String => tryParseV(key, s, classOf[Long])(_.toLong)
+        case _         => cceMessage(key, value, classOf[Long]).failure
       }
   }
 
@@ -191,18 +181,16 @@ object TypeCaster extends LowPriorityTypeCaster {
     @throws[ClassCastException]
     override def cast(key: String, value: Any): Float =
       value match {
-        case v: Float           => v
-        case v: java.lang.Float => v.floatValue
-        case s: String          => tryParse(key, s, classOf[Float])(_.toFloat)
-        case _                  => throw new ClassCastException(cceMessage(key, value, classOf[Float]))
+        case v: Float  => v
+        case s: String => tryParse(key, s, classOf[Float])(_.toFloat)
+        case _         => throw new ClassCastException(cceMessage(key, value, classOf[Float]))
       }
 
     override def validate(key: String, value: Any): Validation[Float] =
       value match {
-        case v: Float           => v.success
-        case v: java.lang.Float => v.floatValue.success
-        case s: String          => tryParseV(key, s, classOf[Float])(_.toFloat)
-        case _                  => cceMessage(key, value, classOf[Float]).failure
+        case v: Float  => v.success
+        case s: String => tryParseV(key, s, classOf[Float])(_.toFloat)
+        case _         => cceMessage(key, value, classOf[Float]).failure
       }
   }
 
@@ -210,18 +198,16 @@ object TypeCaster extends LowPriorityTypeCaster {
     @throws[ClassCastException]
     override def cast(key: String, value: Any): Double =
       value match {
-        case v: Double           => v
-        case v: java.lang.Double => v.doubleValue
-        case s: String           => tryParse(key, s, classOf[Double])(_.toDouble)
-        case _                   => throw new ClassCastException(cceMessage(key, value, classOf[Double]))
+        case v: Double => v
+        case s: String => tryParse(key, s, classOf[Double])(_.toDouble)
+        case _         => throw new ClassCastException(cceMessage(key, value, classOf[Double]))
       }
 
     override def validate(key: String, value: Any): Validation[Double] =
       value match {
-        case v: Double           => v.success
-        case v: java.lang.Double => v.doubleValue.success
-        case s: String           => tryParseV(key, s, classOf[Double])(_.toDouble)
-        case _                   => cceMessage(key, value, classOf[Double]).failure
+        case v: Double => v.success
+        case s: String => tryParseV(key, s, classOf[Double])(_.toDouble)
+        case _         => cceMessage(key, value, classOf[Double]).failure
       }
   }
 
@@ -230,7 +216,6 @@ object TypeCaster extends LowPriorityTypeCaster {
     override def cast(key: String, value: Any): Char =
       value match {
         case v: Char                    => v
-        case v: java.lang.Character     => v.charValue
         case v: String if v.length == 1 => v.charAt(0)
         case _                          => throw new ClassCastException(cceMessage(key, value, classOf[Char]))
       }
@@ -238,7 +223,6 @@ object TypeCaster extends LowPriorityTypeCaster {
     override def validate(key: String, value: Any): Validation[Char] =
       value match {
         case v: Char                    => v.success
-        case v: java.lang.Character     => v.charValue.success
         case v: String if v.length == 1 => v.charAt(0).success
         case _                          => cceMessage(key, value, classOf[Char]).failure
       }
@@ -256,7 +240,6 @@ object TypeCaster extends LowPriorityTypeCaster {
     override def cast(key: String, value: Any): FiniteDuration =
       value match {
         case v: Long           => v.seconds
-        case v: java.lang.Long => v.longValue.seconds
         case s: String         => tryParse(key, s, classOf[Long])(_.toLong.seconds)
         case v: FiniteDuration => v
         case _                 => throw new ClassCastException(cceMessage(key, value, classOf[FiniteDuration]))
@@ -264,8 +247,7 @@ object TypeCaster extends LowPriorityTypeCaster {
 
     override def validate(key: String, value: Any): Validation[FiniteDuration] =
       value match {
-        case v: Long           => (v.seconds).success
-        case v: java.lang.Long => (v.longValue.seconds).success
+        case v: Long           => v.seconds.success
         case s: String         => tryParseV(key, s, classOf[Long])(_.toLong.seconds)
         case v: FiniteDuration => v.success
         case _                 => cceMessage(key, value, classOf[FiniteDuration]).failure


### PR DESCRIPTION
For example, the `TypeCaster` for `Double` is `io.gatling.commons.util.TypeCaster$$anon$8`.

In the following two clauses in `cast`:
```scala
case v: Double           => v
case v: java.lang.Double => v.doubleValue
```

The first clause gets compiled to checking if `value` is an instance of `java.lang.Double`. (Because it's an `Any`, it has to be a boxed value)

```
         3: aload         5
         5: instanceof    #56                 // class java/lang/Double
         8: ifeq          24
        11: aload         5
        13: invokestatic  #62                 // Method scala/runtime/BoxesRunTime.unboxToDouble:(Ljava/lang/Object;)D
        16: dstore        6
        18: dload         6
        20: dstore_3
        21: goto          113
        24: goto          27
```

The second clause does essentially the same thing.

```
        27: aload         5
        29: instanceof    #56                 // class java/lang/Double
        32: ifeq          51
        35: aload         5
        37: checkcast     #56                 // class java/lang/Double
        40: astore        8
        42: aload         8
        44: invokevirtual #66                 // Method java/lang/Double.doubleValue:()D
        47: dstore_3
        48: goto          113
        51: goto          54
```

This PR removes the checks for Java boxed primitive types.