### PR TITLE
Upgrade scopt from 3.7.1 to 4.1.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,4 @@
 commits.message = "chore: update ${artifactName} from ${currentVersion} to ${nextVersion}"
 
 updates.pin = [
-  // major API changes
-  { groupId = "com.github.scopt", artifactId="scopt", version="3." }
 ]

--- a/gatling-app/src/main/scala/io/gatling/app/cli/GatlingArgsParser.scala
+++ b/gatling-app/src/main/scala/io/gatling/app/cli/GatlingArgsParser.scala
@@ -58,7 +58,7 @@ private[app] final class GatlingArgsParser(args: Array[String]) {
     }
 
   def parseArguments: Either[GatlingArgs, StatusCode] =
-    if (cliOptsParser.parse(args)) {
+    if (cliOptsParser.parse(args, ()).isDefined) {
       Left(gatlingArgs)
     } else {
       Right(StatusCode.InvalidArguments)

--- a/gatling-recorder/src/main/scala/io/gatling/recorder/cli/RecorderArgsParser.scala
+++ b/gatling-recorder/src/main/scala/io/gatling/recorder/cli/RecorderArgsParser.scala
@@ -47,7 +47,7 @@ private[recorder] final class RecorderArgsParser(args: Array[String]) {
   }
 
   def parseArguments: RecorderArgs =
-    if (cliOptsParser.parse(args)) {
+    if (cliOptsParser.parse(args, ()).isDefined) {
       RecorderArgs(
         simulationsFolder = simulationsFolder.getOrElse(throw new IllegalArgumentException("Missing simulationsFolder")),
         resourcesFolder = resourcesFolder.getOrElse(throw new IllegalArgumentException("Missing resourcesFolder")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
   private val xmlresolverData                = xmlresolver                                           classifier "data"
   private val slf4jApi                       = "org.slf4j"                                                    % "slf4j-api"                % "2.0.17"
   private val cfor                           = "io.github.metarank"                                          %% "cfor"                     % "0.3"
-  private val scopt                          = "com.github.scopt"                                            %% "scopt"                    % "3.7.1"
+  private val scopt                          = "com.github.scopt"                                            %% "scopt"                    % "4.1.0"
   private val scalaLogging                   = "com.typesafe.scala-logging"                                  %% "scala-logging"            % "3.9.6"
   private val jackson                        = "com.fasterxml.jackson.core"                                   % "jackson-databind"         % "2.21.0"
   private val sfm = ("org.simpleflatmapper" % "lightning-csv" % "9.0.2")


### PR DESCRIPTION
## Changes

Upgrade scopt 3.7.1 → 4.1.0. The `Zero` typeclass was removed in 4.x, so the two `parse(args)` call sites become `parse(args, ()).isDefined` (identical semantics). Also removes the Scala Steward 3.x pin.

## Motivation

Projects using scopt 4.x alongside Gatling get `NoClassDefFoundError: scopt/Zero$` at runtime due to version eviction.

## Verified

- `sbt compile` — clean
- `sbt test` — all passing (2 pre-existing HTTP proxy test failures, unrelated)

I don't see dedicated CLI parsing tests in the repo. Happy to run any additional smoke tests you'd recommend — please point me in the right direction.