### PR TITLE
fix: handle HTTP/2 GOAWAY properly, close #4349

### DIFF
--- a/gatling-http-client/src/main/java/io/gatling/http/client/pool/ChannelPool.java
+++ b/gatling-http-client/src/main/java/io/gatling/http/client/pool/ChannelPool.java
@@ -128,7 +128,10 @@ public class ChannelPool {
       long clientId, String domain, List<InetSocketAddress> addresses) {
     Channel channel =
         coalescingChannelPool.getCoalescedChannel(
-            clientId, domain, addresses, ChannelPool::canOpenStream);
+            clientId,
+            domain,
+            addresses,
+            chan -> ChannelPool.isNotGoAway(chan) && ChannelPool.canOpenStream(chan));
     if (channel != null) {
       LOGGER.debug("Retrieved channel from coalescing pool for domain {}", domain);
     }


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix: handle HTTP/2 GOAWAY properly
### Does this pull request fix one issue?
Try to fixes the issue I submitted: #4349,  in my case, it works. 
Please review that it applies to more case. I hope it's helpful to community.
### Describe how you did it
When poll Coalesced Channel, only the channel that is not CHANNEL_GOAWAY can be poll.
