### PR TITLE
HTTP: WebSocket should honour `disableAutoOrigin` flag, close #4585

### DIFF
--- a/gatling-http-client/src/main/java/io/gatling/http/client/impl/WebSocketHandler.java
+++ b/gatling-http-client/src/main/java/io/gatling/http/client/impl/WebSocketHandler.java
@@ -96,7 +96,8 @@ public final class WebSocketHandler extends ChannelDuplexHandler {
                 true, // performMasking
                 false, // allowMaskMismatch
                 -1, // forceCloseTimeoutMillis
-                absoluteUpgradeUrl);
+                absoluteUpgradeUrl,
+                tx.request.isAutoOrigin());
 
         handshaker.handshake(ctx.channel());
 


### PR DESCRIPTION
Fixes #4585