### PR TITLE
Doc: fix the URL in HttpProtocolSampleScala 

### DIFF
--- a/src/docs/content/reference/current/http/protocol/code/HttpProtocolSampleScala.scala
+++ b/src/docs/content/reference/current/http/protocol/code/HttpProtocolSampleScala.scala
@@ -41,7 +41,7 @@ val scn = scenario("Scenario")
   )
   // will make a request to "https://github.com/gatling/gatling"
   .exec(
-    http("Absolute").get("https://github.com")
+    http("Absolute").get("https://github.com/gatling/gatling")
   )
 
 setUp(scn.inject(atOnceUsers(1)).protocols(httpProtocol))


### PR DESCRIPTION
In Kotlin and Java, the URL is `https://github.com/gatling/gatling`, as mentioned in the comments.  
However, in Scala it is `https://github.com`, so I fix it.