### PR TITLE
doc: add to third party plugins list elasticsearch logger

### DIFF
--- a/src/docs/content/reference/current/extensions/third_parties.md
+++ b/src/docs/content/reference/current/extensions/third_parties.md
@@ -24,6 +24,7 @@ If you run into an issue, please contact their respective owners.
 * [Kafka plugin (Gatling 3.9)](https://github.com/Tinkoff/gatling-kafka-plugin) by Tinkoff
 * [Sftp plugin (Gatling 3.9)](https://github.com/fherbreteau/gatling-sftp) by François Herbreteau
 * [Ftp plugin (Gatling 3.9)](https://github.com/fherbreteau/gatling-ftp) by François Herbreteau
+* [Logger to Elasticsearch (Gatling 3.9)](https://github.com/Amerousful/gatling-elasticsearch-logs) by Pavel Bairov
 
 ### Lagging Gatling Version
 


### PR DESCRIPTION
Hey there!
Do you mind if I add my logger, which parses Gatling's logs and sends them to Elasticsearch, to third-party plugins?
https://github.com/Amerousful/gatling-elasticsearch-logs

