### PR TITLE
fix: GATLING_VERSION path glob

### DIFF
--- a/gatling-bundle/src/universal/bin/enterprisePackage.sh
+++ b/gatling-bundle/src/universal/bin/enterprisePackage.sh
@@ -62,7 +62,7 @@ fi
 # Run the compiler
 "$JAVA" $COMPILER_OPTS -cp "$COMPILER_CLASSPATH" io.gatling.compiler.ZincCompiler $EXTRA_COMPILER_OPTIONS "$@" 2> /dev/null
 
-GATLING_VERSION="$(ls "${GATLING_HOME}/lib/gatling-app-*.jar" | sed -n -E "s/^.*gatling-app-(.*)\.jar$/\1/p")"
+GATLING_VERSION="$(ls "${GATLING_HOME}/lib/gatling-app-"*.jar | sed -n -E "s/^.*gatling-app-(.*)\.jar$/\1/p")"
 
 echo "GATLING_VERSION is set to '$GATLING_VERSION'"
 


### PR DESCRIPTION
`MANIFEST.MF` file is not being generated correctly due to an empty `GATLING_VERSION` environment variable:

```
$ ./bin/enterprisePackage.sh 
GATLING_HOME is set to /mnt/hgfs/gatling-charts-highcharts-bundle-3.7.5
ls: cannot access '/mnt/hgfs/gatling-charts-highcharts-bundle-3.7.5/lib/gatling-app-*.jar': No such file or directory
GATLING_VERSION is set to ''
Creating package...
Package created

$ unzip target/package.jar META-INF/MANIFEST.MF && cat META-INF/MANIFEST.MF 
Archive:  target/package.jar
  inflating: META-INF/MANIFEST.MF    
Manifest-Version: 1.0
Gatling-Version: 
Gatling-Packager: bundle
Created-By: 17.0.1 (N/A)
```

Adjust path glob to `"${GATLING_HOME}/lib/gatling-app-"*.jar` to fix this:

```
$ ./bin/enterprisePackage.sh 
GATLING_HOME is set to /mnt/hgfs/gatling-charts-highcharts-bundle-3.7.5
GATLING_VERSION is set to '3.7.5'
Creating package...
Package created

$ unzip target/package.jar META-INF/MANIFEST.MF && cat META-INF/MANIFEST.MF 
Archive:  target/package.jar
  inflating: META-INF/MANIFEST.MF    
Manifest-Version: 1.0
Gatling-Version: 3.7.5
Gatling-Packager: bundle
Created-By: 17.0.1 (Eclipse Adoptium)
```

Tested on:
- macOS 12.2.1 (bash & zsh)
- Arch Linux (bash & zsh)
