### PR TITLE
HTTP: Fetch prefetch resources

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/fetch/HtmlParser.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/fetch/HtmlParser.scala
@@ -62,6 +62,7 @@ private[gatling] object HtmlParser extends StrictLogging {
   private val HrefAttribute = "href"
   private val IconAttributeName = "icon"
   private val ShortcutIconAttributeName = "shortcut icon"
+  private val PrefetchAttributeName = "prefetch"
   private val RelAttribute = "rel"
   private val SrcAttribute = "src"
   private val StyleAttribute = StyleTagName
@@ -130,6 +131,11 @@ class HtmlParser extends StrictLogging {
                     addResource(tag, HrefAttribute, CssRawResource)
                   case Some(rel)
                       if CharSequenceUtil.equalsIgnoreCase(rel, IconAttributeName) || CharSequenceUtil.equalsIgnoreCase(rel, ShortcutIconAttributeName) =>
+                    addResource(tag, HrefAttribute, RegularRawResource)
+                  case Some(rel)
+                      if CharSequenceUtil.equalsIgnoreCase(rel, PrefetchAttributeName) && tag.getAttributeValue(HrefAttribute).toString.endsWith(".css") =>
+                    addResource(tag, HrefAttribute, CssRawResource)
+                  case Some(rel) if CharSequenceUtil.equalsIgnoreCase(rel, PrefetchAttributeName) =>
                     addResource(tag, HrefAttribute, RegularRawResource)
                   case _ =>
                 }

--- a/gatling-http/src/test/scala/io/gatling/http/fetch/HtmlParserSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/fetch/HtmlParserSpec.scala
@@ -89,4 +89,26 @@ class HtmlParserSpec extends BaseSpec {
 
     embeddedResources("http://example.com/", html) shouldBe empty
   }
+
+  it should "extract prefetch links" in {
+    val html =
+      s"""<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Test page</title>
+          <link href="/resources/test-prefetch.js" rel="prefetch">
+          <link href="/resources/test-prefetch2.css" rel="prefetch">
+        </head>
+        <body>
+          <script src="/resources/app.js"></script>
+        </body>
+      </html>
+      """.toCharArray
+
+    embeddedResources("http://example.com/", html) shouldBe List(
+      BasicResource("http://example.com/resources/test-prefetch.js"),
+      CssResource("http://example.com/resources/test-prefetch2.css"),
+      BasicResource("http://example.com/resources/app.js")
+    )
+  }
 }

--- a/src/docs/content/reference/current/http/protocol/index.md
+++ b/src/docs/content/reference/current/http/protocol/index.md
@@ -301,7 +301,7 @@ The supported resources are:
 
 * `<script>`
 * `<base>`
-* `<link>`
+* `<link>` (including prefetch resources)
 * `<bgsound>`
 * `<frame>`
 * `<iframe>`


### PR DESCRIPTION
This PR adds support to Gatling for fetching prefetch resources in HTML pages (making Gatling a bit more realistic to browsers).

Scala isn't a language I know well, let me know if I've done anything wrong in this PR.

We've also tested this PR in our own performance test and it seems to work for us.