### PR TITLE
fix: categorize WebSocket traffic logs like HTTP (DEBUG failures, TRACE all)

### DIFF
--- a/gatling-core/src/main/resources/logback.dummy
+++ b/gatling-core/src/main/resources/logback.dummy
@@ -8,12 +8,12 @@
 		<immediateFlush>false</immediateFlush>
 	</appender>
 
-	<!-- uncomment and set to DEBUG to log all failing HTTP requests -->
-	<!-- uncomment and set to TRACE to log all HTTP requests -->
+	<!-- uncomment and set to DEBUG to log failing HTTP and WebSocket requests -->
+	<!-- uncomment and set to TRACE to log all HTTP and WebSocket requests -->
 	<!--<logger name="io.gatling.http.engine.response" level="TRACE" />-->
 
-	<!-- uncomment to log WebSocket events -->
-    <!--<logger name="io.gatling.http.action.ws.fsm" level="DEBUG" />-->
+	<!-- uncomment and set to TRACE to log WebSocket FSM events (connect/send/receive state machine) -->
+    <!--<logger name="io.gatling.http.action.ws.fsm" level="TRACE" />-->
 
 	<!-- uncomment to log SSE events -->
     <!--<logger name="io.gatling.http.action.sse.fsm" level="DEBUG" />-->

