### PR TITLE
Core: print the actual values in the case of failed assertions

### DIFF
--- a/gatling-app/src/main/scala/io/gatling/app/RunResultProcessor.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/RunResultProcessor.scala
@@ -67,7 +67,10 @@ private final class RunResultProcessor(configuration: GatlingConfiguration) {
 
   private def runStatus(assertionResults: List[AssertionResult]): StatusCode = {
     val consolidatedAssertionResult = assertionResults.foldLeft(true) { (isValid, assertionResult) =>
-      println(s"${assertionResult.message} : ${assertionResult.result}")
+      if (assertionResult.result)
+        println(s"${assertionResult.message} : ${assertionResult.result}")
+      else
+        println(s"${assertionResult.message} : ${assertionResult.result} (actual : ${assertionResult.actualValue.getOrElse(-1.0)})")
       isValid && assertionResult.result
     }
 

--- a/gatling-app/src/main/scala/io/gatling/app/RunResultProcessor.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/RunResultProcessor.scala
@@ -70,7 +70,7 @@ private final class RunResultProcessor(configuration: GatlingConfiguration) {
       if (assertionResult.result)
         println(s"${assertionResult.message} : ${assertionResult.result}")
       else
-        println(s"${assertionResult.message} : ${assertionResult.result} (actual : ${assertionResult.actualValue.getOrElse(-1.0)})")
+        println(s"${assertionResult.message} : ${assertionResult.result} (actual : ${assertionResult.actualValue.getOrElse("-")})")
       isValid && assertionResult.result
     }
 


### PR DESCRIPTION
Hello gatling devs. I have noticed that the console output for a simulation's failed assertions are not including the actual value in `RunResultProcessor`. This is not in line with more formal assertion templates such as `AssertionsJUnitTemplate` or `AssertionsJsonTemplate`.

I request that in the case of a failed assertion the actual value gets included in output printed to stdout, as that output serves as a very useful "executive report" for the simulation. This change would be extra helpful in the case where the actual value is not found in the assert condition's range such as with the `around()`, `between()`, and `deviatesAround()` conditions.

Attaching a screenshot showing assertions produced by `RunResultProcessor` without the actual values present for context.

<img width="566" alt="failed assertion not printing actual value" src="https://user-images.githubusercontent.com/35076933/225434707-f8abdea5-c163-4723-a9a7-dbcf469e02b6.png">