### PR TITLE
WebSockets: allow auto reply to specific messages, related #3929

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsIdleState.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsIdleState.scala
@@ -109,8 +109,10 @@ final class WsIdleState(fsm: WsFsm, session: Session, webSocket: WebSocket) exte
   }
 
   override def onTextFrameReceived(message: String, timestamp: Long): NextWsState = {
-    // server push message, just log
-    logUnmatchedServerMessage(session)
+    // try to auto reply or log the message
+    if (!autoReplyTextFrames(message, webSocket)) {
+      logUnmatchedServerMessage(session)
+    }
     NextWsState(this)
   }
 

--- a/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsPerformingCheckState.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsPerformingCheckState.scala
@@ -74,9 +74,11 @@ final case class WsPerformingCheckState(
         tryApplyingChecks(message, timestamp, matchConditions, checks)
 
       case _ =>
-        logger.debug(s"Received unmatched text frame $message")
-        // server unmatched message, just log
-        logUnmatchedServerMessage(session)
+        // server unmatched message, try to auto reply or log the message
+        if (!autoReplyTextFrames(message, webSocket)) {
+          logger.debug(s"Received unmatched text frame $message")
+          logUnmatchedServerMessage(session)
+        }
         NextWsState(this)
     }
 

--- a/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
@@ -105,7 +105,8 @@ object HttpProtocol extends StrictLogging {
       ),
       wsPart = HttpProtocolWsPart(
         wsBaseUrls = Nil,
-        maxReconnects = 0
+        maxReconnects = 0,
+        autoReplyTextFrames = PartialFunction.empty
       ),
       proxyPart = HttpProtocolProxyPart(
         proxy = None,
@@ -181,7 +182,8 @@ final case class HttpProtocolResponsePart(
 
 final case class HttpProtocolWsPart(
     wsBaseUrls: List[String],
-    maxReconnects: Int
+    maxReconnects: Int,
+    autoReplyTextFrames: PartialFunction[String, String]
 )
 
 final case class HttpProtocolProxyPart(

--- a/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocolBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocolBuilder.scala
@@ -187,6 +187,9 @@ final case class HttpProtocolBuilder(protocol: HttpProtocol, useOpenSsl: Boolean
   def wsBaseUrls(urls: List[String]): HttpProtocolBuilder = this.modify(_.protocol.wsPart.wsBaseUrls).setTo(urls)
   def wsReconnect: HttpProtocolBuilder = wsMaxReconnects(Int.MaxValue)
   def wsMaxReconnects(max: Int): HttpProtocolBuilder = this.modify(_.protocol.wsPart.maxReconnects).setTo(max)
+  def wsAutoReplyTextFrame(f: PartialFunction[String, String]): HttpProtocolBuilder =
+    this.modify(_.protocol.wsPart.autoReplyTextFrames).setTo(f)
+  def wsAutoReplySocketIo4: HttpProtocolBuilder = wsAutoReplyTextFrame({ case "2" => "3" })
 
   // proxyPart
   def noProxyFor(hosts: String*): HttpProtocolBuilder = this.modify(_.protocol.proxyPart.proxyExceptions).setTo(hosts)

--- a/gatling-http/src/test/scala/io/gatling/http/compile/WsCompileTest.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/compile/WsCompileTest.scala
@@ -29,6 +29,7 @@ class WsCompileTest extends Simulation {
     .wsBaseUrl("ws://localhost:9000")
     .wsReconnect
     .wsMaxReconnects(3)
+    .wsAutoReplyTextFrame({ case "ping" => "pong"; case "1" => "2" })
 
   private val scn = scenario("WebSocket")
     .exec(http("Home").get("/"))

--- a/src/docs/content/reference/current/cheat-sheet.md
+++ b/src/docs/content/reference/current/cheat-sheet.md
@@ -1483,6 +1483,15 @@ content:
               - signature: (count)
                 description: Where <i>count</i> is the number of maximum reconnections url
 
+          - keyword: wsAutoReplyTextFrame
+            description: Configure auto reply for specific WebSocket text messages
+            syntax:
+              - signature: (PartialFunction[message, response])
+                description: Where <i>PartialFunction</i> can be a case statement like <i>{ case "ping" => "pong" }</i>
+
+          - keyword: wsAutoReplySocketIo4
+            description: Enable partial support for Engine.IO v4 - Gatling will automatically respond to server ping messages (<i>2</i>) with pong (<i>3</i>).
+
   - title: SSE (Server Sent Events)
     description: Define the SSE requests sent in your scenario
     sections:

--- a/src/docs/content/reference/current/http/websocket/index.md
+++ b/src/docs/content/reference/current/http/websocket/index.md
@@ -136,6 +136,10 @@ Websocket support introduces new HttpProtocol parameters:
 
 `wsMaxReconnects(max: Int)`: set a limit on the number of times a WebSocket will be automatically reconnected
 
+`wsAutoReplyTextFrame(f: PartialFunction[String, String])`: configure auto reply for specific WebSocket text messages. Example: `wsAutoReplyTextFrame({ case "ping" => "pong" })` will automatically reply with message `"pong"` when message `"ping"` is received. Those messages won't be visible in any reports or statistics.
+
+`wsAutoReplySocketIo4`: enable partial support for Engine.IO v4 - Gatling will automatically respond to server ping messages (`2`) with pong (`3`). Cannot be used together with `wsAutoReplyTextFrame`.
+
 ## Debugging
 
 In your logback configuration, lower logging level to `DEBUG` on logger `io.gatling.http.action.ws.fsm`:


### PR DESCRIPTION
Some WebSocket implementations require low level automatic replies from
clients to specific messages, for example for heartbeat purposes.

This commit introduces two new WebSocket options: `wsAutoReplyTextFrame`
and `wsAutoReplySocketIo4`.

The `wsAutoReplyTextFrame` is generic, it accepts
`f: PartialFunction[String, String]` as a parameter and allows
configuration of custom reponse for specific message, for example:
`{ case "ping" => "pong" }`

The `wsAutoReplySocketIo4` is utilizing `wsAutoReplyTextFrame` with
pre-configured heartbeat mechanism introduced in Engine.IO v4. It
automatically replies with pong message (`3`) to server ping message
(`2`).