--- a/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsFsm.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsFsm.scala
@@ -55,6 +55,7 @@ final class WsFsm(
   private[fsm] def scheduleTimeout(dur: FiniteDuration): Unit = {
     currentTimeout = eventLoop.schedule(
       () => {
+        // timeout fired (often a failed check) — keep at DEBUG for troubleshooting
         logger.debug(s"Timeout ${currentTimeout.hashCode} triggered")
         currentTimeout = null
         execute(currentState.onTimeout())
@@ -62,17 +63,18 @@ final class WsFsm(
       dur.toMillis,
       TimeUnit.MILLISECONDS
     )
-    logger.debug(s"Timeout ${currentTimeout.hashCode} scheduled")
+    // high-volume lifecycle noise — TRACE so DEBUG can stay reserved for failures / dumps
+    logger.trace(s"Timeout ${currentTimeout.hashCode} scheduled")
   }
 
   private[fsm] def cancelTimeout(): Unit =
     if (currentTimeout == null) {
-      logger.debug("Couldn't cancel timeout because it wasn't set")
+      logger.trace("Couldn't cancel timeout because it wasn't set")
     } else {
       if (currentTimeout.cancel(true)) {
-        logger.debug(s"Timeout ${currentTimeout.hashCode} cancelled")
+        logger.trace(s"Timeout ${currentTimeout.hashCode} cancelled")
       } else {
-        logger.debug(s"Failed to cancel timeout ${currentTimeout.hashCode}")
+        logger.trace(s"Failed to cancel timeout ${currentTimeout.hashCode}")
       }
       currentTimeout = null
     }

--- a/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsIdleState.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsIdleState.scala
@@ -40,16 +40,17 @@ final class WsIdleState(fsm: WsFsm, session: Session, webSocket: WebSocket, prot
       session: Session,
       next: Action
   ): NextWsState = {
-    logger.debug(s"Send text frame $actionName $message")
+    // outbound traffic: TRACE at send time (DEBUG reserved for failed checks via WsLogger)
+    logger.trace(s"Send text frame $actionName $message")
     // actually send message!
     val now = clock.nowMillis
     webSocket.sendFrame(new TextWebSocketFrame(message))
-    fsm.wsLogger.logOk(actionName, session, Some(message))
     statsEngine.logResponse(session.scenario, session.groups, actionName, now, now, OK, None, None)
 
     checkSequences match {
       case WsFrameCheckSequence(timeout, currentCheck :: remainingChecks) :: remainingCheckSequences =>
-        logger.debug("Trigger check after sending text frame")
+        // retain outbound for later DEBUG/TRACE dump with check outcome; do not log OK yet
+        logger.trace("Trigger check after sending text frame")
         scheduleTimeout(timeout)
         // [e]
         //
@@ -71,6 +72,8 @@ final class WsIdleState(fsm: WsFsm, session: Session, webSocket: WebSocket, prot
         )
 
       case _ =>
+        // no check: TRACE dump of the outbound message only
+        fsm.wsLogger.logOk(actionName, session, Some(message))
         // same as Nil as WsFrameCheckSequence#checks can't be Nil, but compiler complains that match may not be exhaustive
         NextWsState(this, () => next ! session)
     }
@@ -83,18 +86,19 @@ final class WsIdleState(fsm: WsFsm, session: Session, webSocket: WebSocket, prot
       session: Session,
       next: Action
   ): NextWsState = {
-    logger.debug(s"Send binary frame $actionName length=${message.length}")
+    // outbound traffic: TRACE at send time (DEBUG reserved for failed checks via WsLogger)
+    logger.trace(s"Send binary frame $actionName length=${message.length}")
     // actually send message!
     val now = clock.nowMillis
     webSocket.sendFrame(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(message)))
     val requestMessage =
       if (HttpTracing.IS_HTTP_DEBUG_ENABLED) Some(s"<<<BINARY CONTENT length=${message.length}>>>") else None
-    fsm.wsLogger.logOk(actionName, session, requestMessage)
     statsEngine.logResponse(session.scenario, session.groups, actionName, now, now, OK, None, None)
 
     checkSequences match {
       case WsFrameCheckSequence(timeout, currentCheck :: remainingChecks) :: remainingCheckSequences =>
-        logger.debug("Trigger check after sending binary frame")
+        // retain outbound for later DEBUG/TRACE dump with check outcome; do not log OK yet
+        logger.trace("Trigger check after sending binary frame")
         scheduleTimeout(timeout)
         // [e]
         //
@@ -116,6 +120,8 @@ final class WsIdleState(fsm: WsFsm, session: Session, webSocket: WebSocket, prot
         )
 
       case _ => // same as Nil as WsFrameCheckSequence#checks can't be Nil, but compiler complains that match may not be exhaustive
+        // no check: TRACE dump of the outbound message only
+        fsm.wsLogger.logOk(actionName, session, requestMessage)
         NextWsState(this, () => next ! session)
     }
   }

--- a/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsPerformingCheckState.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsPerformingCheckState.scala
@@ -98,7 +98,8 @@ final case class WsPerformingCheckState(
           tryApplyingChecks(message, timestamp, matchConditions, checks)
 
         case _ =>
-          logger.debug(s"Received unmatched text frame $message")
+          // wrong frame type for the current check — TRACE traffic, retain for failed-check dump
+          logger.trace(s"Received unmatched text frame $message")
           unmatchedInboundMessageBuffer.addOne(WsInboundMessage.Text(timestamp, message))
           // server unmatched message, just log
           logUnmatchedServerMessage(session)
@@ -114,7 +115,8 @@ final case class WsPerformingCheckState(
         tryApplyingChecks(message, timestamp, matchConditions, checks)
 
       case _ =>
-        logger.debug("Received unmatched binary frame")
+        // wrong frame type for the current check — TRACE traffic, retain for failed-check dump
+        logger.trace("Received unmatched binary frame")
         unmatchedInboundMessageBuffer.addOne(WsInboundMessage.Binary(timestamp, message))
         // server unmatched message, just log
         logUnmatchedServerMessage(session)
@@ -152,9 +154,9 @@ final case class WsPerformingCheckState(
       }
     }
     if (messageMatches) {
-      logger.debug(s"Received matching message $message")
-      fsm.wsLogger.logCheck(actionName, session, OK, None, Some(currentCheck.resolvedName), requestMessage)
-      // matching message, apply checks
+      logger.trace(s"Received matching message $message")
+      // matching message, apply checks before logging so failures keep the inbound buffer
+      // (WsLogger.logCheck clears it) and only dump at DEBUG when the check is KO
       val (sessionWithCheckUpdate, checkError) = Check.check(message, session, checks, preparedCache)
 
       checkError match {
@@ -196,24 +198,25 @@ final case class WsPerformingCheckState(
           )
 
         case _ =>
-          logger.debug("Current check success")
-          // check success
+          logger.trace("Current check success")
+          // check success — TRACE dump (parity with HTTP: successes only at TRACE)
+          fsm.wsLogger.logCheck(actionName, session, OK, None, Some(currentCheck.resolvedName), requestMessage)
           val newSession = logCheckResult(sessionWithCheckUpdate, timestamp, OK, None, None)
           remainingChecks match {
             case nextCheck :: nextRemainingChecks =>
               // perform next check
-              logger.debug("Perform next check of current check sequence")
+              logger.trace("Perform next check of current check sequence")
               // [e]
               //
               // [e]
               NextWsState(this.copy(currentCheck = nextCheck, remainingChecks = nextRemainingChecks, session = newSession))
 
             case _ =>
-              logger.debug("Current check sequence complete")
+              logger.trace("Current check sequence complete")
               cancelTimeout()
               remainingCheckSequences match {
                 case WsFrameCheckSequence(timeout, nextCheck :: nextRemainingChecks) :: nextRemainingCheckSequences =>
-                  logger.debug("Perform next check sequence")
+                  logger.trace("Perform next check sequence")
                   // perform next CheckSequence
                   scheduleTimeout(timeout)
                   // [e]
@@ -231,7 +234,7 @@ final case class WsPerformingCheckState(
 
                 case _ =>
                   // all check sequences complete
-                  logger.debug("Check sequences completed successfully")
+                  logger.trace("Check sequences completed successfully")
                   val nextStateAction =
                     next match {
                       case Left(nextAction) => () => nextAction ! newSession
@@ -245,8 +248,8 @@ final case class WsPerformingCheckState(
           }
       }
     } else {
-      logger.debug(s"Received non-matching message $message")
-      fsm.wsLogger.logCheck(actionName, session, OK, None, Some(currentCheck.resolvedName), requestMessage)
+      // non-matching inbound: TRACE only; keep buffered for a possible later DEBUG failure dump
+      logger.trace(s"Received non-matching message $message")
       // server unmatched message, just log
       logUnmatchedServerMessage(session)
       NextWsState(this)


### PR DESCRIPTION
### Motivation

Fixes #4468.

WebSocket FSM path logged almost all traffic-related events at `DEBUG`, so enabling WebSocket logging (or the package logger) dumped entire successful traffic into multi-GB files. HTTP already uses `DEBUG` for failures only and `TRACE` for everything via `io.gatling.http.engine.response`.

This aligns WebSocket with that model, following the approach agreed on the issue:

- outbound: TRACE at send; retain for later dump when a check is present
- inbound matching a check: TRACE dump on success, DEBUG dump on failure (`WsLogger`)
- inbound non-matching / wrong type: TRACE only (keep buffered for a later failed-check dump)
- high-volume FSM lifecycle (timeout schedule/cancel): TRACE

Also fixes a buffer-clear bug: `logCheck(OK)` was called before applying checks and on non-matching frames, which cleared the inbound buffer so later KO dumps (timeout / failed check) often lost received messages.

### Modifications

- `WsIdleState`: send frame logs → TRACE; `logOk` only when there is no check; with checks, defer dump until check outcome
- `WsPerformingCheckState`: matching/non-matching/unmatched traffic → TRACE; call `logCheck(OK)` only after check success; do not `logCheck` on non-matching (retain buffer)
- `WsFsm`: timeout schedule/cancel → TRACE; timeout trigger stays DEBUG
- `logback.dummy`: document that `io.gatling.http.engine.response` covers HTTP **and** WebSocket; FSM package at TRACE for state-machine noise

`WsLogger` already uses `HttpTracing.LOGGER` (`io.gatling.http.engine.response`) from #4471.

### Result

With:

```xml
<logger name="io.gatling.http.engine.response" level="DEBUG"/>
```

only failed WebSocket checks (and failed HTTP requests) are logged.

With `TRACE` on the same logger, full traffic dumps are logged.

FSM package logger no longer floods DEBUG with full message bodies on successful traffic.

### Testing

- `sbt gatling-http/compile` (Temurin 21) — success
- No open prior PR for #4468 (searched issue number + WebSocket/WsLogger log keywords)