### PR TITLE
Update GatlingPropertiesBuilder.scala

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/config/GatlingPropertiesBuilder.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/config/GatlingPropertiesBuilder.scala
@@ -16,7 +16,7 @@
 
 package io.gatling.core.config
 
-import scala.collection.mutable
+import scala.collection.mutable._
 
 import io.gatling.core.ConfigKeys._
 


### PR DESCRIPTION
Change : import scala.collection.mutable._
Previously : import scala.collection.mutable

Fixed Issue : 
Exception in thread "main" java.lang.NoSuchMethodError: 'java.lang.Object scala.collection.mutable.Map$.empty()'
at io.gatling.core.config.GatlingPropertiesBuilder.<init>(GatlingPropertiesBuilder.scala:25)
at io.gatling.app.cli.ArgsParser.<init>(ArgsParser.scala:26)
at io.gatling.app.Gatling$.fromArgs(Gatling.scala:44)
at io.gatling.app.Gatling$.main(Gatling.scala:37)
at io.gatling.app.Gatling.main(Gatling.scala)