### PR TITLE
fix: ZonedDate for Gatling EL 'currentDate'

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/session/el/ElCompiler.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/session/el/ElCompiler.scala
@@ -17,7 +17,7 @@
 package io.gatling.core.session.el
 
 import java.{ util => ju }
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
@@ -235,7 +235,7 @@ case object CurrentTimeMillisPart extends ElPart[Long] {
 }
 
 final case class CurrentDateTimePart(format: DateTimeFormatter) extends ElPart[String] {
-  def apply(session: Session): Validation[String] = format.format(LocalDateTime.now()).success
+  def apply(session: Session): Validation[String] = format.format(ZonedDateTime.now()).success
 }
 
 case object RandomSecureUUID extends ElPart[UUID] {

--- a/src/docs/content/reference/current/core/session/el/index.md
+++ b/src/docs/content/reference/current/core/session/el/index.md
@@ -76,7 +76,7 @@ Gatling EL provide the following built-in functions:
 // System.currentTimeMillis
 "#{currentTimeMillis()}"
 
-// LocalDateTime.now() formatted with a java.time.format.DateTimeFormatter pattern
+// ZonedDateTime.now() formatted with a java.time.format.DateTimeFormatter pattern
 "#{currentDate(<pattern>)}"
   
 // unescape an HTML String (entities decoded)


### PR DESCRIPTION
Issue: https://github.com/gatling/gatling/issues/4332

```DateTimeFormatter.ofPattern(pattern).format(LocalDateTime.now())``` doesn't support time zone

Pattern ```EEE MMM dd YYYY HH:mm:ss 'GMT'Z``` will throw ```java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: OffsetSeconds```