### PR TITLE
fix: when serializing SSE events, convert numeric id to number, close #4671

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/action/sse/fsm/ServerSentEvent.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/sse/fsm/ServerSentEvent.scala
@@ -31,7 +31,20 @@ final case class ServerSentEvent(
       sb.append("\"event\":\"").append(value).append("\",")
     }
     id.foreach { value =>
-      sb.append("\"id\":\"").append(value).append("\",")
+      sb.append("\"id\":")
+      val length = value.length
+      if (
+        length > 0 &&
+          value.forall(_.isDigit) &&
+          (length == 1 || value.charAt(0) != '0')
+      ) {
+        // numeric id
+        sb.append(value)
+      } else {
+        // string id
+        sb.append('"').append(value).append('"')
+      }
+      sb.append(',')
     }
     data.foreach { value =>
       sb.append("\"data\":")

--- a/gatling-http/src/test/scala/io/gatling/http/action/sse/fsm/ServerSentEventSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/action/sse/fsm/ServerSentEventSpec.scala
@@ -47,4 +47,40 @@ class ServerSentEventSpec extends AnyFlatSpecLike with Matchers {
       retry = Option(1)
     ).asJsonString shouldBe """{"event":"EVENT","id":"ID","data":"DATA","retry":1}"""
   }
+
+  it should "convert numeric id to number" in {
+    ServerSentEvent(
+      event = Option("EVENT"),
+      data = Option("DATA"),
+      id = Option("77535"),
+      retry = Option(1)
+    ).asJsonString shouldBe """{"event":"EVENT","id":77535,"data":"DATA","retry":1}"""
+  }
+
+  it should "keep non-numeric id as string" in {
+    ServerSentEvent(
+      event = Option("EVENT"),
+      data = Option("DATA"),
+      id = Option("abc123"),
+      retry = Option(1)
+    ).asJsonString shouldBe """{"event":"EVENT","id":"abc123","data":"DATA","retry":1}"""
+  }
+
+  it should "keep id with leading zeros as string" in {
+    ServerSentEvent(
+      event = Option("EVENT"),
+      data = Option("DATA"),
+      id = Option("007"),
+      retry = Option(1)
+    ).asJsonString shouldBe """{"event":"EVENT","id":"007","data":"DATA","retry":1}"""
+  }
+
+  it should "convert single zero id to number" in {
+    ServerSentEvent(
+      event = Option("EVENT"),
+      data = Option("DATA"),
+      id = Option("0"),
+      retry = Option(1)
+    ).asJsonString shouldBe """{"event":"EVENT","id":0,"data":"DATA","retry":1}"""
+  }
 }


### PR DESCRIPTION
Motivation:
Similar to #4670, the `id` field should be serialized as a number when the value is numeric, matching the documentation example.

Changes:
- Detect numeric id values and serialize without quotes
- Handle edge cases: leading zeros kept as string, single "0" as number
- Add tests for numeric, non-numeric, leading zeros, and single zero cases

Note:
The numeric check uses `forall(_.isDigit)` which is a simple character comparison loop with no memory allocation. Given that SSE id values are typically short (a few digits), the overhead is negligible - similar to the existing `charAt` checks for JSON data detection.