### PR TITLE
doc: fix documentation url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Gatling is developed in Scala and built upon:
 
 ## Questions, help?
 
-Read the [documentation](https://gatling.io/docs/current/).
+Read the [documentation](https://docs.gatling.io/).
 
 Join the [Gatling Community Forum](https://community.gatling.io).
 


### PR DESCRIPTION
Original link refers to gatling.io/docs/current/ and redirecting to docs.gatling.io/current/ (it is 404 now). Actual docs location is docs.gatling.io