### PR TITLE
Fix SSE JSON detection with lightweight RFC 8259 validator replacing boundary heuristic [NOT-BREAKING], close #4687

### DIFF
--- a/gatling-core/src/main/scala/io/gatling/core/json/JsonValidator.scala
+++ b/gatling-core/src/main/scala/io/gatling/core/json/JsonValidator.scala
@@ -1,0 +1,466 @@
+/*
+ * Copyright 2011-2026 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.core.json
+
+import java.util
+
+/**
+ * High-performance JSON string validator. Validates JSON syntax per RFC 8259 without building a DOM tree.
+ */
+@SuppressWarnings(Array("org.wartremover.warts.Return"))
+private[gatling] object JsonValidator {
+
+  private final val Threshold: Int = 80
+
+  private final val ArrFirst: Byte = 0
+  private final val ArrNext: Byte = 1
+  private final val ArrAfter: Byte = 2
+  private final val ObjFirst: Byte = 3
+  private final val ObjNext: Byte = 4
+  private final val ObjAfterKey: Byte = 5
+  private final val ObjExpectVal: Byte = 6
+  private final val ObjAfterVal: Byte = 7
+
+  private val SharedHexTable: Array[Byte] = {
+    val table = new Array[Byte](128)
+    util.Arrays.fill(table, -1.toByte)
+    var c = '0'.toInt
+    while (c <= '9') { table(c) = (c - '0').toByte; c += 1 }
+    c = 'a'
+    while (c <= 'f') { table(c) = (c - 'a' + 10).toByte; c += 1 }
+    c = 'A'
+    while (c <= 'F') { table(c) = (c - 'A' + 10).toByte; c += 1 }
+    table
+  }
+
+  def isValid(s: String): Boolean = {
+    if (s == null || s.isEmpty) return false
+    if (s.length < Threshold) PathShort.isValid(s)
+    else PathLong.isValid(s)
+  }
+
+  private object PathShort {
+
+    private final val InitialStackCap: Int = 32
+
+    private final class Ctx(val s: String) {
+      val n: Int = s.length
+      var p: Int = 0
+      var stack: Array[Byte] = new Array[Byte](InitialStackCap)
+      var depth: Int = 0
+    }
+
+    def isValid(s: String): Boolean = {
+      val ctx = new Ctx(s)
+      skipWs(ctx)
+      if (ctx.p >= ctx.n) return false
+
+      val c0 = ch(ctx)
+      if (c0 == '{') {
+        ctx.p += 1; pushState(ctx, ObjFirst)
+      } else if (c0 == '[') {
+        ctx.p += 1; pushState(ctx, ArrFirst)
+      } else {
+        if (!parsePrimitive(ctx)) return false
+        skipWs(ctx); return ctx.p == ctx.n
+      }
+
+      var valid = true
+      while (valid && ctx.depth > 0) {
+        skipWs(ctx)
+        if (ctx.p >= ctx.n) { valid = false }
+        else {
+          val top = ctx.depth - 1
+          val st = ctx.stack(top)
+          if (st <= ArrAfter) valid = handleArray(ctx, top, st)
+          else valid = handleObject(ctx, top, st)
+        }
+      }
+      if (!valid) return false
+      skipWs(ctx); ctx.p == ctx.n
+    }
+
+    private def handleArray(ctx: Ctx, top: Int, st: Byte): Boolean = {
+      if (st == ArrFirst) {
+        if (ch(ctx) == ']') { ctx.p += 1; ctx.depth -= 1; return true }
+        return parseValue(ctx, top, ArrAfter)
+      }
+      if (st == ArrNext) return parseValue(ctx, top, ArrAfter)
+      val c = ch(ctx)
+      if (c == ']') { ctx.p += 1; ctx.depth -= 1; return true }
+      if (c == ',') { ctx.p += 1; ctx.stack(top) = ArrNext; return true }
+      false
+    }
+
+    private def handleObject(ctx: Ctx, top: Int, st: Byte): Boolean = {
+      if (st == ObjFirst) {
+        if (ch(ctx) == '}') { ctx.p += 1; ctx.depth -= 1; return true }
+        if (ch(ctx) != '"' || !parseString(ctx)) return false
+        ctx.stack(top) = ObjAfterKey; return true
+      }
+      if (st == ObjNext) {
+        if (ch(ctx) != '"' || !parseString(ctx)) return false
+        ctx.stack(top) = ObjAfterKey; return true
+      }
+      if (st == ObjAfterKey) {
+        if (ch(ctx) != ':') return false
+        ctx.p += 1; ctx.stack(top) = ObjExpectVal; return true
+      }
+      if (st == ObjExpectVal) return parseValue(ctx, top, ObjAfterVal)
+      val c = ch(ctx)
+      if (c == '}') { ctx.p += 1; ctx.depth -= 1; return true }
+      if (c == ',') { ctx.p += 1; ctx.stack(top) = ObjNext; return true }
+      false
+    }
+
+    private def parseValue(ctx: Ctx, top: Int, afterState: Byte): Boolean = {
+      val c = ch(ctx)
+      if (c == '{') { ctx.stack(top) = afterState; ctx.p += 1; pushState(ctx, ObjFirst); return true }
+      if (c == '[') { ctx.stack(top) = afterState; ctx.p += 1; pushState(ctx, ArrFirst); return true }
+      if (parsePrimitive(ctx)) { ctx.stack(top) = afterState; return true }
+      false
+    }
+
+    private def skipWs(ctx: Ctx): Unit =
+      while (ctx.p < ctx.n) {
+        (ch(ctx): @scala.annotation.switch) match {
+          case ' ' | '\n' | '\r' | '\t' => ctx.p += 1
+          case _                        => return
+        }
+      }
+
+    private def pushState(ctx: Ctx, state: Byte): Unit = {
+      if (ctx.depth == ctx.stack.length) {
+        ctx.stack = util.Arrays.copyOf(ctx.stack, ctx.depth + InitialStackCap)
+      }
+      ctx.stack(ctx.depth) = state; ctx.depth += 1
+    }
+
+    private def parsePrimitive(ctx: Ctx): Boolean = {
+      val c = ch(ctx)
+      if (c == '"') return parseString(ctx)
+      if (c == 't') return parseLiteral(ctx, 'r', 'u', 'e', 4)
+      if (c == 'f') return parseLiteral(ctx, 'a', 'l', 's', 5)
+      if (c == 'n') return parseLiteral(ctx, 'u', 'l', 'l', 4)
+      if (c == '-' || (c >= '0' && c <= '9')) return parseNumber(ctx)
+      false
+    }
+
+    private def parseLiteral(ctx: Ctx, c1: Char, c2: Char, c3: Char, len: Int): Boolean = {
+      if (ctx.p + len > ctx.n) return false
+      if (ch(ctx, 1) != c1 || ch(ctx, 2) != c2 || ch(ctx, 3) != c3) return false
+      if (len == 5 && ch(ctx, 4) != 'e') return false
+      ctx.p += len; true
+    }
+
+    private def parseString(ctx: Ctx): Boolean = {
+      ctx.p += 1
+      while (ctx.p < ctx.n) {
+        var brk = false
+        while (!brk && ctx.p < ctx.n) {
+          val c = ch(ctx)
+          if (c == '"' || c == '\\' || c < 0x20) brk = true
+          else ctx.p += 1
+        }
+        if (ctx.p >= ctx.n) return false
+
+        val c = ch(ctx)
+        if (c == '"') { ctx.p += 1; return true }
+        if (c == '\\') {
+          ctx.p += 1
+          if (ctx.p >= ctx.n) return false
+          val e = ch(ctx)
+          if (
+            e == '"' || e == '\\' || e == '/' || e == 'b' ||
+            e == 'f' || e == 'n' || e == 'r' || e == 't'
+          ) {
+            ctx.p += 1
+          } else if (e == 'u') {
+            ctx.p += 1
+            val cp = parseUnicodeEscape(ctx)
+            if (cp < 0) return false
+            if (cp >= 0xd800 && cp <= 0xdbff) {
+              if (ctx.p + 1 >= ctx.n || ch(ctx) != '\\' || ch(ctx, 1) != 'u') return false
+              ctx.p += 2
+              val lo = parseUnicodeEscape(ctx)
+              if (lo < 0xdc00 || lo > 0xdfff) return false
+            } else if (cp >= 0xdc00 && cp <= 0xdfff) return false
+          } else return false
+        } else {
+          if (c < 0x20) return false
+          ctx.p += 1
+        }
+      }
+      false
+    }
+
+    private def parseUnicodeEscape(ctx: Ctx): Int = {
+      if (ctx.p + 4 > ctx.n) return -1
+      var v = 0; var i = 0
+      while (i < 4) {
+        val c = ch(ctx, i)
+        val h =
+          if (c >= '0' && c <= '9') c - '0'
+          else if (c >= 'a' && c <= 'f') c - 'a' + 10
+          else if (c >= 'A' && c <= 'F') c - 'A' + 10
+          else return -1
+        v = (v << 4) | h; i += 1
+      }
+      ctx.p += 4; v
+    }
+
+    private def parseNumber(ctx: Ctx): Boolean = {
+      if (ch(ctx) == '-') { ctx.p += 1; if (ctx.p >= ctx.n) return false }
+      val c0 = ch(ctx)
+      if (c0 == '0') {
+        ctx.p += 1
+        if (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') return false
+      } else if (c0 >= '1' && c0 <= '9') {
+        ctx.p += 1
+        while (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') ctx.p += 1
+      } else return false
+
+      if (ctx.p < ctx.n && ch(ctx) == '.') {
+        ctx.p += 1
+        if (ctx.p >= ctx.n || ch(ctx) < '0' || ch(ctx) > '9') return false
+        ctx.p += 1
+        while (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') ctx.p += 1
+      }
+      if (ctx.p < ctx.n && (ch(ctx) == 'e' || ch(ctx) == 'E')) {
+        ctx.p += 1
+        if (ctx.p >= ctx.n) return false
+        if (ch(ctx) == '+' || ch(ctx) == '-') { ctx.p += 1; if (ctx.p >= ctx.n) return false }
+        if (ch(ctx) < '0' || ch(ctx) > '9') return false
+        ctx.p += 1
+        while (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') ctx.p += 1
+      }
+      true
+    }
+
+    @inline private def ch(ctx: Ctx): Char = ctx.s.charAt(ctx.p)
+    @inline private def ch(ctx: Ctx, offset: Int): Char = ctx.s.charAt(ctx.p + offset)
+  }
+
+  private object PathLong {
+
+    private final val InitialStackCap: Int = 24
+    private val HexTable: Array[Byte] = SharedHexTable
+
+    private val TlBuf: ThreadLocal[Array[Char]] =
+      ThreadLocal.withInitial[Array[Char]](() => new Array[Char](4096))
+
+    private final class Ctx(s: String) {
+      val n: Int = s.length
+      val buf: Array[Char] = acquireBuffer(n)
+      var p: Int = 0
+      var stack: Array[Byte] = new Array[Byte](InitialStackCap)
+      var depth: Int = 0
+      s.getChars(0, n, buf, 0)
+    }
+
+    def isValid(s: String): Boolean = {
+      val ctx = new Ctx(s)
+      skipWs(ctx)
+      if (ctx.p >= ctx.n) return false
+
+      val c0 = ch(ctx)
+      if (c0 == '{') {
+        ctx.p += 1; pushState(ctx, ObjFirst)
+      } else if (c0 == '[') {
+        ctx.p += 1; pushState(ctx, ArrFirst)
+      } else {
+        if (!parsePrimitive(ctx)) return false
+        skipWs(ctx); return ctx.p == ctx.n
+      }
+
+      var valid = true
+      while (valid && ctx.depth > 0) {
+        skipWs(ctx)
+        if (ctx.p >= ctx.n) { valid = false }
+        else {
+          val top = ctx.depth - 1
+          val st = ctx.stack(top)
+          if (st <= ArrAfter) valid = handleArray(ctx, top, st)
+          else valid = handleObject(ctx, top, st)
+        }
+      }
+      if (!valid) return false
+      skipWs(ctx); ctx.p == ctx.n
+    }
+
+    private def handleArray(ctx: Ctx, top: Int, st: Byte): Boolean = {
+      if (st == ArrFirst) {
+        if (ch(ctx) == ']') { ctx.p += 1; ctx.depth -= 1; return true }
+        return parseValue(ctx, top, ArrAfter)
+      }
+      if (st == ArrNext) return parseValue(ctx, top, ArrAfter)
+      val c = ch(ctx)
+      if (c == ']') { ctx.p += 1; ctx.depth -= 1; return true }
+      if (c == ',') { ctx.p += 1; ctx.stack(top) = ArrNext; return true }
+      false
+    }
+
+    private def handleObject(ctx: Ctx, top: Int, st: Byte): Boolean = {
+      if (st == ObjFirst) {
+        if (ch(ctx) == '}') { ctx.p += 1; ctx.depth -= 1; return true }
+        if (ch(ctx) != '"' || !parseString(ctx)) return false
+        ctx.stack(top) = ObjAfterKey; return true
+      }
+      if (st == ObjNext) {
+        if (ch(ctx) != '"' || !parseString(ctx)) return false
+        ctx.stack(top) = ObjAfterKey; return true
+      }
+      if (st == ObjAfterKey) {
+        if (ch(ctx) != ':') return false
+        ctx.p += 1; ctx.stack(top) = ObjExpectVal; return true
+      }
+      if (st == ObjExpectVal) return parseValue(ctx, top, ObjAfterVal)
+      val c = ch(ctx)
+      if (c == '}') { ctx.p += 1; ctx.depth -= 1; return true }
+      if (c == ',') { ctx.p += 1; ctx.stack(top) = ObjNext; return true }
+      false
+    }
+
+    private def parseValue(ctx: Ctx, top: Int, afterState: Byte): Boolean = {
+      val c = ch(ctx)
+      if (c == '{') { ctx.stack(top) = afterState; ctx.p += 1; pushState(ctx, ObjFirst); return true }
+      if (c == '[') { ctx.stack(top) = afterState; ctx.p += 1; pushState(ctx, ArrFirst); return true }
+      if (parsePrimitive(ctx)) { ctx.stack(top) = afterState; return true }
+      false
+    }
+
+    private def skipWs(ctx: Ctx): Unit =
+      while (ctx.p < ctx.n) {
+        (ch(ctx): @scala.annotation.switch) match {
+          case ' ' | '\n' | '\r' | '\t' => ctx.p += 1
+          case _                        => return
+        }
+      }
+
+    private def pushState(ctx: Ctx, state: Byte): Unit = {
+      if (ctx.depth == ctx.stack.length) {
+        ctx.stack = util.Arrays.copyOf(ctx.stack, ctx.depth + InitialStackCap)
+      }
+      ctx.stack(ctx.depth) = state; ctx.depth += 1
+    }
+
+    private def parsePrimitive(ctx: Ctx): Boolean = {
+      val c = ch(ctx)
+      if (c == '"') return parseString(ctx)
+      if (c == 't') return parseLiteral(ctx, 'r', 'u', 'e', 4)
+      if (c == 'f') return parseLiteral(ctx, 'a', 'l', 's', 5)
+      if (c == 'n') return parseLiteral(ctx, 'u', 'l', 'l', 4)
+      if (c == '-' || (c >= '0' && c <= '9')) return parseNumber(ctx)
+      false
+    }
+
+    private def parseLiteral(ctx: Ctx, c1: Char, c2: Char, c3: Char, len: Int): Boolean = {
+      if (ctx.p + len > ctx.n) return false
+      if (ch(ctx, 1) != c1 || ch(ctx, 2) != c2 || ch(ctx, 3) != c3) return false
+      if (len == 5 && ch(ctx, 4) != 'e') return false
+      ctx.p += len; true
+    }
+
+    private def parseString(ctx: Ctx): Boolean = {
+      ctx.p += 1
+      while (ctx.p < ctx.n) {
+        val c = ch(ctx)
+        if (c == '"') { ctx.p += 1; return true }
+        if (c == '\\') {
+          ctx.p += 1
+          if (ctx.p >= ctx.n) return false
+          val e = ch(ctx)
+          if (
+            e == '"' || e == '\\' || e == '/' || e == 'b' ||
+            e == 'f' || e == 'n' || e == 'r' || e == 't'
+          ) {
+            ctx.p += 1
+          } else if (e == 'u') {
+            ctx.p += 1
+            val cp = parseUnicodeEscape(ctx)
+            if (cp < 0) return false
+            if (cp >= 0xd800 && cp <= 0xdbff) {
+              if (ctx.p + 1 >= ctx.n || ch(ctx) != '\\' || ch(ctx, 1) != 'u') return false
+              ctx.p += 2
+              val lo = parseUnicodeEscape(ctx)
+              if (lo < 0xdc00 || lo > 0xdfff) return false
+            } else if (cp >= 0xdc00 && cp <= 0xdfff) return false
+          } else return false
+        } else {
+          if (c < 0x20) return false
+          ctx.p += 1
+        }
+      }
+      false
+    }
+
+    private def parseUnicodeEscape(ctx: Ctx): Int = {
+      if (ctx.p + 4 > ctx.n) return -1
+      val ht = HexTable
+      var v = 0; var i = 0
+      while (i < 4) {
+        val c = ch(ctx, i)
+        if (c >= ht.length) return -1
+        val h = ht(c)
+        if (h < 0) return -1
+        v = (v << 4) | h; i += 1
+      }
+      ctx.p += 4; v
+    }
+
+    private def parseNumber(ctx: Ctx): Boolean = {
+      if (ch(ctx) == '-') { ctx.p += 1; if (ctx.p >= ctx.n) return false }
+      val c0 = ch(ctx)
+      if (c0 == '0') {
+        ctx.p += 1
+        if (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') return false
+      } else if (c0 >= '1' && c0 <= '9') {
+        ctx.p += 1
+        while (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') ctx.p += 1
+      } else return false
+
+      if (ctx.p < ctx.n && ch(ctx) == '.') {
+        ctx.p += 1
+        if (ctx.p >= ctx.n || ch(ctx) < '0' || ch(ctx) > '9') return false
+        ctx.p += 1
+        while (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') ctx.p += 1
+      }
+      if (ctx.p < ctx.n && (ch(ctx) == 'e' || ch(ctx) == 'E')) {
+        ctx.p += 1
+        if (ctx.p >= ctx.n) return false
+        if (ch(ctx) == '+' || ch(ctx) == '-') { ctx.p += 1; if (ctx.p >= ctx.n) return false }
+        if (ch(ctx) < '0' || ch(ctx) > '9') return false
+        ctx.p += 1
+        while (ctx.p < ctx.n && ch(ctx) >= '0' && ch(ctx) <= '9') ctx.p += 1
+      }
+      true
+    }
+
+    private def acquireBuffer(required: Int): Array[Char] = {
+      var buf = TlBuf.get()
+      if (buf.length >= required) return buf
+      var cap = buf.length
+      while (cap < required) cap <<= 1
+      buf = new Array[Char](cap)
+      TlBuf.set(buf)
+      buf
+    }
+
+    @inline private def ch(ctx: Ctx): Char = ctx.buf(ctx.p)
+    @inline private def ch(ctx: Ctx, offset: Int): Char = ctx.buf(ctx.p + offset)
+  }
+}

--- a/gatling-core/src/test/scala/io/gatling/core/json/JsonValidatorSpec.scala
+++ b/gatling-core/src/test/scala/io/gatling/core/json/JsonValidatorSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2011-2026 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.core.json
+
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class JsonValidatorSpec extends AnyFlatSpecLike with Matchers {
+
+  "isValid" should "accept a JSON object" in {
+    JsonValidator.isValid("{}") shouldBe true
+    JsonValidator.isValid("""{"key":"value"}""") shouldBe true
+    JsonValidator.isValid("""{"a":1,"b":true,"c":null}""") shouldBe true
+  }
+
+  it should "accept a JSON array" in {
+    JsonValidator.isValid("[]") shouldBe true
+    JsonValidator.isValid("[1,2,3]") shouldBe true
+    JsonValidator.isValid("""["foo","bar"]""") shouldBe true
+  }
+
+  it should "accept JSON primitives" in {
+    JsonValidator.isValid(""""hello"""") shouldBe true
+    JsonValidator.isValid("42") shouldBe true
+    JsonValidator.isValid("-3.14") shouldBe true
+    JsonValidator.isValid("1e10") shouldBe true
+    JsonValidator.isValid("true") shouldBe true
+    JsonValidator.isValid("false") shouldBe true
+    JsonValidator.isValid("null") shouldBe true
+  }
+
+  it should "accept nested structures" in {
+    JsonValidator.isValid("""{"a":{"b":[1,2]}}""") shouldBe true
+    JsonValidator.isValid("""[{"x":1},{"x":2}]""") shouldBe true
+  }
+
+  it should "accept values with surrounding whitespace" in {
+    JsonValidator.isValid("  { }  ") shouldBe true
+    JsonValidator.isValid(" [ 1 , 2 ] ") shouldBe true
+  }
+
+  it should "accept inputs longer than 80 characters (PathLong path)" in {
+    val longJson = """{"description":"this is a long string value that exceeds the threshold for the long path in the validator"}"""
+    longJson.length should be > 80
+    JsonValidator.isValid(longJson) shouldBe true
+  }
+
+  it should "reject null input" in {
+    JsonValidator.isValid(null) shouldBe false
+  }
+
+  it should "reject an empty string" in {
+    JsonValidator.isValid("") shouldBe false
+  }
+
+  it should "reject a bare unquoted word" in {
+    JsonValidator.isValid("hello") shouldBe false
+  }
+
+  it should "reject an object with unquoted keys" in {
+    JsonValidator.isValid("{invalid}") shouldBe false
+    JsonValidator.isValid("{key:1}") shouldBe false
+  }
+
+  it should "reject an array with unquoted string elements" in {
+    JsonValidator.isValid("[invalid]") shouldBe false
+  }
+
+  it should "reject truncated JSON" in {
+    JsonValidator.isValid("{") shouldBe false
+    JsonValidator.isValid("[") shouldBe false
+    JsonValidator.isValid("""{"key":""") shouldBe false
+  }
+
+  it should "reject a string with an unterminated escape sequence" in {
+    JsonValidator.isValid(""""bad\\""") shouldBe false
+  }
+}

--- a/gatling-http/src/main/scala/io/gatling/http/action/sse/fsm/ServerSentEvent.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/sse/fsm/ServerSentEvent.scala
@@ -16,7 +16,7 @@
 
 package io.gatling.http.action.sse.fsm
 
-import io.gatling.core.json.Json
+import io.gatling.core.json.{ Json, JsonValidator }
 import io.gatling.shared.util.StringBuilderPool
 
 final case class ServerSentEvent(
@@ -35,15 +35,7 @@ final case class ServerSentEvent(
     }
     data.foreach { value =>
       sb.append("\"data\":")
-      val length = value.length
-      if (
-        length > 1 && (
-          // JSON object
-          (value.charAt(0) == '{' && value.charAt(length - 1) == '}') ||
-            // JSON array
-            (value.charAt(0) == '[' && value.charAt(length - 1) == ']')
-        )
-      ) {
+      if (JsonValidator.isValid(value)) {
         sb.append(value)
       } else {
         sb.append('"').append(Json.stringify(value, isRootObject = true)).append('"')

--- a/gatling-http/src/test/scala/io/gatling/http/action/sse/fsm/ServerSentEventSpec.scala
+++ b/gatling-http/src/test/scala/io/gatling/http/action/sse/fsm/ServerSentEventSpec.scala
@@ -47,4 +47,49 @@ class ServerSentEventSpec extends AnyFlatSpecLike with Matchers {
       retry = Option(1)
     ).asJsonString shouldBe """{"event":"EVENT","id":"ID","data":"DATA","retry":1}"""
   }
+
+  it should "escape data that looks like JSON but is invalid" in {
+    ServerSentEvent(
+      event = None,
+      data = Option("{invalid}"),
+      id = None,
+      retry = None
+    ).asJsonString shouldBe """{"data":"{invalid}"}"""
+  }
+
+  it should "escape data that looks like JSON Array but is invalid" in {
+    ServerSentEvent(
+      event = None,
+      data = Option("[invalid]"),
+      id = None,
+      retry = None
+    ).asJsonString shouldBe """{"data":"[invalid]"}"""
+  }
+
+  it should "inject JSON primitive string data as escaped string" in {
+    ServerSentEvent(
+      event = None,
+      data = Option(""""hello""""),
+      id = None,
+      retry = None
+    ).asJsonString shouldBe """{"data":"hello"}"""
+  }
+
+  it should "inject JSON primitive number data as-is" in {
+    ServerSentEvent(
+      event = None,
+      data = Option("42"),
+      id = None,
+      retry = None
+    ).asJsonString shouldBe """{"data":42}"""
+  }
+
+  it should "inject JSON primitive boolean data as-is" in {
+    ServerSentEvent(
+      event = None,
+      data = Option("true"),
+      id = None,
+      retry = None
+    ).asJsonString shouldBe """{"data":true}"""
+  }
 }


### PR DESCRIPTION
> Replaces #4688 with cleaner commit history.

### Motivation

Fixes #4687

`ServerSentEvent.asJsonString` determines whether the `data` field contains JSON by checking only the first and last characters (`{}`/`[]`):

```scala
val length = value.length
if (
  length > 1 && (
    (value.charAt(0) == '{' && value.charAt(length - 1) == '}') ||
      (value.charAt(0) == '[' && value.charAt(length - 1) == ']')
  )
)
```

This causes two categories of failure:

1. **False positives** — Strings that happen to start and end with `{}`/`[]` (e.g., `{Title}`, `[Silence] is often louder than words: [screaming]`) are injected as raw broken JSON into the serialized output, corrupting the entire message and making it unparseable by `jmesPath`.

2. **False negatives** — Valid JSON primitives defined by RFC 8259 §2 (numbers like `42`, booleans like `true`, strings like `"hello"`, and `null`) are never recognized because the heuristic only looks for `{}`/`[]` boundaries. These values get double-escaped as strings instead of being embedded as-is.

## Why a custom validator is acceptable overhead

The natural fix is to run a proper JSON validator on every incoming SSE `data` value. However, for a load testing tool where SSE messages arrive at high frequency, the overhead of validation matters.

Key observations:

- When Gatling determines that `data` is **not** JSON, it calls `Json.stringify()` to escape the entire string. This means `stringify()` represents the **overhead upper bound** that Gatling already accepts for non-JSON data.
- Before #4670, `stringify()` was called on **every** SSE message unconditionally — meaning the per-message cost of `stringify()` was already accepted across the board, not just for non-JSON data.

I benchmarked six JVM JSON libraries (Jackson, Gson, org.json, JSON-P, Moshi, Networknt) against `stringify()` and found that all of them are slower — Jackson being the fastest among them. This is expected, since these are general-purpose libraries not optimized solely for validation. So I built [Validason](https://github.com/kyu4583/validason), a Java library focused exclusively on JSON string validation, and verified that `Validason.isValid()` is **equal to or faster than** `stringify()` — the very overhead Gatling already accepts. The [Validason repository](https://github.com/kyu4583/validason) documents the full benchmark methodology, results, and accuracy verification against [JSONTestSuite](https://github.com/nst/JSONTestSuite) (100% accuracy, 283/283 cases).

### Avoiding an external dependency: porting Validason to Scala

**Rather than adding Validason as an external dependency, this PR inlines a Scala port of its core logic directly into `gatling-core` as `JsonValidator`.** A separate benchmark confirmed that the Scala port preserves the same performance characteristics.

Benchmark result in Scala:
<img width="1934" height="885" alt="Image" src="https://github.com/user-attachments/assets/90b2a860-18eb-4de6-bcbb-332b7f103426" />
The benchmark methodology is the same as documented in the [Validason repository](https://github.com/kyu4583/validason).


## Changes

**`gatling-core/src/main/scala/io/gatling/core/json/JsonValidator.scala`** (new):
- Lightweight RFC 8259 syntax validator that checks JSON validity without building a DOM tree
- Two internal paths: `PathShort` for strings < 80 chars (operates on `String.charAt` directly), `PathLong` for longer strings (bulk-copies to `char[]` for cache-friendly sequential access)
- Handles all JSON value types: objects, arrays, strings (with full unicode escape and surrogate pair validation), numbers, booleans, `null`

**`gatling-core/src/test/scala/io/gatling/core/json/JsonValidatorSpec.scala`** (new):
- Unit tests for `JsonValidator.isValid` covering valid JSON (objects, arrays, primitives, nested structures, whitespace), invalid JSON (null, empty, bare words, unquoted keys, truncated input), and the PathLong code path (inputs exceeding 80 characters)

**`gatling-http/src/main/scala/io/gatling/http/action/sse/fsm/ServerSentEvent.scala`**:
- Replace the `charAt(0)`/`charAt(length-1)` heuristic with `JsonValidator.isValid(value)`

**`gatling-http/src/test/scala/io/gatling/http/action/sse/fsm/ServerSentEventSpec.scala`**:
- Add tests for invalid JSON that superficially matches `{}`/`[]` boundaries (`{invalid}`, `[invalid]`)
- Add tests for JSON primitives: string (`"hello"`), number (`42`), boolean (`true`)

## Before / After

Same simulation as the linked issue:

**Before** (5 of 7 data checks fail):
```text
---- Requests -----------------------------------------------|---Total---|-----OK----|----KO----
> Global                                                     |         9 |         4 |         5
> Open SSE connection                                        |         1 |         1 |         0
> json-object check                                          |         1 |         1 |         0
> json-array check                                           |         1 |         1 |         0
> invalid-json check                                         |         1 |         0 |         1
> invalid-json-array check                                   |         1 |         0 |         1
> json-number check                                          |         1 |         0 |         1
> json-bool check                                            |         1 |         0 |         1
> json-string check                                          |         1 |         0 |         1
> Close SSE connection                                       |         1 |         1 |         0
```

**After** (all checks pass):
```text
---- Requests -----------------------------------------------|---Total---|-----OK----|----KO----
> Global                                                     |         9 |         9 |         0
> Open SSE connection                                        |         1 |         1 |         0
> json-object check                                          |         1 |         1 |         0
> json-array check                                           |         1 |         1 |         0
> invalid-json check                                         |         1 |         1 |         0
> invalid-json-array check                                   |         1 |         1 |         0
> json-number check                                          |         1 |         1 |         0
> json-bool check                                            |         1 |         1 |         0
> json-string check                                          |         1 |         1 |         0
> Close SSE connection                                       |         1 |         1 |         0
```