### PR TITLE
Upgrade org.scala-sbt:zinc to 1.9.0 to fix a CVE

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
   private val jmespath                       = "io.burt"                              % "jmespath-jackson"                  % "0.5.1"
   private val boopickle                      = "io.suzaku"                           %% "boopickle"                         % "1.3.3"
   private val redisClient                    = "net.debasishg"                       %% "redisclient"                       % "3.42"
-  private val zinc                           = ("org.scala-sbt"                      %% "zinc"                              % "1.8.1")
+  private val zinc                           = ("org.scala-sbt"                      %% "zinc"                              % "1.9.0")
     .exclude("org.jline", "jline")
     .exclude("org.scala-sbt.jline3", "jline-terminal")
     .exclude("org.jline", "jline-terminal-jna")


### PR DESCRIPTION
I saw a CVE that was being flagged can now be resolved by upgrading the zinc version
Link to CVE details: https://www.mend.io/vulnerability-database/CVE-2022-36944 
Link to Zinc release details: https://github.com/sbt/zinc/releases/tag/v1.9.0
