### PR TITLE
doc: fix code examples in Check and failure management chapter

### DIFF
--- a/src/docs/content/tutorials/advanced/code/AdvancedTutorialSampleJava.java
+++ b/src/docs/content/tutorials/advanced/code/AdvancedTutorialSampleJava.java
@@ -134,6 +134,7 @@ ChainBuilder edit =
     .pause(1)
     .exec(http("Post")
       .post("/computers")
+      .formParam("name", "computer xyz")
       .check(status().is(session ->
         200 + java.util.concurrent.ThreadLocalRandom.current().nextInt(2) // 2
       ))

--- a/src/docs/content/tutorials/advanced/code/AdvancedTutorialSampleKotlin.kt
+++ b/src/docs/content/tutorials/advanced/code/AdvancedTutorialSampleKotlin.kt
@@ -125,6 +125,7 @@ val edit =
     .pause(1)
     .exec(http("Post")
       .post("/computers")
+      .formParam("name", "computer xyz")
       .check(status().shouldBe { session ->
         200 + java.util.concurrent.ThreadLocalRandom.current().nextInt(2)
       })

--- a/src/docs/content/tutorials/advanced/code/AdvancedTutorialSampleScala.scala
+++ b/src/docs/content/tutorials/advanced/code/AdvancedTutorialSampleScala.scala
@@ -124,6 +124,7 @@ val edit =
     .pause(1)
     .exec(http("Post")
       .post("/computers")
+      .formParam("name", "computer xyz")
       .check(status.is(session =>
         200 + java.util.concurrent.ThreadLocalRandom.current.nextInt(2) // 2
       ))


### PR DESCRIPTION
Fix the issue where the example code returned with http 400 instead of http 200. Added a now required form parameter, called name to the new a computer POST request.