### PR TITLE
doc(realtimemonitoring): Adding a process to connect gatling to influ…

### DIFF
--- a/src/docs/content/guides/realtime_monitoring/index.md
+++ b/src/docs/content/guides/realtime_monitoring/index.md
@@ -117,31 +117,9 @@ time                count max mean min percentiles50 percentiles75 percentiles95
 
 #### Install
 
-Graphite can be installed through [Synthesize](https://Gatling can provide live metrics via the Graphite protocol which can be persisted and visualised.
+Graphite can be installed through [Synthesize](https://github.com/obfuscurity/synthesize) on Ubuntu 14.04
 
-The sections below describe how to configure Gatling with InfluxDB and Graphite, and use Grafana as a graphing library. We also present a lo-fi solution which prints parsed Graphite data to standard out.
-
-{{< alert warning >}} As explained in one of our blog posts, Graphite and InfluxDB can't store distributions but only numbers. As a result, only one-second-resolution non-aggregated response time stats are correct.
-
-All aggregations will result in computing averages on percentiles and will inherently be broken.
-
-This is not a limitation of Gatling, but a limitation of those time series databases. {{< /alert >}}
-
-Gatling
-In the gatling.conf add "graphite" to the data writers and specify the host of the Carbon or InfluxDB server.
-
-gatling {
-  data {
-    writers = [console, file, graphite]
-
-    graphite {
-      host = "192.0.2.235"  # InfluxDB or Carbon server
-      port = 2003           # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
-      # writePeriod = 1     # Default write interval of one second
-    }
-  }
-}
-InfluxDB
+#### Configuration
 
 In `$GRAPHITE_HOME/conf/storage-schemas.conf`:
 


### PR DESCRIPTION
The current documentation is working only for the previous version of Ifnluxdb 1. X. 

No need Grafana. With version 2 of influxdb, you need to use telegraf to load your data from graphite, and you can now create your dashboard in Influxdb directly.  If you need grafana, you can also connect grafana to influxdb 2.0 to use a flux connection.