### PR TITLE
corrected typo (I think)

### DIFF
--- a/src/docs/content/reference/current/core/session/feeder/index.md
+++ b/src/docs/content/reference/current/core/session/feeder/index.md
@@ -94,7 +94,7 @@ If your files are very large, you can provide them zipped and ask gatling to `un
 
 {{< include-code "unzip" java kt scala >}}
 
-Supported formats are gzip and zip (but archive most contain only one single file).
+Supported formats are gzip and zip (but archive must contain only one single file).
 
 ## Distributed Files (Gatling Enterprise only)
 


### PR DESCRIPTION
Original sentence was "Supported formats are gzip and zip (but archive most contain only one single file)."
I think the word "must" was meant to be written instead of "most"