### PR TITLE
feat: added svg to the ignore static resource list

### DIFF
--- a/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/ui/swing/frame/ConfigurationFrame.scala
@@ -452,6 +452,7 @@ private[swing] class ConfigurationFrame(frontend: RecorderFrontEnd, configuratio
       """.*\.woff2""",
       """.*\.(t|o)tf""",
       """.*\.png""",
+      """.*\.svg""",
       """.*detectportal\.firefox\.com.*"""
     ).foreach(denyListTable.addRow)
 


### PR DESCRIPTION
Could we, also, ignore the svg request as part of the static resource list?