### PR TITLE
doc: Update InfluxDB Telegraph Graphite input link

### DIFF
--- a/src/docs/content/guides/realtime_monitoring/index.md
+++ b/src/docs/content/guides/realtime_monitoring/index.md
@@ -56,7 +56,7 @@ gatling.users.(<scenario>|allUsers).(active|waiting|done)"
 
 Please check your tool of choice's documentation, eg:
 * Prometheus' [Graphite Exporter](https://github.com/prometheus/graphite_exporter)
-* InfluxDB Telegraph's [Graphite input](https://docs.influxdata.com/telegraf/v1.20/data_formats/input/graphite/)
+* InfluxDB Telegraph's [Graphite input](https://docs.influxdata.com/telegraf/latest/data_formats/input/graphite/)
 
 {{< alert warning >}}
 As explained in [one of our blog posts](/2018/11/metrics-analysis-part-1-mean-standard-deviation/), Graphite and InfluxDB can't store distributions but only numbers. As a result, only one-second-resolution non-aggregated response time stats are correct.


### PR DESCRIPTION
As mentioned in Issue: https://github.com/gatling/gatling/issues/4371

Acctual version of InfluxDB Telegraph is 1.24 but Documentation refer to 1.20:

https://github.com/gatling/gatling/blob/b4e431758e775a3887bf54d41b2758e9116b49d6/src/docs/content/guides/realtime_monitoring/index.md?plain=1#L59

I wondering if it will be better to set version to `latest`:
https://docs.influxdata.com/telegraf/latest/data_formats/input/graphite/