### PR TITLE
Docs: change links with maven plugin

### DIFF
--- a/src/docs/content/reference/current/extensions/maven_plugin.md
+++ b/src/docs/content/reference/current/extensions/maven_plugin.md
@@ -3,7 +3,7 @@ title: "Maven Plugin"
 description: "How to use the maven plugin for Gatling to run tests and deploy them to Gatling Enterprise."
 lead: "The Maven plugin allows you to run Gatling tests from the command line, without the bundle, as well as to package your simulations for Gatling Enterprise"
 date: 2021-04-20T18:30:56+02:00
-lastmod: 2023-03-09T17:00:00+00:00
+lastmod: 2023-07-26T13:50:00+00:00
 weight: 2080100
 ---
 
@@ -12,7 +12,7 @@ This plugin can also be used to package your Gatling project to run it on [Gatli
 
 ## Versions
 
-Check out available versions on [Maven Central](https://central.sonatype.com/search?q=g%253Aio.gatling%2520a%253Agatling-maven-plugin).
+Check out available versions on [Maven Central](https://central.sonatype.com/search?q=gatling-maven-plugin&namespace=io.gatling).
 
 Beware that milestones (M versions) are not documented for OSS users and are only released for [Gatling Enterprise](https://gatling.io/enterprise/) customers.
 

--- a/src/docs/content/reference/current/extensions/sbt_plugin.md
+++ b/src/docs/content/reference/current/extensions/sbt_plugin.md
@@ -3,7 +3,7 @@ title: "SBT Plugin"
 description: "How to use the sbt plugin for Gatling to run tests and deploy them to Gatling Enterprise."
 lead: "The SBT plugin allows you to run Gatling tests from the command line, without the bundle, as well as to package your simulations for Gatling Enterprise"
 date: 2021-04-20T18:30:56+02:00
-lastmod: 2023-03-09T17:00:00+00:00
+lastmod: 2023-07-26T13:50:00+00:00
 weight: 2080300
 ---
 
@@ -12,7 +12,7 @@ package your Gatling project to run it on [Gatling Enterprise](https://gatling.i
 
 ## Versions
 
-Check out available versions on [Maven Central](https://central.sonatype.com/search?q=g%253Aio.gatling%2520a%253Agatling-sbt).
+Check out available versions on [Maven Central](https://central.sonatype.com/search?q=gatling-sbt&namespace=io.gatling).
 
 Beware that milestones (M versions) are not documented for OSS users and are only released for [Gatling Enterprise](https://gatling.io/enterprise/) customers.
 

--- a/src/docs/content/reference/current/upgrading/2.3-to-3.0.md
+++ b/src/docs/content/reference/current/upgrading/2.3-to-3.0.md
@@ -3,7 +3,7 @@ title: "Upgrading from 2.3 to 3.0"
 description: "Gatling upgrade guide from 2.3 to 3.0"
 lead: ""
 date: 2021-04-20T18:30:56+02:00
-lastmod: 2023-03-09T17:00:00+00:00
+lastmod: 2023-07-26T13:50:00+00:00
 weight: 2090400
 ---
 
@@ -46,6 +46,6 @@ weight: 2090400
 
 ## gatling-maven-plugin
 
-* Maven users must upgrade gatling-maven-plugin to [3.0](https://central.sonatype.com/search?q=g%253Aio.gatling%2520a%253Agatling-maven-plugin).
+* Maven users must upgrade gatling-maven-plugin to [3.0](https://central.sonatype.com/search?q=gatling-maven-plugin&namespace=io.gatling).
 * options' aliases were dropped, use full option names instead
 * Drop deprecated gatling-maven-plugin's `execute` task, use `test` instead


### PR DESCRIPTION
I discovered that there are some links with incorrect or outdated paths.

**Before**:
https://central.sonatype.com/search?q=g%253Aio.gatling%2520a%253Agatling-maven-plugin
 <img width="1512" alt="image 2457" src="https://github.com/gatling/gatling/assets/22199881/2e471a97-8adb-4346-b528-8c60193df2a5">
***
**After**: 
https://central.sonatype.com/search?q=gatling-maven-plugin&namespace=io.gatling
<img width="1512" alt="image 2463" src="https://github.com/gatling/gatling/assets/22199881/37c47ce2-6fec-425a-b0c4-01537edc3377">
