### PR TITLE
Override up to date check for all Gatling run tasks

### DIFF
--- a/src/docs/content/reference/current/extensions/gradle_plugin.md
+++ b/src/docs/content/reference/current/extensions/gradle_plugin.md
@@ -258,7 +258,9 @@ gradle --rerun-tasks gatlingRun
 To always rerun the gatling task when called, you may add this line in ``build.gradle``:
 
 ```groovy
-tasks.gatlingRun.outputs.upToDateWhen { false }
+tasks.withType(io.gatling.gradle.GatlingRunTask) {
+  outputs.upToDateWhen { false }
+}
 ```
 {{< /alert >}}
 


### PR DESCRIPTION
The documented way to override the up to date check for the gradle run task does not work for specific scenario commands. (i.e. gatlingRun-SimulationFQN)
By using the with type function this will also work for these commands.