### PR TITLE
remove transform step if conversion to java is noop

### DIFF
--- a/gatling-core-java/src/main/java/io/gatling/javaapi/core/CheckBuilder.java
+++ b/gatling-core-java/src/main/java/io/gatling/javaapi/core/CheckBuilder.java
@@ -110,7 +110,7 @@ public interface CheckBuilder {
       @Nonnull
       public Validate<JavaX> find() {
         return new Validate.Default<>(
-            wrapped.find().transform(toScalaFunction(scalaXToJavaX)), type, javaXClass);
+            transformSingleCheck(wrapped.find(), scalaXToJavaX), type, javaXClass);
       }
 
       @Override

--- a/gatling-core-java/src/main/scala/io/gatling/javaapi/core/internal/CoreCheckBuilders.scala
+++ b/gatling-core-java/src/main/scala/io/gatling/javaapi/core/internal/CoreCheckBuilders.scala
@@ -57,14 +57,23 @@ object CoreCheckBuilders {
   def transformSingleCheck[T, P, ScalaX, JavaX](
       wrapped: io.gatling.core.check.CheckBuilder.Validate[T, P, ScalaX],
       scalaXToJavaX: juf.Function[ScalaX, JavaX]
-  ): io.gatling.core.check.CheckBuilder.Validate[T, P, JavaX] =
-    wrapped.transform(scalaXToJavaX.asScala)
+  ): io.gatling.core.check.CheckBuilder.Validate[T, P, JavaX] = {
+    if (scalaXToJavaX eq juf.Function.identity[JavaX]()) {
+      wrapped.asInstanceOf[io.gatling.core.check.CheckBuilder.Validate[T, P, JavaX]]
+    } else {
+      wrapped.transform(scalaXToJavaX.asScala)
+    }
+  }
 
   def transformSeqCheck[T, P, ScalaX, JavaX](
       wrapped: io.gatling.core.check.CheckBuilder.Validate[T, P, Seq[ScalaX]],
       scalaXToJavaX: juf.Function[ScalaX, JavaX]
   ): io.gatling.core.check.CheckBuilder.Validate[T, P, ju.List[JavaX]] =
-    wrapped.transform(_.map(scalaXToJavaX.asScala).asJava)
+    if (scalaXToJavaX eq juf.Function.identity[JavaX]()) {
+      wrapped.transform(_.asInstanceOf[Seq[JavaX]].asJava)
+    } else {
+      wrapped.transform(_.map(scalaXToJavaX.asScala).asJava)
+    }
 
   def toFindRandomCheck[T, P, X](
       wrapped: io.gatling.core.check.CheckBuilder.MultipleFind[T, P, X],

--- a/gatling-jms-java/src/main/java/io/gatling/javaapi/jms/JmsDsl.java
+++ b/gatling-jms-java/src/main/java/io/gatling/javaapi/jms/JmsDsl.java
@@ -111,8 +111,7 @@ public final class JmsDsl {
         return new io.gatling.core.check.CheckBuilder() {
           @Override
           public Check<?> build(CheckMaterializer materializer) {
-            return io.gatling.jms.Predef.simpleCheck(
-                toScalaFunction(f.andThen(Function.identity()))); // trick compiler
+            return io.gatling.jms.Predef.simpleCheck(f::apply);
           }
         };
       }


### PR DESCRIPTION
I was bothered seeing `.find.transform` in the logs when the user code has done no `transform`.

This change should also be a nano-optimization.