### PR TITLE
spelling mistake in gatling-defaults.conf

### DIFF
--- a/gatling-core/src/main/resources/gatling-defaults.conf
+++ b/gatling-core/src/main/resources/gatling-defaults.conf
@@ -100,7 +100,7 @@ gatling {
     }
   }
   jms {
-    replyTimeoutScanPeriod = 1000  # scan period for timedout reply messages
+    replyTimeoutScanPeriod = 1000  # scan period for timeout reply messages
   }
   data {
     writers = [console, file]      # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite)


### PR DESCRIPTION
it should be "timeout", not "timedout"