### PR TITLE
Update LogFileReader to use PathHelper.deepFiles() in order to find log files in subfolders

### DIFF
--- a/gatling-charts/src/main/scala/io/gatling/charts/stats/LogFileReader.scala
+++ b/gatling-charts/src/main/scala/io/gatling/charts/stats/LogFileReader.scala
@@ -41,7 +41,7 @@ private[gatling] object LogFileReader extends StrictLogging {
 
   def apply(runUuid: String, configuration: GatlingConfiguration): LogFileReader = {
     val inputFiles = PathHelper
-      .files(simulationLogDirectory(runUuid, create = false, configuration))
+      .deepFiles(simulationLogDirectory(runUuid, create = false, configuration))
       .collect { case file if file.filename.matches(SimulationFilesNamePattern) => file.path }
 
     logger.info(s"Collected $inputFiles from $runUuid")


### PR DESCRIPTION
Fixes #4398

Seems to have been introduced after this change, released in 3.9.0:
https://github.com/gatling/gatling/commit/9a12fa054009c69bdea54eb00dcc795a23a13c51#diff-d4b1939befadcbc67fefb00664db270a3b3ceee756226743a7f6bf23164e91cdR43-R45