### PR TITLE
Websocket: fix date format (zoneId)

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/util/package.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/util/package.scala
@@ -17,7 +17,7 @@
 package io.gatling.http
 
 import java.{ lang => jl }
-import java.time.Instant
+import java.time.{ Instant, ZoneId }
 import java.time.format.DateTimeFormatter
 
 import scala.jdk.CollectionConverters._
@@ -34,7 +34,7 @@ import io.netty.handler.codec.http.HttpHeaders
 
 package object util extends LazyLogging {
 
-  private val bufferFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
+  private val bufferFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
 
   implicit class HttpStringBuilder(val buff: jl.StringBuilder) extends AnyVal {
     def appendHttpHeaders(headers: HttpHeaders): jl.StringBuilder = {


### PR DESCRIPTION
I've caught the bug about zoneId for WS buffer. And I have no clue why I didn't catch it when run tests locally 

<img width="1358" alt="image 446" src="https://user-images.githubusercontent.com/22199881/208145981-893e9a94-662d-436c-8a8d-f10008e7b3c2.png">
