### PR TITLE
fix sbt docs

### DIFF
--- a/src/docs/content/reference/current/extensions/sbt_plugin.md
+++ b/src/docs/content/reference/current/extensions/sbt_plugin.md
@@ -109,7 +109,7 @@ sbt Gatling/test
 Or run a single simulation, by its FQN (fully qualified class name), from the `it` configuration:
 
 ```bash
-sbt GatlingIt/testOnly com.project.simu.MySimulation
+sbt 'GatlingIt/testOnly com.project.simu.MySimulation'
 ```
 
 {{< alert tip >}}


### PR DESCRIPTION
the command and the arg has to be in quotes, otherwise sbt sees it as two commands