### PR TITLE
chore: Prove jakarta-jms-adapter works

### DIFF
--- a/gatling-jms-java/src/test/java/io/gatling/javaapi/jms/JmsJavaCompileTest.java
+++ b/gatling-jms-java/src/test/java/io/gatling/javaapi/jms/JmsJavaCompileTest.java
@@ -19,6 +19,7 @@ package io.gatling.javaapi.jms;
 import static io.gatling.javaapi.core.CoreDsl.*;
 import static io.gatling.javaapi.jms.JmsDsl.*;
 
+import com.github.marschall.jakartajmsadapter.JakartaConnectionFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.gatling.javaapi.core.ScenarioBuilder;
 import io.gatling.javaapi.core.Simulation;
@@ -50,7 +51,8 @@ public class JmsJavaCompileTest extends Simulation {
   // create JmsProtocol from standard ConnectionFactory
   private final JmsProtocolBuilder jmsProtocol =
       jms.connectionFactory(
-          new org.apache.activemq.ActiveMQConnectionFactory("tcp://localhost:61616"));
+          new JakartaConnectionFactory(
+              new org.apache.activemq.ActiveMQConnectionFactory("tcp://localhost:61616")));
 
   // create JmsProtocol from JNDI based ConnectionFactory
   private JmsProtocolBuilder jmsProtocolWithJndiConnectionFactory =

--- a/gatling-jms/src/test/scala/io/gatling/jms/compile/JmsCompileTest.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/compile/JmsCompileTest.scala
@@ -22,6 +22,7 @@ import io.gatling.core.Predef._
 import io.gatling.jms.Predef._
 import io.gatling.jms.protocol.JmsMessageMatcher
 
+import com.github.marschall.jakartajmsadapter.JakartaConnectionFactory
 import jakarta.jms._
 
 object HeaderMatcher extends JmsMessageMatcher {
@@ -33,7 +34,7 @@ object HeaderMatcher extends JmsMessageMatcher {
 class JmsCompileTest extends Simulation {
   // create JmsProtocol from standard ConnectionFactory
   private val jmsProtocolWithNativeConnectionFactory = jms
-    .connectionFactory(new org.apache.activemq.ActiveMQConnectionFactory("tcp://localhost:61616"))
+    .connectionFactory(new JakartaConnectionFactory(new org.apache.activemq.ActiveMQConnectionFactory("tcp://localhost:61616")))
 
   // create JmsProtocol from JNDI based ConnectionFactory
   private val jmsProtocolWithJndiConnectionFactory = jms

--- a/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsSpec.scala
+++ b/gatling-jms/src/test/scala/io/gatling/jms/integration/JmsSpec.scala
@@ -32,6 +32,7 @@ import io.gatling.jms._
 import io.gatling.jms.protocol.JmsProtocolBuilder
 import io.gatling.jms.request._
 
+import com.github.marschall.jakartajmsadapter.JakartaConnectionFactory
 import jakarta.jms.{ Session => JmsSession, _ }
 import org.apache.activemq.ActiveMQConnectionFactory
 import org.apache.activemq.broker.{ BrokerFactory, BrokerService }
@@ -96,7 +97,7 @@ trait JmsSpec extends ActorSpec with JmsDsl with EmptySession {
     broker.waitUntilStopped()
   }
 
-  val cf = new ActiveMQConnectionFactory("vm://gatling?broker.persistent=false&broker.useJmx=false")
+  val cf = new JakartaConnectionFactory(new ActiveMQConnectionFactory("vm://gatling?broker.persistent=false&broker.useJmx=false"))
 
   implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
   private val jmespath                       = "io.burt"                              % "jmespath-jackson"                  % "0.6.0"
   private val redisClient                    = "net.debasishg"                       %% "redisclient"                       % "3.42"
   private val testInterface                  = "org.scala-sbt"                        % "test-interface"                    % "1.0"
-  private val jmsApi                         = "jakarta.jms"                          % "jakarta.jms-api"                   % "3.1.0"
+  private val jakartaJmsApi                  = "jakarta.jms"                          % "jakarta.jms-api"                   % "3.1.0"
   private val logback                        = "ch.qos.logback"                       % "logback-classic"                   % "1.5.18"
   private val tdigest                        = "com.tdunning"                         % "t-digest"                          % "3.3"
   private val hdrHistogram                   = "org.hdrhistogram"                     % "HdrHistogram"                      % "2.2.1"
@@ -68,7 +68,10 @@ object Dependencies {
   private val scalaTestMockito               = scalaTestScalacheck.organization      %% "mockito-5-12"                      % "3.2.19.0"          % Test
   private val scalaCheck                     = "org.scalacheck"                      %% "scalacheck"                        % "1.18.1"            % Test
   private val mockitoCore                    = "org.mockito"                          % "mockito-core"                      % "5.16.1"            % Test
-  private val activemqBroker                 = "org.apache.activemq"                  % "activemq-broker"                   % "6.1.6"             % Test
+  private val activemqBroker                 = ("org.apache.activemq"                 % "activemq-broker"                   % "5.19.0"            % Test)
+    .exclude("jakarta.jms", "jakarta.jms-api")
+  private val javaxJmsApi                    = "javax.jms"                            % "javax.jms-api"                     % "2.0.1"             % Test
+  private val jakartaJmsAdapter              = "com.github.marschall"                 % "jakarta-jms-adapter"               % "1.5.0"             % Test
   private val h2                             = "com.h2database"                       % "h2"                                % "2.3.232"           % Test
   private val jmh                            = "org.openjdk.jmh"                      % "jmh-core"                          % "1.37"              % Test
 
@@ -184,7 +187,7 @@ object Dependencies {
 
   val httpDependencies = Seq(saxon, xmlresolver, xmlresolverData) ++ testDeps
 
-  val jmsDependencies = Seq(jmsApi, fastUuid, activemqBroker) ++ testDeps
+  val jmsDependencies = Seq(jakartaJmsApi, fastUuid, activemqBroker, javaxJmsApi, jakartaJmsAdapter) ++ testDeps
 
   val jdbcDependencies = h2 +: testDeps
 


### PR DESCRIPTION
Motivation:

Prove that the https://github.com/marschall/jakarta-jms-adapter library works.

Procedure:
* requires Java 17+
* make sure that the javax.jms classes are in the classpath, in particular, deal with clashes between `jakarta.jms-api` 2 (javax) and 3 (jakarta). If the broker was originally pulling `jakarta.jms-api` 2, need to add `javax.jms:javax.jms-api`.
* wrap javax `ConnectionFactory` with `JakartaConnectionFactory`

TODO:

Add procedure to documentation.