### PR TITLE
adds Nullable annotation to Session methods' return type

### DIFF
--- a/gatling-core-java/src/main/java/io/gatling/javaapi/core/Session.java
+++ b/gatling-core-java/src/main/java/io/gatling/javaapi/core/Session.java
@@ -44,8 +44,7 @@ public final class Session {
    * @param <T> the type of the desired value
    * @return the value if it exists, null otherwise
    */
-  @Nullable
-  public <T> T get(@Nonnull String key) {
+  public <T> @Nullable T get(@Nonnull String key) {
     return wrapped.attributes().getOrElse(key, () -> null);
   }
 

--- a/gatling-core-java/src/main/java/io/gatling/javaapi/core/Session.java
+++ b/gatling-core-java/src/main/java/io/gatling/javaapi/core/Session.java
@@ -44,6 +44,7 @@ public final class Session {
    * @param <T> the type of the desired value
    * @return the value if it exists, null otherwise
    */
+  @Nullable
   public <T> T get(@Nonnull String key) {
     return wrapped.attributes().getOrElse(key, () -> null);
   }

--- a/gatling-core-java/src/main/java/io/gatling/javaapi/core/Session.java
+++ b/gatling-core-java/src/main/java/io/gatling/javaapi/core/Session.java
@@ -21,6 +21,7 @@ import static io.gatling.javaapi.core.internal.Converters.*;
 import io.gatling.javaapi.core.internal.Sessions;
 import java.util.*;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import scala.collection.Seq;
 
 /**
@@ -53,7 +54,7 @@ public final class Session {
    * @param key the storage key
    * @return the value if it exists, null otherwise
    */
-  public String getString(@Nonnull String key) {
+  public @Nullable String getString(@Nonnull String key) {
     Object value = get(key);
     return value != null ? value.toString() : null;
   }
@@ -66,7 +67,7 @@ public final class Session {
    * @throws NumberFormatException if the value is a String that can't be parsed into a int
    * @throws ClassCastException if the value is neither a number nor a String
    */
-  public Integer getIntegerWrapper(@Nonnull String key) {
+  public @Nullable Integer getIntegerWrapper(@Nonnull String key) {
     Object value = get(key);
     if (value instanceof Integer) {
       return (Integer) value;
@@ -109,7 +110,7 @@ public final class Session {
    * @throws NumberFormatException if the value is a String that can't be parsed into a long
    * @throws ClassCastException if the value is neither a number nor a String
    */
-  public Long getLongWrapper(@Nonnull String key) {
+  public @Nullable Long getLongWrapper(@Nonnull String key) {
     Object value = get(key);
     if (value instanceof Integer) {
       return ((Integer) value).longValue();
@@ -156,7 +157,7 @@ public final class Session {
    * @throws NumberFormatException if the value is a String that can't be parsed into a double
    * @throws ClassCastException if the value is neither a number nor a String
    */
-  public Double getDoubleWrapper(@Nonnull String key) {
+  public @Nullable Double getDoubleWrapper(@Nonnull String key) {
     Object value = get(key);
     if (value instanceof Integer) {
       return ((Integer) value).doubleValue();
@@ -207,7 +208,7 @@ public final class Session {
    * @throws NumberFormatException if the value is a String that can't be parsed into a boolean
    * @throws ClassCastException if the value is neither a boolean nor a String
    */
-  public Boolean getBooleanWrapper(@Nonnull String key) {
+  public @Nullable Boolean getBooleanWrapper(@Nonnull String key) {
     Object value = get(key);
     if (value instanceof Boolean) {
       return (Boolean) value;

--- a/src/docs/content/reference/current/core/check/code/CheckSampleKotlin.kt
+++ b/src/docs/content/reference/current/core/check/code/CheckSampleKotlin.kt
@@ -358,7 +358,7 @@ http("").get("")
   jmesPath("foo")
     .validate("MyCustomValidator") { actual, session ->
 
-      val prefix: String = session.getString("prefix")
+      val prefix: String = session.getString("prefix")!!
       if (actual == null) {
         throw NullPointerException("Value is missing")
       } else {

--- a/src/docs/content/reference/current/core/session/function/code/FunctionSampleKotlin.kt
+++ b/src/docs/content/reference/current/core/session/function/code/FunctionSampleKotlin.kt
@@ -19,16 +19,16 @@ import io.gatling.javaapi.core.*
 import io.gatling.javaapi.core.CoreDsl.*
 import io.gatling.javaapi.http.HttpDsl.*
 
-class FunctionSampleJava {
+class FunctionSampleKotlin {
   init {
 //#function
 // inline usage with a Java lamdba
 exec(http("name")
-  .get { session -> "/foo/${session.getString("param").toLowerCase(Locale.getDefault())}" })
+  .get { session -> "/foo/${session.getString("param")!!.toLowerCase(Locale.getDefault())}" })
 
 // passing a reference to a function
 val f =
-  { session: Session -> "/foo/${session.getString("param").toLowerCase(Locale.getDefault())}" }
+  { session: Session -> "/foo/${session.getString("param")!!.toLowerCase(Locale.getDefault())}" }
 exec(http("name").get(f))
 //#function
   }

--- a/src/docs/content/reference/current/core/session/session_api/code/SessionSampleKotlin.kt
+++ b/src/docs/content/reference/current/core/session/session_api/code/SessionSampleKotlin.kt
@@ -60,24 +60,24 @@ val contains = session.contains("key")
 // get an attribute value and cast it
 val string = session.getString("key")
 
-// get an int attribute (will throw if it's null)
+// get an Int attribute (will throw if it's null)
 val primitiveInt = session.getInt("key")
-// get an Integer attribute
+// get an Int? attribute
 val intWrapper = session.getIntegerWrapper("key")
 
-// get a long attribute (will throw if it's null)
+// get a Long attribute (will throw if it's null)
 val primitiveLong = session.getLong("key")
-// get a Long attribute
+// get a Long? attribute
 val longWrapper = session.getLongWrapper("key")
 
-// get a boolean attribute (will throw if it's null)
+// get a Boolean attribute (will throw if it's null)
 val primitiveBoolean = session.getBoolean("key")
-// get a Boolean attribute
+// get a Boolean? attribute
 val booleanWrapper = session.getBooleanWrapper("key")
 
-// get a double attribute (will throw if it's null)
+// get a Double attribute (will throw if it's null)
 val primitiveDouble = session.getDouble("key")
-// get a Double attribute
+// get a Double? attribute
 val doubleWrapper = session.getDoubleWrapper("key")
 
 // get an attribute value and cast it into a List

--- a/src/docs/content/reference/current/core/session/session_api/code/SessionSampleKotlin.kt
+++ b/src/docs/content/reference/current/core/session/session_api/code/SessionSampleKotlin.kt
@@ -87,7 +87,7 @@ val set: Set<MyPojo> = session.getSet("key")
 // get an attribute value and cast it into a Map
 val map: Map<String, MyPojo> = session.getMap("key")
 // get an attribute value and cast it
-val myPojo: MyPojo = session.get("key")
+val myPojoOrNull: MyPojo? = session.get("key")
 //#get
   }
 


### PR DESCRIPTION
Motivation:

Kotlin has nullable types, but it needs annotation from Java code to know if something is nullable.

Modifications:

Return types in the Session API are annotated @Nullable.
Comments in the Kotlin sample use the types as they are called in Kotlin.

Result:

Kotlin compiler now knows the nullability of values.